### PR TITLE
Added a minimal landing-page tracker table to `docs/landing-pages.md`…

### DIFF
--- a/docs/landing-pages.md
+++ b/docs/landing-pages.md
@@ -3,9 +3,11 @@
 This marketing site supports segment-specific landing pages under `/{locale}/landing/{segment}`.
 They reuse a shared layout and only swap copy + iconography.
 
-## Current segments
+## Segment tracker
 
-- `expansion` → `/en/landing/expansion` (noindex for now)
+| slug | path | focus | status |
+| --- | --- | --- | --- |
+| expansion | `/{locale}/landing/expansion` | Global expansion demand capture | noindex |
 
 ## Add a new landing segment
 


### PR DESCRIPTION
… so there’s a single place to list segments and their focus/status; this replaces the one-off bullet under “Current segments” to keep tracking consistent as you add new pages.

What I meant by “derive `landingSegments` from `landingContent`”: make the segment list come from the content map so you only update one place. Example:

```ts
export const landingContent = {
  expansion: { /* ... */ },
  // new segments here
} as const;

export type LandingSegment = keyof typeof landingContent;
export const landingSegments = Object.keys(landingContent) as LandingSegment[];
```

Next steps (optional):
1. Tell me if you want different columns in the tracker table (e.g., owner, primary CTA), and I’ll adjust.
2. If you want, I can wire `landingSegments` to derive from `landingContent` in `modules/landing/content.ts`.