### PR TITLE
docs(website): add strict backend docs sync + coverage guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,22 +34,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Checkout backend (OpenAPI contracts)
-        if: ${{ secrets.CROSS_REPO_CHECKOUT_TOKEN != '' }}
-        uses: actions/checkout@v6
-        with:
-          repository: lucent-lab/weblingo
-          path: backend
-          token: ${{ secrets.CROSS_REPO_CHECKOUT_TOKEN }}
-
-      - name: Enable backend OpenAPI contract tests
-        if: ${{ secrets.CROSS_REPO_CHECKOUT_TOKEN != '' }}
-        run: echo "WEBHOOKS_OPENAPI_JSON_PATH=backend/workers/webhooks-worker/src/openapi.generated.json" >> $GITHUB_ENV
-
-      - name: Backend contracts token missing (contract tests skipped)
-        if: ${{ secrets.CROSS_REPO_CHECKOUT_TOKEN == '' }}
-        run: echo "Skipping backend OpenAPI contract tests. Set CROSS_REPO_CHECKOUT_TOKEN to enable."
-
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
@@ -78,3 +62,59 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  docs-sync-check:
+    if: ${{ secrets.CROSS_REPO_CHECKOUT_TOKEN != '' }}
+    runs-on: ubuntu-latest
+    env:
+      HOME_PAGE_VARIANT: expansion
+      KV_REST_API_TOKEN: dummy
+      KV_REST_API_URL: https://example.com
+      NEXT_PUBLIC_APP_URL: https://example.com
+      NEXT_PUBLIC_POSTHOG_HOST: https://example.com
+      NEXT_PUBLIC_POSTHOG_KEY: phc_dummy
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_dummy
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: anon_dummy
+      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+      NEXT_PUBLIC_WEBHOOKS_API_BASE: https://example.com
+      NEXT_PUBLIC_WEBHOOKS_API_TIMEOUT_MS: "15000"
+      PUBLIC_PORTAL_MODE: disabled
+      STRIPE_SECRET_KEY: sk_test_dummy
+      STRIPE_WEBHOOK_SECRET: whsec_dummy
+      SUPABASE_AUTH_TIMEOUT_MS: "15000"
+      SUPABASE_SECRET_KEY: service_role_dummy
+      WEBSITE_CONTACT_MAX_PER_WINDOW: "10"
+      WEBSITE_CONTACT_RATE_LIMIT_WINDOW_MS: "60000"
+      WEBSITE_WAITLIST_MAX_BODY_BYTES: "4096"
+      WEBSITE_WAITLIST_MAX_PER_WINDOW: "20"
+      WEBSITE_WAITLIST_RATE_LIMIT_WINDOW_MS: "60000"
+    steps:
+      - name: Checkout website
+        uses: actions/checkout@v6
+
+      - name: Checkout backend repository
+        uses: actions/checkout@v6
+        with:
+          repository: lucent-lab/weblingo
+          path: backend
+          token: ${{ secrets.CROSS_REPO_CHECKOUT_TOKEN }}
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Docs sync freshness check
+        run: WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" pnpm docs:sync:check
+
+      - name: Contract and docs coverage tests
+        run: pnpm test:contracts

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Thumbs.db
 coverage/
 .nyc_output/
 test-results/
+.tmp/
 
 .vercel/
 *.log

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,6 @@ review.md
 
 # Supabase generated types
 types/database.ts
+
+# Backend-synced docs artifacts (deterministic generator output)
+content/docs/_generated/*.json

--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
 4. Dashboard access: visit `/dashboard`, sign in via Supabase auth, then create/manage sites (calls `NEXT_PUBLIC_WEBHOOKS_API_BASE`).
 5. Validation: optional `pnpm run lint`, `pnpm run typecheck`, `pnpm run format` before committing.
 
+## Backend Docs Sync
+
+Website API docs use backend-synced snapshots under `content/docs/_generated`.
+
+- Refresh snapshots:
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync`
+- Verify snapshots are fresh (fails fast when missing/stale):
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync:check`
+- Contract/doc coverage tests:
+  - `pnpm test:contracts`
+
+`WEBLINGO_REPO_PATH` is required for sync commands. There is no fallback path.
+
 ## Stripe Setup
 
 1. Create three recurring prices for the Launch, Growth, and Enterprise plans. Name the price IDs so they include the site identifier, e.g. `price_weblingo_growth_monthly`.

--- a/app/[locale]/(docs)/docs/[...slug]/page.tsx
+++ b/app/[locale]/(docs)/docs/[...slug]/page.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, ArrowRight } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { docSections, docs, getDocBySlug } from "@/content/docs";
+import { cn } from "@/lib/utils";
 import { env } from "@internal/core";
 import { i18nConfig, normalizeLocale } from "@internal/i18n";
 
@@ -40,9 +41,10 @@ export default async function DocPage({
   const prev = currentIndex > 0 ? orderedDocs[currentIndex - 1] : null;
   const next = currentIndex >= 0 ? (orderedDocs[currentIndex + 1] ?? null) : null;
   const DocComponent = doc.component;
+  const isApiReference = doc.slug.join("/") === "api-reference";
 
   return (
-    <article className="mx-auto w-full max-w-3xl pb-16">
+    <article className={cn("mx-auto w-full pb-16", isApiReference ? "max-w-none" : "max-w-3xl")}>
       <header className="space-y-4 pb-8">
         <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           {doc.section}
@@ -57,26 +59,28 @@ export default async function DocPage({
 
       <DocComponent />
 
-      <div className="mt-12 flex flex-wrap items-center justify-between gap-4 border-t border-border pt-6">
-        {prev ? (
-          <Button asChild variant="outline" className="gap-2">
-            <Link href={`/${locale}/docs/${prev.slug.join("/")}`}>
-              <ArrowLeft className="h-4 w-4" />
-              {prev.title}
-            </Link>
-          </Button>
-        ) : (
-          <span />
-        )}
-        {next ? (
-          <Button asChild variant="outline" className="gap-2">
-            <Link href={`/${locale}/docs/${next.slug.join("/")}`}>
-              {next.title}
-              <ArrowRight className="h-4 w-4" />
-            </Link>
-          </Button>
-        ) : null}
-      </div>
+      {isApiReference ? null : (
+        <div className="mt-12 flex flex-wrap items-center justify-between gap-4 border-t border-border pt-6">
+          {prev ? (
+            <Button asChild variant="outline" className="gap-2">
+              <Link href={`/${locale}/docs/${prev.slug.join("/")}`}>
+                <ArrowLeft className="h-4 w-4" />
+                {prev.title}
+              </Link>
+            </Button>
+          ) : (
+            <span />
+          )}
+          {next ? (
+            <Button asChild variant="outline" className="gap-2">
+              <Link href={`/${locale}/docs/${next.slug.join("/")}`}>
+                {next.title}
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          ) : null}
+        </div>
+      )}
     </article>
   );
 }

--- a/app/[locale]/(docs)/docs/_components/docs-shell.tsx
+++ b/app/[locale]/(docs)/docs/_components/docs-shell.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { BookOpen } from "lucide-react";
+import { BookOpen, Code2, FileText, Globe, ListChecks, Workflow } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -25,12 +25,21 @@ import { cn } from "@/lib/utils";
 type DocsNavItem = {
   href: string;
   title: string;
+  iconKey?: DocsNavIconKey;
 };
 
 export type DocsNavSection = {
   title: string;
   items: DocsNavItem[];
 };
+
+export type DocsNavIconKey =
+  | "default"
+  | "getting-started"
+  | "site-setup"
+  | "pipeline"
+  | "api-reference"
+  | "workflows";
 
 type HeaderLink = {
   href: string;
@@ -54,6 +63,10 @@ type DocsShellProps = {
 
 export function DocsShell({ locale, navSections, headerLinks, copy, children }: DocsShellProps) {
   const pathname = usePathname() ?? "";
+  const isApiReferencePage =
+    pathname === `/${locale}/docs/api-reference` ||
+    pathname.startsWith(`/${locale}/docs/api-reference/`);
+  const showDocsSidebar = !isApiReferencePage;
   const activeHeader = headerLinks.reduce((best, link) => {
     if (pathname === link.href || pathname.startsWith(`${link.href}/`)) {
       return link.href.length > best.length ? link.href : best;
@@ -62,47 +75,56 @@ export function DocsShell({ locale, navSections, headerLinks, copy, children }: 
   }, "");
 
   return (
-    <SidebarProvider defaultOpen>
-      <Sidebar collapsible="icon">
-        <SidebarHeader className="gap-3 px-4 py-4">
-          <Link href={`/${locale}/docs`} className="flex items-center gap-2 text-sm font-semibold">
-            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-              <BookOpen className="h-4 w-4" />
-            </span>
-            <span className="truncate">{copy.title}</span>
-          </Link>
-          <p className="text-xs text-muted-foreground">{copy.subtitle}</p>
-        </SidebarHeader>
+    <SidebarProvider defaultOpen={showDocsSidebar}>
+      {showDocsSidebar ? (
+        <Sidebar collapsible="icon">
+          <SidebarHeader className="gap-4">
+            <div className="flex items-center gap-2 px-2 pt-2 group-data-[collapsible=icon]:px-1 group-data-[collapsible=icon]:pt-1">
+              <Link href={`/${locale}/docs`} className="flex min-w-0 items-center gap-2">
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+                  <BookOpen className="h-4 w-4" />
+                </span>
+                <span className="min-w-0 truncate text-sm font-semibold group-data-[collapsible=icon]:hidden">
+                  {copy.title}
+                </span>
+              </Link>
+              <SidebarTrigger className="ml-auto md:hidden" />
+            </div>
+            <p className="px-2 text-xs text-muted-foreground group-data-[collapsible=icon]:hidden">
+              {copy.subtitle}
+            </p>
+          </SidebarHeader>
 
-        <SidebarContent>
-          {navSections.map((section) => (
-            <SidebarGroup key={section.title}>
-              <SidebarGroupLabel>{section.title}</SidebarGroupLabel>
-              <SidebarGroupContent>
-                <DocsNav items={section.items} />
-              </SidebarGroupContent>
-            </SidebarGroup>
-          ))}
-        </SidebarContent>
+          <SidebarContent>
+            {navSections.map((section) => (
+              <SidebarGroup key={section.title}>
+                <SidebarGroupLabel>{section.title}</SidebarGroupLabel>
+                <SidebarGroupContent>
+                  <DocsNav items={section.items} />
+                </SidebarGroupContent>
+              </SidebarGroup>
+            ))}
+          </SidebarContent>
 
-        <SidebarFooter>
-          <div className="rounded-md border border-sidebar-border bg-sidebar-accent/60 p-3 text-xs text-sidebar-foreground/80 group-data-[collapsible=icon]:hidden">
-            <p className="text-sm font-semibold text-sidebar-foreground">{copy.supportTitle}</p>
-            <p>{copy.supportDescription}</p>
-            <Button asChild variant="outline" size="sm" className="mt-3 w-full bg-transparent">
-              <Link href="mailto:contact@weblingo.app">{copy.supportCta}</Link>
-            </Button>
-          </div>
-        </SidebarFooter>
-      </Sidebar>
+          <SidebarFooter>
+            <div className="rounded-md border border-sidebar-border bg-sidebar-accent/60 p-3 text-xs text-sidebar-foreground/80 group-data-[collapsible=icon]:hidden">
+              <p className="text-sm font-semibold text-sidebar-foreground">{copy.supportTitle}</p>
+              <p>{copy.supportDescription}</p>
+              <Button asChild variant="outline" size="sm" className="mt-3 w-full bg-transparent">
+                <Link href="mailto:contact@weblingo.app">{copy.supportCta}</Link>
+              </Button>
+            </div>
+          </SidebarFooter>
+        </Sidebar>
+      ) : null}
 
       <SidebarInset className="bg-muted/30">
         <header className="border-b bg-background">
           <div className="flex w-full flex-col gap-4 px-4 py-4 lg:px-6">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
               <div className="flex flex-wrap items-center gap-3 text-sm font-medium">
-                <SidebarTrigger className="shrink-0" />
-                <div className="hidden h-5 w-px bg-border sm:block" />
+                {showDocsSidebar ? <SidebarTrigger className="shrink-0" /> : null}
+                {showDocsSidebar ? <div className="hidden h-5 w-px bg-border sm:block" /> : null}
                 <nav className="flex flex-wrap items-center gap-4 text-sm font-medium">
                   {headerLinks.map((link) => {
                     const isActive = activeHeader === link.href;
@@ -133,7 +155,12 @@ export function DocsShell({ locale, navSections, headerLinks, copy, children }: 
           </div>
         </header>
 
-        <section className="flex w-full max-w-7xl min-w-0 flex-1 flex-col px-4 py-8 lg:px-6">
+        <section
+          className={cn(
+            "flex w-full min-w-0 flex-1 flex-col py-8",
+            showDocsSidebar ? "max-w-7xl px-4 lg:px-6" : "max-w-none px-0",
+          )}
+        >
           {children}
         </section>
       </SidebarInset>
@@ -160,6 +187,7 @@ function DocsNav({ items }: { items: DocsNavItem[] }) {
           <SidebarMenuItem key={item.href}>
             <SidebarMenuButton asChild isActive={isActive} tooltip={item.title}>
               <Link href={item.href} aria-current={isActive ? "page" : undefined}>
+                <DocsNavIcon iconKey={item.iconKey} />
                 <span className="truncate group-data-[collapsible=icon]:sr-only">{item.title}</span>
               </Link>
             </SidebarMenuButton>
@@ -168,4 +196,22 @@ function DocsNav({ items }: { items: DocsNavItem[] }) {
       })}
     </SidebarMenu>
   );
+}
+
+function DocsNavIcon({ iconKey = "default" }: { iconKey?: DocsNavIconKey }) {
+  const commonClassName = "h-4 w-4 shrink-0";
+  switch (iconKey) {
+    case "getting-started":
+      return <BookOpen className={commonClassName} />;
+    case "site-setup":
+      return <Globe className={commonClassName} />;
+    case "pipeline":
+      return <Workflow className={commonClassName} />;
+    case "api-reference":
+      return <Code2 className={commonClassName} />;
+    case "workflows":
+      return <ListChecks className={commonClassName} />;
+    default:
+      return <FileText className={commonClassName} />;
+  }
 }

--- a/app/[locale]/(docs)/docs/layout.tsx
+++ b/app/[locale]/(docs)/docs/layout.tsx
@@ -1,8 +1,9 @@
 import { notFound } from "next/navigation";
 
-import { DocsShell, type DocsNavSection } from "./_components/docs-shell";
+import { DocsShell, type DocsNavIconKey, type DocsNavSection } from "./_components/docs-shell";
 
 import { docSections } from "@/content/docs";
+import { getWorkflowPlaybooks } from "@/content/docs/workflow-playbooks";
 import { normalizeLocale, resolveLocaleTranslator } from "@internal/i18n";
 
 export default async function DocsLayout({
@@ -24,8 +25,21 @@ export default async function DocsLayout({
     items: section.items.map((item) => ({
       href: `/${locale}/docs/${item.slug.join("/")}`,
       title: item.title,
+      iconKey: resolveDocIconKey(item.slug),
     })),
   }));
+  if (getWorkflowPlaybooks().length > 0) {
+    navSections.push({
+      title: "Workflows",
+      items: [
+        {
+          href: `/${locale}/docs/workflows`,
+          title: "Workflow Playbooks",
+          iconKey: "workflows",
+        },
+      ],
+    });
+  }
   const copy = {
     title: t("docs.shell.title"),
     subtitle: t("docs.shell.subtitle"),
@@ -48,4 +62,20 @@ export default async function DocsLayout({
       {children}
     </DocsShell>
   );
+}
+
+function resolveDocIconKey(slug: string[]): DocsNavIconKey {
+  const key = slug.join("/");
+  switch (key) {
+    case "getting-started":
+      return "getting-started";
+    case "site-setup":
+      return "site-setup";
+    case "translation-pipeline":
+      return "pipeline";
+    case "api-reference":
+      return "api-reference";
+    default:
+      return "default";
+  }
 }

--- a/app/[locale]/(docs)/docs/page.tsx
+++ b/app/[locale]/(docs)/docs/page.tsx
@@ -5,6 +5,7 @@ import { ArrowRight } from "lucide-react";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { docSections } from "@/content/docs";
+import { getWorkflowPlaybooks } from "@/content/docs/workflow-playbooks";
 import { createLocalizedMetadata, normalizeLocale, resolveLocaleTranslator } from "@internal/i18n";
 
 export default async function DocsPage({ params }: { params: Promise<{ locale: string }> }) {
@@ -15,6 +16,7 @@ export default async function DocsPage({ params }: { params: Promise<{ locale: s
   }
 
   const { t } = await resolveLocaleTranslator(Promise.resolve({ locale }));
+  const workflowCount = getWorkflowPlaybooks().length;
 
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-10">
@@ -59,6 +61,36 @@ export default async function DocsPage({ params }: { params: Promise<{ locale: s
             </div>
           </section>
         ))}
+
+        {workflowCount > 0 ? (
+          <section className="space-y-4">
+            <div>
+              <h2 className="text-xl font-semibold text-foreground">Workflows</h2>
+              <p className="text-sm text-muted-foreground">
+                {workflowCount} generated playbook{workflowCount === 1 ? "" : "s"} linked to API
+                capabilities.
+              </p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <Link href={`/${locale}/docs/workflows`} className="group">
+                <Card className="h-full transition hover:-translate-y-0.5 hover:shadow-md">
+                  <CardHeader>
+                    <CardTitle className="text-xl">Workflow Playbooks</CardTitle>
+                    <CardDescription>
+                      Task-specific docs generated from synced backend playbooks.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <span className="inline-flex items-center gap-2 text-sm font-medium text-primary">
+                      Open workflows
+                      <ArrowRight className="h-4 w-4 transition group-hover:translate-x-1" />
+                    </span>
+                  </CardContent>
+                </Card>
+              </Link>
+            </div>
+          </section>
+        ) : null}
       </div>
     </div>
   );

--- a/app/[locale]/(docs)/docs/workflows/[slug]/page.tsx
+++ b/app/[locale]/(docs)/docs/workflows/[slug]/page.tsx
@@ -1,0 +1,143 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { getWorkflowPlaybookBySlug, getWorkflowPlaybooks } from "@/content/docs/workflow-playbooks";
+import { createLocalizedMetadata, i18nConfig, normalizeLocale } from "@internal/i18n";
+
+type PageParams = {
+  locale: string;
+  slug: string;
+};
+
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+  const playbooks = getWorkflowPlaybooks();
+  return i18nConfig.locales.flatMap((locale) =>
+    playbooks.map((playbook) => ({
+      locale,
+      slug: playbook.slug,
+    })),
+  );
+}
+
+export default async function WorkflowPlaybookDetailPage({
+  params,
+}: {
+  params: Promise<PageParams>;
+}) {
+  const { locale: rawLocale, slug } = await params;
+  const locale = normalizeLocale(rawLocale);
+  if (locale !== rawLocale) {
+    notFound();
+  }
+
+  const playbook = getWorkflowPlaybookBySlug(slug);
+  if (!playbook) {
+    notFound();
+  }
+
+  return (
+    <article className="mx-auto w-full max-w-3xl pb-16">
+      <header className="space-y-4 pb-8">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Workflow
+        </p>
+        <div className="space-y-3">
+          <h1 className="text-4xl font-semibold text-foreground">{playbook.shortTitle}</h1>
+          <p className="text-lg text-muted-foreground">
+            Follow the sequence below, then use API Reference for payload schema and response
+            details.
+          </p>
+        </div>
+      </header>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-foreground">Steps</h2>
+        <ol className="ml-6 list-decimal space-y-5 text-muted-foreground">
+          {playbook.stepDetails.map((step, index) => (
+            <li key={`${playbook.id}:step:${index}`} className="space-y-2">
+              <p className="text-foreground">{step.text}</p>
+              {step.operationIds.length > 0 ? (
+                <p className="text-sm">
+                  Operation IDs:{" "}
+                  {step.operationIds.map((operationId, operationIndex) => (
+                    <span key={`${playbook.id}:step:${index}:op:${operationId}`}>
+                      <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{operationId}</code>
+                      {operationIndex < step.operationIds.length - 1 ? ", " : ""}
+                    </span>
+                  ))}
+                </p>
+              ) : null}
+              {step.surfacePaths.length > 0 ? (
+                <p className="text-sm">
+                  Surface paths:{" "}
+                  {step.surfacePaths.map((surfacePath, surfaceIndex) => (
+                    <span key={`${playbook.id}:step:${index}:surface:${surfacePath}`}>
+                      <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{surfacePath}</code>
+                      {surfaceIndex < step.surfacePaths.length - 1 ? ", " : ""}
+                    </span>
+                  ))}
+                </p>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {playbook.notes.length > 0 ? (
+        <section className="mt-10 space-y-4">
+          <h2 className="text-2xl font-semibold text-foreground">Notes</h2>
+          <div className="space-y-3 text-muted-foreground">
+            {playbook.notes.map((note, index) => (
+              <p key={`${playbook.id}:note:${index}`}>{note}</p>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="mt-10 space-y-4">
+        <h2 className="text-2xl font-semibold text-foreground">Related Docs</h2>
+        <div className="flex flex-wrap gap-3">
+          <Button asChild variant="outline" className="gap-2">
+            <Link href={`/${locale}/docs/workflows`}>
+              <ArrowLeft className="h-4 w-4" />
+              All workflows
+            </Link>
+          </Button>
+          <Button asChild variant="outline" className="gap-2">
+            <Link href={`/${locale}/docs/api-reference`}>
+              API reference
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </Button>
+        </div>
+      </section>
+    </article>
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<PageParams>;
+}): Promise<Metadata> {
+  const { locale: rawLocale, slug } = await params;
+  const locale = normalizeLocale(rawLocale);
+  if (locale !== rawLocale) {
+    return {};
+  }
+
+  const playbook = getWorkflowPlaybookBySlug(slug);
+  if (!playbook) {
+    return {};
+  }
+
+  return createLocalizedMetadata(Promise.resolve({ locale }), {
+    titleFallback: `${playbook.shortTitle} | Workflow`,
+    descriptionFallback: `Step-by-step workflow for ${playbook.shortTitle}.`,
+  });
+}

--- a/app/[locale]/(docs)/docs/workflows/page.tsx
+++ b/app/[locale]/(docs)/docs/workflows/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowRight } from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getWorkflowPlaybooks } from "@/content/docs/workflow-playbooks";
+import { createLocalizedMetadata, normalizeLocale } from "@internal/i18n";
+
+export default async function WorkflowPlaybooksPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: rawLocale } = await params;
+  const locale = normalizeLocale(rawLocale);
+  if (locale !== rawLocale) {
+    notFound();
+  }
+
+  const playbooks = getWorkflowPlaybooks();
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
+      <header className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Workflows
+        </p>
+        <h1 className="text-4xl font-semibold text-foreground">Workflow Playbooks</h1>
+        <p className="text-base text-muted-foreground">
+          Task-focused sequences generated from synced backend playbooks. Use API Reference for
+          payload and response schemas.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {playbooks.map((playbook) => {
+          const href = `/${locale}/docs/workflows/${playbook.slug}`;
+          const summary =
+            playbook.stepDetails[0]?.text ??
+            playbook.notes[0] ??
+            "Follow the workflow steps and validate outcomes per stage.";
+          return (
+            <Link key={playbook.id} href={href} className="group">
+              <Card className="h-full transition hover:-translate-y-0.5 hover:shadow-md">
+                <CardHeader>
+                  <CardTitle className="text-xl">{playbook.shortTitle}</CardTitle>
+                  <CardDescription>{summary}</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  <p className="text-xs text-muted-foreground">
+                    {playbook.operationIds.length} operation
+                    {playbook.operationIds.length === 1 ? "" : "s"}
+                    {playbook.surfacePaths.length > 0
+                      ? ` · ${playbook.surfacePaths.length} serve surface${playbook.surfacePaths.length === 1 ? "" : "s"}`
+                      : ""}
+                  </p>
+                  <span className="inline-flex items-center gap-2 text-sm font-medium text-primary">
+                    Open workflow
+                    <ArrowRight className="h-4 w-4 transition group-hover:translate-x-1" />
+                  </span>
+                </CardContent>
+              </Card>
+            </Link>
+          );
+        })}
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        Need schema details? Go to{" "}
+        <Link href={`/${locale}/docs/api-reference`} className="font-medium text-primary">
+          API Reference
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale: rawLocale } = await params;
+  const locale = normalizeLocale(rawLocale);
+  if (locale !== rawLocale) {
+    return {};
+  }
+
+  return createLocalizedMetadata(Promise.resolve({ locale }), {
+    titleFallback: "Workflow Playbooks",
+    descriptionFallback:
+      "Task-oriented API workflows for account setup, domains, crawl/translate, and previews.",
+  });
+}

--- a/components/docs/api-reference-data.ts
+++ b/components/docs/api-reference-data.ts
@@ -1,0 +1,229 @@
+export type OpenApiTag = {
+  name?: string;
+  [key: string]: unknown;
+};
+
+export type OpenApiOperation = {
+  operationId?: string;
+  tags?: string[];
+  [key: string]: unknown;
+};
+
+export type OpenApiSpec = {
+  openapi?: string;
+  info?: Record<string, unknown>;
+  servers?: Array<Record<string, unknown>>;
+  paths?: Record<string, Record<string, OpenApiOperation>>;
+  tags?: OpenApiTag[];
+  components?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type FeatureCatalogEntry = {
+  family?: string;
+  userFacing?: boolean;
+  endpoint?: {
+    operationId?: string;
+  };
+};
+
+export type FeatureCatalog = {
+  features?: FeatureCatalogEntry[];
+};
+
+export type ParsedPlaybook = {
+  id: string;
+  title: string;
+  anchor: string;
+  notes: string[];
+  steps: string[];
+  stepDetails: Array<{
+    text: string;
+    operationIds: string[];
+    surfacePaths: string[];
+  }>;
+  operationIds: string[];
+  surfacePaths: string[];
+};
+
+export function toAnchor(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+export function toOperationAnchor(operationId: string): string {
+  return `endpoint-${toAnchor(operationId)}`;
+}
+
+export function getUserFacingApiOperationIds(catalog: FeatureCatalog): Set<string> {
+  return new Set(
+    (catalog.features ?? [])
+      .filter((entry) => entry.family === "api" && entry.userFacing)
+      .map((entry) => entry.endpoint?.operationId)
+      .filter((operationId): operationId is string => typeof operationId === "string"),
+  );
+}
+
+export function collectOperationIdsFromSpec(spec: OpenApiSpec): Set<string> {
+  const ids = new Set<string>();
+  for (const methods of Object.values(spec.paths ?? {})) {
+    for (const operation of Object.values(methods ?? {})) {
+      const operationId = operation.operationId;
+      if (operationId) {
+        ids.add(operationId);
+      }
+    }
+  }
+  return ids;
+}
+
+export function buildUserFacingOpenApiSpec(
+  spec: OpenApiSpec,
+  catalog: FeatureCatalog,
+): OpenApiSpec {
+  const userFacingOperationIds = getUserFacingApiOperationIds(catalog);
+  const filteredPaths: Record<string, Record<string, OpenApiOperation>> = {};
+  const usedTags = new Set<string>();
+
+  for (const [path, methods] of Object.entries(spec.paths ?? {})) {
+    const keptMethods: Record<string, OpenApiOperation> = {};
+    for (const [method, operation] of Object.entries(methods ?? {})) {
+      const operationId = operation.operationId;
+      if (!operationId || !userFacingOperationIds.has(operationId)) {
+        continue;
+      }
+      keptMethods[method] = operation;
+      for (const tag of operation.tags ?? []) {
+        usedTags.add(tag);
+      }
+    }
+    if (Object.keys(keptMethods).length > 0) {
+      filteredPaths[path] = keptMethods;
+    }
+  }
+
+  const filteredTags = Array.isArray(spec.tags)
+    ? spec.tags.filter((tag) => {
+        if (!tag.name) {
+          return false;
+        }
+        return usedTags.has(tag.name);
+      })
+    : undefined;
+  const info = {
+    ...(spec.info ?? {}),
+    title: "WebLingo API",
+    description:
+      "User-facing API for account setup, site/domain configuration, crawl and translation workflows, previews, and notifications.",
+  };
+  const servers = [{ url: "/api", description: "WebLingo API base path" }];
+
+  return {
+    ...spec,
+    info,
+    servers,
+    paths: filteredPaths,
+    tags: filteredTags,
+  };
+}
+
+export function parsePlaybooksMarkdown(markdown: string): ParsedPlaybook[] {
+  const lines = markdown.split(/\r?\n/);
+  const playbooks: ParsedPlaybook[] = [];
+  let current: ParsedPlaybook | null = null;
+  let currentStep: {
+    text: string;
+    operationIds: string[];
+    surfacePaths: string[];
+  } | null = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    const headingMatch = line.match(/^##\s+(Playbook.*)$/);
+    if (headingMatch) {
+      if (current) {
+        playbooks.push(current);
+      }
+      const title = headingMatch[1].trim();
+      const anchor = toAnchor(title);
+      current = {
+        id: anchor,
+        title,
+        anchor,
+        notes: [],
+        steps: [],
+        stepDetails: [],
+        operationIds: [],
+        surfacePaths: [],
+      };
+      currentStep = null;
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    const stepMatch = line.match(/^\d+\.\s+(.*)$/);
+    if (stepMatch) {
+      const text = stepMatch[1].trim();
+      current.steps.push(text);
+      currentStep = {
+        text,
+        operationIds: [],
+        surfacePaths: [],
+      };
+      current.stepDetails.push(currentStep);
+      continue;
+    }
+
+    const operationMatch = line.match(/`operationId`:\s*`([^`]+)`/);
+    if (operationMatch) {
+      const operationId = operationMatch[1].trim();
+      current.operationIds.push(operationId);
+      if (currentStep) {
+        currentStep.operationIds.push(operationId);
+      }
+      continue;
+    }
+
+    const surfaceMatch = line.match(/`(?:GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS)\s+([^`]+)`/);
+    if (surfaceMatch) {
+      const surfacePath = surfaceMatch[1].trim();
+      current.surfacePaths.push(surfacePath);
+      if (currentStep) {
+        currentStep.surfacePaths.push(surfacePath);
+      }
+      continue;
+    }
+
+    const cleanLine = line.trim();
+    if (
+      cleanLine &&
+      !cleanLine.startsWith("-") &&
+      !cleanLine.startsWith("```") &&
+      !cleanLine.startsWith("#")
+    ) {
+      current.notes.push(cleanLine);
+    }
+  }
+
+  if (current) {
+    playbooks.push(current);
+  }
+
+  return playbooks.map((playbook) => ({
+    ...playbook,
+    stepDetails: playbook.stepDetails.map((step) => ({
+      ...step,
+      operationIds: Array.from(new Set(step.operationIds)),
+      surfacePaths: Array.from(new Set(step.surfacePaths)),
+    })),
+    operationIds: Array.from(new Set(playbook.operationIds)),
+    surfacePaths: Array.from(new Set(playbook.surfacePaths)),
+  }));
+}

--- a/components/docs/redoc-api-reference.tsx
+++ b/components/docs/redoc-api-reference.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import isPropValid from "@emotion/is-prop-valid";
+import dynamic from "next/dynamic";
+import { StyleSheetManager } from "styled-components";
+
+import featureCatalog from "@/content/docs/_generated/backend-feature-catalog.snapshot.json";
+import openApiSpec from "@/content/docs/_generated/backend-openapi.snapshot.json";
+
+import {
+  buildUserFacingOpenApiSpec,
+  type FeatureCatalog,
+  type OpenApiSpec,
+} from "./api-reference-data";
+
+const RedocStandalone = dynamic(() => import("redoc").then((module) => module.RedocStandalone), {
+  ssr: false,
+  loading: () => (
+    <p className="px-4 py-3 text-sm text-muted-foreground">Loading API reference...</p>
+  ),
+});
+
+const userFacingSpec = buildUserFacingOpenApiSpec(
+  openApiSpec as unknown as OpenApiSpec,
+  featureCatalog as unknown as FeatureCatalog,
+);
+
+const redocOptions = {
+  hideDownloadButton: true,
+  hideHostname: false,
+  pathInMiddlePanel: true,
+  requiredPropsFirst: true,
+  sortPropsAlphabetically: true,
+  sortOperationsAlphabetically: true,
+  sortTagsAlphabetically: true,
+  nativeScrollbars: true,
+  disableSearch: false,
+  hideFab: true,
+  onlyRequiredInSamples: false,
+} as const;
+
+function shouldForwardProp(propName: string, target: unknown): boolean {
+  if (typeof target === "string") {
+    return isPropValid(propName);
+  }
+  return true;
+}
+
+export function RedocApiReference() {
+  return (
+    <div className="weblingo-redoc rounded-lg border border-border bg-card p-1">
+      <StyleSheetManager shouldForwardProp={shouldForwardProp}>
+        <RedocStandalone spec={userFacingSpec} options={redocOptions} />
+      </StyleSheetManager>
+    </div>
+  );
+}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -337,7 +337,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-sm font-medium text-sidebar-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+  "flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-sm font-medium text-sidebar-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/content/docs/_generated/backend-feature-catalog.snapshot.json
+++ b/content/docs/_generated/backend-feature-catalog.snapshot.json
@@ -1,0 +1,2006 @@
+{
+  "features": [
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "accounts.claim",
+        "path": "/accounts/claim"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "accounts",
+      "id": "api.accounts.claim",
+      "name": "Create/link an account for the authenticated Supabase user",
+      "playbooks": [
+        {
+          "anchor": "playbook-account-language-setup",
+          "id": "playbook-account-language-setup",
+          "title": "Playbook: Account & Language Setup"
+        }
+      ],
+      "routeIds": [
+        "accounts.claim"
+      ],
+      "stability": "GA",
+      "summary": "Create/link an account for the authenticated Supabase user",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "accounts.me",
+        "path": "/accounts/me"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "accounts",
+      "id": "api.accounts.me",
+      "name": "Get current account entitlements and quotas",
+      "playbooks": [
+        {
+          "anchor": "playbook-account-language-setup",
+          "id": "playbook-account-language-setup",
+          "title": "Playbook: Account & Language Setup"
+        }
+      ],
+      "routeIds": [
+        "accounts.me"
+      ],
+      "stability": "GA",
+      "summary": "Get current account entitlements and quotas",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "agency.customers.create",
+        "path": "/agency/customers"
+      },
+      "family": "api",
+      "flagKeys": [
+        "agencyActionsEnabled"
+      ],
+      "group": "agency",
+      "id": "api.agency.customers.create",
+      "name": "Create/invite a managed customer account",
+      "playbooks": [
+        {
+          "anchor": "playbook-site-portfolio-management",
+          "id": "playbook-site-portfolio-management",
+          "title": "Playbook: Site Portfolio Management"
+        }
+      ],
+      "routeIds": [
+        "agency.customers.create"
+      ],
+      "stability": "GA",
+      "summary": "Create/invite a managed customer account",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "agency.customers.list",
+        "path": "/agency/customers"
+      },
+      "family": "api",
+      "flagKeys": [
+        "agencyActionsEnabled"
+      ],
+      "group": "agency",
+      "id": "api.agency.customers.list",
+      "name": "List agency-managed customer accounts",
+      "playbooks": [
+        {
+          "anchor": "playbook-site-portfolio-management",
+          "id": "playbook-site-portfolio-management",
+          "title": "Playbook: Site Portfolio Management"
+        }
+      ],
+      "routeIds": [
+        "agency.customers.list"
+      ],
+      "stability": "GA",
+      "summary": "List agency-managed customer accounts",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "auth.token.mint",
+        "path": "/auth/token"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "auth",
+      "id": "api.auth.token.mint",
+      "name": "Exchange Supabase access token for webhooks JWT",
+      "playbooks": [
+        {
+          "anchor": "playbook-1-dashboard-bootstrap-and-site-setup",
+          "id": "playbook-1",
+          "title": "Playbook 1: Dashboard Bootstrap and Site Setup"
+        }
+      ],
+      "routeIds": [
+        "auth.token.mint"
+      ],
+      "stability": "GA",
+      "summary": "Mints a short-lived WebLingo dashboard JWT from a Supabase access token. Agencies can scope the token to a managed customer account.",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "dashboard.bootstrap",
+        "path": "/dashboard/bootstrap"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "dashboard",
+      "id": "api.dashboard.bootstrap",
+      "name": "Bootstrap dashboard auth + account context",
+      "playbooks": [
+        {
+          "anchor": "playbook-1-dashboard-bootstrap-and-site-setup",
+          "id": "playbook-1",
+          "title": "Playbook 1: Dashboard Bootstrap and Site Setup"
+        }
+      ],
+      "routeIds": [
+        "dashboard.bootstrap"
+      ],
+      "stability": "GA",
+      "summary": "Bootstrap dashboard auth + account context",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "PUT",
+        "operationId": "digests.subscription.upsert",
+        "path": "/digests/subscription"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "digests",
+      "id": "api.digests.subscription.upsert",
+      "name": "Upsert digest subscription",
+      "playbooks": [
+        {
+          "anchor": "playbook-5-previews-and-notifications",
+          "id": "playbook-5",
+          "title": "Playbook 5: Previews and Notifications"
+        }
+      ],
+      "routeIds": [
+        "digests.subscription.upsert"
+      ],
+      "stability": "Beta",
+      "summary": "Creates or updates the account-level translation digest destination and frequency.",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "none",
+        "method": "GET",
+        "operationId": "meta.languages.list",
+        "path": "/meta/languages"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "meta",
+      "id": "api.meta.languages.list",
+      "name": "List supported languages",
+      "playbooks": [
+        {
+          "anchor": "playbook-account-language-setup",
+          "id": "playbook-account-language-setup",
+          "title": "Playbook: Account & Language Setup"
+        }
+      ],
+      "routeIds": [
+        "meta.languages.list"
+      ],
+      "stability": "GA",
+      "summary": "List supported languages",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "previewToken",
+        "method": "POST",
+        "operationId": "previews.create",
+        "path": "/previews"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "previews",
+      "id": "api.previews.create",
+      "name": "Create try-now preview",
+      "playbooks": [
+        {
+          "anchor": "playbook-5-previews-and-notifications",
+          "id": "playbook-5",
+          "title": "Playbook 5: Previews and Notifications"
+        }
+      ],
+      "routeIds": [
+        "previews.create"
+      ],
+      "stability": "Beta",
+      "summary": "Creates an ephemeral preview translation request and enqueues preview processing. Supports either public preview token auth or dashboard bearer auth.",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "previewStatusToken",
+        "method": "GET",
+        "operationId": "previews.status",
+        "path": "/previews/:previewId"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "previews",
+      "id": "api.previews.status",
+      "name": "Get preview status",
+      "playbooks": [
+        {
+          "anchor": "playbook-5-previews-and-notifications",
+          "id": "playbook-5",
+          "title": "Playbook 5: Previews and Notifications"
+        }
+      ],
+      "routeIds": [
+        "previews.status"
+      ],
+      "stability": "Beta",
+      "summary": "Get preview status",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.crawl_translate.trigger",
+        "path": "/sites/:siteId/crawl-translate"
+      },
+      "family": "api",
+      "flagKeys": [
+        "crawlTriggerEnabled"
+      ],
+      "group": "sites.crawl_translate",
+      "id": "api.sites.crawl_translate.trigger",
+      "name": "Trigger crawl+translate for selected pages",
+      "playbooks": [
+        {
+          "anchor": "playbook-3-crawl-and-translate-lifecycle",
+          "id": "playbook-3",
+          "title": "Playbook 3: Crawl and Translate Lifecycle"
+        }
+      ],
+      "routeIds": [
+        "sites.crawl_translate.trigger"
+      ],
+      "stability": "GA",
+      "summary": "Trigger crawl+translate for selected pages",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.crawl.trigger",
+        "path": "/sites/:siteId/crawl"
+      },
+      "family": "api",
+      "flagKeys": [
+        "crawlTriggerEnabled"
+      ],
+      "group": "sites.crawl",
+      "id": "api.sites.crawl.trigger",
+      "name": "Trigger crawl",
+      "playbooks": [
+        {
+          "anchor": "playbook-3-crawl-and-translate-lifecycle",
+          "id": "playbook-3",
+          "title": "Playbook 3: Crawl and Translate Lifecycle"
+        }
+      ],
+      "routeIds": [
+        "sites.crawl.trigger"
+      ],
+      "stability": "GA",
+      "summary": "Trigger crawl",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.create",
+        "path": "/sites"
+      },
+      "family": "api",
+      "flagKeys": [
+        "siteCreateEnabled"
+      ],
+      "group": "sites.create",
+      "id": "api.sites.create",
+      "name": "Create site",
+      "playbooks": [
+        {
+          "anchor": "playbook-1-dashboard-bootstrap-and-site-setup",
+          "id": "playbook-1",
+          "title": "Playbook 1: Dashboard Bootstrap and Site Setup"
+        },
+        {
+          "anchor": "playbook-2-domain-verification-and-serving-activation",
+          "id": "playbook-2",
+          "title": "Playbook 2: Domain Verification and Serving Activation"
+        }
+      ],
+      "routeIds": [
+        "sites.create"
+      ],
+      "stability": "GA",
+      "summary": "Registers a new source site, locale map, and domain onboarding metadata, then enqueues the first crawl.",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "sites.deployments.list",
+        "path": "/sites/:siteId/deployments"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.deployments",
+      "id": "api.sites.deployments.list",
+      "name": "List deployments per locale",
+      "playbooks": [
+        {
+          "anchor": "playbook-1-dashboard-bootstrap-and-site-setup",
+          "id": "playbook-1",
+          "title": "Playbook 1: Dashboard Bootstrap and Site Setup"
+        }
+      ],
+      "routeIds": [
+        "sites.deployments.list"
+      ],
+      "stability": "GA",
+      "summary": "List deployments per locale",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "sites.dlq.list",
+        "path": "/sites/:siteId/dlq"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.dlq",
+      "id": "api.sites.dlq.list",
+      "name": "List DLQ messages for a site",
+      "playbooks": [
+        {
+          "anchor": "playbook-6-operations-and-incident-response",
+          "id": "playbook-6",
+          "title": "Playbook 6: Operations and Incident Response"
+        }
+      ],
+      "routeIds": [
+        "sites.dlq.list"
+      ],
+      "stability": "Internal",
+      "summary": "List DLQ messages for a site",
+      "userFacing": false
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.dlq.replay",
+        "path": "/sites/:siteId/dlq/replay"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.dlq",
+      "id": "api.sites.dlq.replay",
+      "name": "Replay DLQ messages for a site",
+      "playbooks": [
+        {
+          "anchor": "playbook-6-operations-and-incident-response",
+          "id": "playbook-6",
+          "title": "Playbook 6: Operations and Incident Response"
+        }
+      ],
+      "routeIds": [
+        "sites.dlq.replay"
+      ],
+      "stability": "Internal",
+      "summary": "Replay DLQ messages for a site",
+      "userFacing": false
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.domains.provision",
+        "path": "/sites/:siteId/domains/:domain/provision"
+      },
+      "family": "api",
+      "flagKeys": [
+        "domainVerifyEnabled"
+      ],
+      "group": "sites.domains",
+      "id": "api.sites.domains.provision",
+      "name": "Provision domain via Cloudflare for SaaS (CNAME + Custom Hostname)",
+      "playbooks": [
+        {
+          "anchor": "playbook-2-domain-verification-and-serving-activation",
+          "id": "playbook-2",
+          "title": "Playbook 2: Domain Verification and Serving Activation"
+        }
+      ],
+      "routeIds": [
+        "sites.domains.provision"
+      ],
+      "stability": "GA",
+      "summary": "Provision domain via Cloudflare for SaaS (CNAME + Custom Hostname)",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.domains.refresh",
+        "path": "/sites/:siteId/domains/:domain/refresh"
+      },
+      "family": "api",
+      "flagKeys": [
+        "domainVerifyEnabled"
+      ],
+      "group": "sites.domains",
+      "id": "api.sites.domains.refresh",
+      "name": "Refresh Cloudflare validation and resync domain status",
+      "playbooks": [
+        {
+          "anchor": "playbook-2-domain-verification-and-serving-activation",
+          "id": "playbook-2",
+          "title": "Playbook 2: Domain Verification and Serving Activation"
+        }
+      ],
+      "routeIds": [
+        "sites.domains.refresh"
+      ],
+      "stability": "GA",
+      "summary": "Refresh Cloudflare validation and resync domain status",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.domains.verify",
+        "path": "/sites/:siteId/domains/:domain/verify"
+      },
+      "family": "api",
+      "flagKeys": [
+        "domainVerifyEnabled"
+      ],
+      "group": "sites.domains",
+      "id": "api.sites.domains.verify",
+      "name": "Verify domain via TXT or test token",
+      "playbooks": [
+        {
+          "anchor": "playbook-2-domain-verification-and-serving-activation",
+          "id": "playbook-2",
+          "title": "Playbook 2: Domain Verification and Serving Activation"
+        }
+      ],
+      "routeIds": [
+        "sites.domains.verify"
+      ],
+      "stability": "GA",
+      "summary": "Verify domain via TXT or test token",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "sites.get",
+        "path": "/sites/:siteId"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.get",
+      "id": "api.sites.get",
+      "name": "Get site",
+      "playbooks": [
+        {
+          "anchor": "playbook-1-dashboard-bootstrap-and-site-setup",
+          "id": "playbook-1",
+          "title": "Playbook 1: Dashboard Bootstrap and Site Setup"
+        }
+      ],
+      "routeIds": [
+        "sites.get"
+      ],
+      "stability": "GA",
+      "summary": "Get site",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "sites.glossary.get",
+        "path": "/sites/:siteId/glossary"
+      },
+      "family": "api",
+      "flagKeys": [
+        "glossaryEnabled"
+      ],
+      "group": "sites.glossary",
+      "id": "api.sites.glossary.get",
+      "name": "Get glossary entries",
+      "playbooks": [
+        {
+          "anchor": "playbook-4-translation-quality-and-content-controls",
+          "id": "playbook-4",
+          "title": "Playbook 4: Translation Quality and Content Controls"
+        }
+      ],
+      "routeIds": [
+        "sites.glossary.get"
+      ],
+      "stability": "GA",
+      "summary": "Get glossary entries",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "PUT",
+        "operationId": "sites.glossary.put",
+        "path": "/sites/:siteId/glossary"
+      },
+      "family": "api",
+      "flagKeys": [
+        "glossaryEnabled"
+      ],
+      "group": "sites.glossary",
+      "id": "api.sites.glossary.put",
+      "name": "Upsert glossary entries",
+      "playbooks": [
+        {
+          "anchor": "playbook-4-translation-quality-and-content-controls",
+          "id": "playbook-4",
+          "title": "Playbook 4: Translation Quality and Content Controls"
+        }
+      ],
+      "routeIds": [
+        "sites.glossary.put"
+      ],
+      "stability": "GA",
+      "summary": "Upsert glossary entries",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "sites.list",
+        "path": "/sites"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.list",
+      "id": "api.sites.list",
+      "name": "List sites",
+      "playbooks": [
+        {
+          "anchor": "playbook-site-portfolio-management",
+          "id": "playbook-site-portfolio-management",
+          "title": "Playbook: Site Portfolio Management"
+        }
+      ],
+      "routeIds": [
+        "sites.list"
+      ],
+      "stability": "GA",
+      "summary": "List sites",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.locales.serve",
+        "path": "/sites/:siteId/locales/:targetLang/serve"
+      },
+      "family": "api",
+      "flagKeys": [
+        "serveAllowed",
+        "localeUpdateEnabled"
+      ],
+      "group": "sites.locales",
+      "id": "api.sites.locales.serve",
+      "name": "Enable or disable serving for a locale",
+      "playbooks": [
+        {
+          "anchor": "playbook-serving-access-and-previews",
+          "id": "playbook-serving-access-and-previews",
+          "title": "Playbook: Serving Access and Previews"
+        },
+        {
+          "anchor": "playbook-2-domain-verification-and-serving-activation",
+          "id": "playbook-2",
+          "title": "Playbook 2: Domain Verification and Serving Activation"
+        },
+        {
+          "anchor": "playbook-4-translation-quality-and-content-controls",
+          "id": "playbook-4",
+          "title": "Playbook 4: Translation Quality and Content Controls"
+        }
+      ],
+      "routeIds": [
+        "sites.locales.serve"
+      ],
+      "stability": "GA",
+      "summary": "Enable or disable serving for a locale",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "PUT",
+        "operationId": "sites.locales.translationSummary.put",
+        "path": "/sites/:siteId/locales/:targetLang/translation-summary"
+      },
+      "family": "api",
+      "flagKeys": [
+        "localeUpdateEnabled"
+      ],
+      "group": "sites.locales",
+      "id": "api.sites.locales.translationSummary.put",
+      "name": "Configure translation summary notification frequency for a locale",
+      "playbooks": [
+        {
+          "anchor": "playbook-5-previews-and-notifications",
+          "id": "playbook-5",
+          "title": "Playbook 5: Previews and Notifications"
+        }
+      ],
+      "routeIds": [
+        "sites.locales.translationSummary.put"
+      ],
+      "stability": "Beta",
+      "summary": "Configure translation summary notification frequency for a locale",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.overrides.create",
+        "path": "/sites/:siteId/overrides"
+      },
+      "family": "api",
+      "flagKeys": [
+        "overridesEnabled"
+      ],
+      "group": "sites.overrides",
+      "id": "api.sites.overrides.create",
+      "name": "Create segment override",
+      "playbooks": [
+        {
+          "anchor": "playbook-4-translation-quality-and-content-controls",
+          "id": "playbook-4",
+          "title": "Playbook 4: Translation Quality and Content Controls"
+        }
+      ],
+      "routeIds": [
+        "sites.overrides.create"
+      ],
+      "stability": "GA",
+      "summary": "Create segment override",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.pages.crawl",
+        "path": "/sites/:siteId/pages/:pageId/crawl"
+      },
+      "family": "api",
+      "flagKeys": [
+        "crawlTriggerEnabled"
+      ],
+      "group": "sites.pages",
+      "id": "api.sites.pages.crawl",
+      "name": "Trigger extract for a single page",
+      "playbooks": [
+        {
+          "anchor": "playbook-3-crawl-and-translate-lifecycle",
+          "id": "playbook-3",
+          "title": "Playbook 3: Crawl and Translate Lifecycle"
+        }
+      ],
+      "routeIds": [
+        "sites.pages.crawl"
+      ],
+      "stability": "GA",
+      "summary": "Trigger extract for a single page",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "sites.pages.list",
+        "path": "/sites/:siteId/pages"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.pages",
+      "id": "api.sites.pages.list",
+      "name": "List discovered pages",
+      "playbooks": [
+        {
+          "anchor": "playbook-site-portfolio-management",
+          "id": "playbook-site-portfolio-management",
+          "title": "Playbook: Site Portfolio Management"
+        }
+      ],
+      "routeIds": [
+        "sites.pages.list"
+      ],
+      "stability": "GA",
+      "summary": "List discovered pages",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "sites.pipeline.status.get",
+        "path": "/sites/:siteId/pipeline/status/:pageVersionId"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.pipeline",
+      "id": "api.sites.pipeline.status.get",
+      "name": "Get pipeline status for a page version",
+      "playbooks": [
+        {
+          "anchor": "playbook-6-operations-and-incident-response",
+          "id": "playbook-6",
+          "title": "Playbook 6: Operations and Incident Response"
+        }
+      ],
+      "routeIds": [
+        "sites.pipeline.status.get"
+      ],
+      "stability": "Internal",
+      "summary": "Get pipeline status for a page version",
+      "userFacing": false
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.slugs.set",
+        "path": "/sites/:siteId/slugs"
+      },
+      "family": "api",
+      "flagKeys": [
+        "slugEditEnabled"
+      ],
+      "group": "sites.slugs",
+      "id": "api.sites.slugs.set",
+      "name": "Set translated slug path",
+      "playbooks": [
+        {
+          "anchor": "playbook-4-translation-quality-and-content-controls",
+          "id": "playbook-4",
+          "title": "Playbook 4: Translation Quality and Content Controls"
+        }
+      ],
+      "routeIds": [
+        "sites.slugs.set"
+      ],
+      "stability": "GA",
+      "summary": "Set translated slug path",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.translate",
+        "path": "/sites/:siteId/translate"
+      },
+      "family": "api",
+      "flagKeys": [
+        "pipelineAllowed",
+        "renderEnabled",
+        "publishEnabled"
+      ],
+      "group": "sites.translate",
+      "id": "api.sites.translate",
+      "name": "Translate a site without recrawling",
+      "playbooks": [
+        {
+          "anchor": "playbook-3-crawl-and-translate-lifecycle",
+          "id": "playbook-3",
+          "title": "Playbook 3: Crawl and Translate Lifecycle"
+        }
+      ],
+      "routeIds": [
+        "sites.translate"
+      ],
+      "stability": "Beta",
+      "summary": "Starts a translation run using existing page snapshots without launching a new crawl.",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.translationRuns.cancel",
+        "path": "/sites/:siteId/translation-runs/:runId/cancel"
+      },
+      "family": "api",
+      "flagKeys": [
+        "pipelineAllowed"
+      ],
+      "group": "sites.translationRuns",
+      "id": "api.sites.translationRuns.cancel",
+      "name": "Cancel a translation run",
+      "playbooks": [
+        {
+          "anchor": "playbook-3-crawl-and-translate-lifecycle",
+          "id": "playbook-3",
+          "title": "Playbook 3: Crawl and Translate Lifecycle"
+        }
+      ],
+      "routeIds": [
+        "sites.translationRuns.cancel"
+      ],
+      "stability": "Beta",
+      "summary": "Cancel a translation run",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "sites.translationRuns.get",
+        "path": "/sites/:siteId/translation-runs/:runId"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.translationRuns",
+      "id": "api.sites.translationRuns.get",
+      "name": "Get translation run status",
+      "playbooks": [
+        {
+          "anchor": "playbook-3-crawl-and-translate-lifecycle",
+          "id": "playbook-3",
+          "title": "Playbook 3: Crawl and Translate Lifecycle"
+        }
+      ],
+      "routeIds": [
+        "sites.translationRuns.get"
+      ],
+      "stability": "Beta",
+      "summary": "Get translation run status",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.translationRuns.resume",
+        "path": "/sites/:siteId/translation-runs/:runId/resume"
+      },
+      "family": "api",
+      "flagKeys": [
+        "pipelineAllowed"
+      ],
+      "group": "sites.translationRuns",
+      "id": "api.sites.translationRuns.resume",
+      "name": "Resume a translation run",
+      "playbooks": [
+        {
+          "anchor": "playbook-3-crawl-and-translate-lifecycle",
+          "id": "playbook-3",
+          "title": "Playbook 3: Crawl and Translate Lifecycle"
+        }
+      ],
+      "routeIds": [
+        "sites.translationRuns.resume"
+      ],
+      "stability": "Beta",
+      "summary": "Resume a translation run",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "sites.translationSummaries.list",
+        "path": "/sites/:siteId/translation-summaries"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.translationSummaries",
+      "id": "api.sites.translationSummaries.list",
+      "name": "List translation summary rollups for dashboard charts",
+      "playbooks": [
+        {
+          "anchor": "playbook-5-previews-and-notifications",
+          "id": "playbook-5",
+          "title": "Playbook 5: Previews and Notifications"
+        }
+      ],
+      "routeIds": [
+        "sites.translationSummaries.list"
+      ],
+      "stability": "Beta",
+      "summary": "List translation summary rollups for dashboard charts",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "PATCH",
+        "operationId": "sites.update",
+        "path": "/sites/:siteId"
+      },
+      "family": "api",
+      "flagKeys": [
+        "localeUpdateEnabled"
+      ],
+      "group": "sites.update",
+      "id": "api.sites.update",
+      "name": "Update site",
+      "playbooks": [
+        {
+          "anchor": "playbook-site-portfolio-management",
+          "id": "playbook-site-portfolio-management",
+          "title": "Playbook: Site Portfolio Management"
+        }
+      ],
+      "routeIds": [
+        "sites.update"
+      ],
+      "stability": "GA",
+      "summary": "Update site",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": false,
+        "pro": false,
+        "starter": false
+      },
+      "family": "flags",
+      "flagKeys": [
+        "agencyActionsEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.agencyActionsEnabled",
+      "name": "agencyActionsEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `agencyActionsEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": true,
+        "pro": true,
+        "starter": true
+      },
+      "family": "flags",
+      "flagKeys": [
+        "clientRuntimeToggleEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.clientRuntimeToggleEnabled",
+      "name": "clientRuntimeToggleEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `clientRuntimeToggleEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": true,
+        "pro": true,
+        "starter": true
+      },
+      "family": "flags",
+      "flagKeys": [
+        "crawlCaptureModeEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.crawlCaptureModeEnabled",
+      "name": "crawlCaptureModeEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `crawlCaptureModeEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": true,
+        "pro": true,
+        "starter": true
+      },
+      "family": "flags",
+      "flagKeys": [
+        "crawlTriggerEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.crawlTriggerEnabled",
+      "name": "crawlTriggerEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `crawlTriggerEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": false,
+        "free": false,
+        "pro": false,
+        "starter": false
+      },
+      "family": "flags",
+      "flagKeys": [
+        "demoMode"
+      ],
+      "group": "entitlements",
+      "id": "flag.demoMode",
+      "name": "demoMode",
+      "stability": "Internal",
+      "summary": "Entitlement/config flag `demoMode` resolved from plan defaults plus account overrides.",
+      "userFacing": false
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": true,
+        "pro": true,
+        "starter": true
+      },
+      "family": "flags",
+      "flagKeys": [
+        "domainVerifyEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.domainVerifyEnabled",
+      "name": "domainVerifyEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `domainVerifyEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": true,
+        "pro": true,
+        "starter": true
+      },
+      "family": "flags",
+      "flagKeys": [
+        "editEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.editEnabled",
+      "name": "editEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `editEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": [],
+        "free": [],
+        "pro": [],
+        "starter": []
+      },
+      "family": "flags",
+      "flagKeys": [
+        "featurePreview"
+      ],
+      "group": "entitlements",
+      "id": "flag.featurePreview",
+      "name": "featurePreview",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `featurePreview` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": true,
+        "pro": true,
+        "starter": false
+      },
+      "family": "flags",
+      "flagKeys": [
+        "glossaryEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.glossaryEnabled",
+      "name": "glossaryEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `glossaryEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": false,
+        "free": false,
+        "pro": false,
+        "starter": false
+      },
+      "family": "flags",
+      "flagKeys": [
+        "internalOpsEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.internalOpsEnabled",
+      "name": "internalOpsEnabled",
+      "stability": "Internal",
+      "summary": "Entitlement/config flag `internalOpsEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": false
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": false,
+        "pro": true,
+        "starter": true
+      },
+      "family": "flags",
+      "flagKeys": [
+        "localeUpdateEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.localeUpdateEnabled",
+      "name": "localeUpdateEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `localeUpdateEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": null,
+        "free": 1,
+        "pro": null,
+        "starter": null
+      },
+      "family": "flags",
+      "flagKeys": [
+        "maxDailyPageRecrawls"
+      ],
+      "group": "entitlements",
+      "id": "flag.maxDailyPageRecrawls",
+      "name": "maxDailyPageRecrawls",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `maxDailyPageRecrawls` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": null,
+        "free": 1,
+        "pro": null,
+        "starter": null
+      },
+      "family": "flags",
+      "flagKeys": [
+        "maxDailyRecrawls"
+      ],
+      "group": "entitlements",
+      "id": "flag.maxDailyRecrawls",
+      "name": "maxDailyRecrawls",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `maxDailyRecrawls` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": null,
+        "free": 5,
+        "pro": 2000,
+        "starter": 50
+      },
+      "family": "flags",
+      "flagKeys": [
+        "maxGlossarySources"
+      ],
+      "group": "entitlements",
+      "id": "flag.maxGlossarySources",
+      "name": "maxGlossarySources",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `maxGlossarySources` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": null,
+        "free": 1,
+        "pro": null,
+        "starter": null
+      },
+      "family": "flags",
+      "flagKeys": [
+        "maxLocales"
+      ],
+      "group": "entitlements",
+      "id": "flag.maxLocales",
+      "name": "maxLocales",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `maxLocales` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": null,
+        "free": 1,
+        "pro": null,
+        "starter": null
+      },
+      "family": "flags",
+      "flagKeys": [
+        "maxSites"
+      ],
+      "group": "entitlements",
+      "id": "flag.maxSites",
+      "name": "maxSites",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `maxSites` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": false,
+        "pro": true,
+        "starter": false
+      },
+      "family": "flags",
+      "flagKeys": [
+        "overridesEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.overridesEnabled",
+      "name": "overridesEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `overridesEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": true,
+        "pro": true,
+        "starter": true
+      },
+      "family": "flags",
+      "flagKeys": [
+        "pipelineAllowed"
+      ],
+      "group": "entitlements",
+      "id": "flag.pipelineAllowed",
+      "name": "pipelineAllowed",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `pipelineAllowed` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": true,
+        "pro": true,
+        "starter": true
+      },
+      "family": "flags",
+      "flagKeys": [
+        "publishEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.publishEnabled",
+      "name": "publishEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `publishEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": true,
+        "pro": true,
+        "starter": true
+      },
+      "family": "flags",
+      "flagKeys": [
+        "renderEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.renderEnabled",
+      "name": "renderEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `renderEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": true,
+        "pro": true,
+        "starter": true
+      },
+      "family": "flags",
+      "flagKeys": [
+        "serveAllowed"
+      ],
+      "group": "entitlements",
+      "id": "flag.serveAllowed",
+      "name": "serveAllowed",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `serveAllowed` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": true,
+        "pro": true,
+        "starter": true
+      },
+      "family": "flags",
+      "flagKeys": [
+        "siteCreateEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.siteCreateEnabled",
+      "name": "siteCreateEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `siteCreateEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": false,
+        "pro": true,
+        "starter": false
+      },
+      "family": "flags",
+      "flagKeys": [
+        "slugEditEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.slugEditEnabled",
+      "name": "slugEditEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `slugEditEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": false,
+        "pro": true,
+        "starter": false
+      },
+      "family": "flags",
+      "flagKeys": [
+        "tmWriteEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.tmWriteEnabled",
+      "name": "tmWriteEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `tmWriteEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "defaultsByPlan": {
+        "agency": true,
+        "free": true,
+        "pro": true,
+        "starter": true
+      },
+      "family": "flags",
+      "flagKeys": [
+        "translatableAttributesEnabled"
+      ],
+      "group": "entitlements",
+      "id": "flag.translatableAttributesEnabled",
+      "name": "translatableAttributesEnabled",
+      "stability": "GA",
+      "summary": "Entitlement/config flag `translatableAttributesEnabled` resolved from plan defaults plus account overrides.",
+      "userFacing": true
+    },
+    {
+      "family": "http",
+      "group": "crawl",
+      "id": "http.crawl.health",
+      "name": "Crawl worker health endpoint",
+      "stability": "Internal",
+      "summary": "Simple health response for crawl-worker.",
+      "surfaces": [
+        {
+          "method": "GET",
+          "path": "/",
+          "trigger": "http",
+          "worker": "crawl-worker"
+        }
+      ],
+      "userFacing": false
+    },
+    {
+      "family": "http",
+      "group": "crawl",
+      "id": "http.crawl.trigger",
+      "name": "Crawl trigger endpoint",
+      "stability": "Internal",
+      "summary": "Internal HTTP trigger for crawl queue fan-out.",
+      "surfaces": [
+        {
+          "auth": "Bearer CRAWL_TRIGGER_TOKEN or x-crawl-token",
+          "method": "POST",
+          "path": "/",
+          "trigger": "http",
+          "worker": "crawl-worker"
+        }
+      ],
+      "userFacing": false
+    },
+    {
+      "family": "http",
+      "group": "digest",
+      "id": "http.digest.scheduled",
+      "name": "Digest scheduled trigger",
+      "stability": "Internal",
+      "summary": "Scheduled digest summary generation and notify enqueue flow.",
+      "surfaces": [
+        {
+          "trigger": "scheduled",
+          "worker": "digest-worker"
+        }
+      ],
+      "userFacing": false
+    },
+    {
+      "family": "http",
+      "group": "digest",
+      "id": "http.digest.trigger",
+      "name": "Digest trigger endpoint",
+      "stability": "Internal",
+      "summary": "Authenticated HTTP trigger for digest summary generation.",
+      "surfaces": [
+        {
+          "auth": "Bearer DIGEST_TRIGGER_TOKEN or x-digest-trigger",
+          "method": "POST",
+          "path": "/",
+          "trigger": "http",
+          "worker": "digest-worker"
+        }
+      ],
+      "userFacing": false
+    },
+    {
+      "family": "http",
+      "group": "serve",
+      "id": "http.serve.dictionary",
+      "name": "Serve runtime dictionaries",
+      "stability": "Beta",
+      "summary": "Serve deployment-scoped runtime dictionary artifacts for hydration-safe runtime/proxy translation paths.",
+      "surfaces": [
+        {
+          "method": "GET|HEAD",
+          "path": "/.well-known/weblingo/dict/*",
+          "trigger": "http",
+          "worker": "serve-worker"
+        }
+      ],
+      "userFacing": false
+    },
+    {
+      "family": "http",
+      "group": "serve",
+      "id": "http.serve.localized",
+      "name": "Serve localized content",
+      "playbooks": [
+        {
+          "anchor": "playbook-serving-access-and-previews",
+          "id": "playbook-serving-access-and-previews",
+          "title": "Playbook: Serving Access and Previews"
+        }
+      ],
+      "stability": "GA",
+      "summary": "DB-free localized page serving via KV deployment pointers and R2 artifacts.",
+      "surfaces": [
+        {
+          "auth": "None",
+          "method": "GET|HEAD",
+          "path": "/{path}",
+          "trigger": "http",
+          "worker": "serve-worker"
+        }
+      ],
+      "userFacing": true
+    },
+    {
+      "family": "http",
+      "group": "serve",
+      "id": "http.serve.preview",
+      "name": "Serve preview pages",
+      "playbooks": [
+        {
+          "anchor": "playbook-serving-access-and-previews",
+          "id": "playbook-serving-access-and-previews",
+          "title": "Playbook: Serving Access and Previews"
+        }
+      ],
+      "stability": "Beta",
+      "summary": "Serve ephemeral preview artifacts from R2 with strict preview TTL semantics.",
+      "surfaces": [
+        {
+          "auth": "None",
+          "method": "GET|HEAD",
+          "path": "/_preview/{previewId}",
+          "trigger": "http",
+          "worker": "serve-worker"
+        }
+      ],
+      "userFacing": true
+    },
+    {
+      "family": "pipeline",
+      "group": "crawl",
+      "id": "pipeline.CrawlRunQueuePayload",
+      "name": "CrawlRunQueuePayload",
+      "payloadContract": {
+        "fields": [
+          {
+            "name": "kind",
+            "optional": false,
+            "type": "\"crawl_run\""
+          },
+          {
+            "name": "site_id",
+            "optional": false,
+            "type": "SiteId"
+          },
+          {
+            "name": "crawl_id",
+            "optional": false,
+            "type": "CrawlRunId"
+          },
+          {
+            "name": "force",
+            "optional": true,
+            "type": "boolean"
+          },
+          {
+            "name": "target_langs",
+            "optional": true,
+            "type": "LangTag[]"
+          }
+        ],
+        "interfaceName": "CrawlRunQueuePayload",
+        "kindLiteral": "crawl_run"
+      },
+      "stability": "Internal",
+      "summary": "Queue payload contract for crawl worker messages.",
+      "userFacing": false
+    },
+    {
+      "family": "pipeline",
+      "group": "crawl",
+      "id": "pipeline.CrawlSiteQueuePayload",
+      "name": "CrawlSiteQueuePayload",
+      "payloadContract": {
+        "fields": [
+          {
+            "name": "kind",
+            "optional": false,
+            "type": "\"crawl\""
+          },
+          {
+            "name": "site_id",
+            "optional": false,
+            "type": "SiteId"
+          },
+          {
+            "name": "source_url",
+            "optional": false,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "optional": true,
+            "type": "boolean"
+          }
+        ],
+        "interfaceName": "CrawlSiteQueuePayload",
+        "kindLiteral": "crawl"
+      },
+      "stability": "Internal",
+      "summary": "Queue payload contract for crawl worker messages.",
+      "userFacing": false
+    },
+    {
+      "family": "pipeline",
+      "group": "notify",
+      "id": "pipeline.NotifyTranslationRunQueuePayload",
+      "name": "NotifyTranslationRunQueuePayload",
+      "payloadContract": {
+        "fields": [
+          {
+            "name": "type",
+            "optional": false,
+            "type": "\"translation.completed\" | \"translation.failed\""
+          },
+          {
+            "name": "site_id",
+            "optional": false,
+            "type": "SiteId"
+          },
+          {
+            "name": "translation_run_id",
+            "optional": false,
+            "type": "TranslationRunId"
+          },
+          {
+            "name": "target_lang",
+            "optional": false,
+            "type": "LangTag"
+          },
+          {
+            "name": "deployment_id",
+            "optional": false,
+            "type": "DeploymentId"
+          },
+          {
+            "name": "pages_total",
+            "optional": false,
+            "type": "number"
+          },
+          {
+            "name": "pages_completed",
+            "optional": false,
+            "type": "number"
+          },
+          {
+            "name": "pages_failed",
+            "optional": false,
+            "type": "number"
+          },
+          {
+            "name": "finished_at",
+            "optional": false,
+            "type": "string"
+          }
+        ],
+        "interfaceName": "NotifyTranslationRunQueuePayload",
+        "kindLiteral": null
+      },
+      "stability": "Internal",
+      "summary": "Queue payload contract for notify worker messages.",
+      "userFacing": false
+    },
+    {
+      "family": "pipeline",
+      "group": "notify",
+      "id": "pipeline.NotifyTranslationSummaryQueuePayload",
+      "name": "NotifyTranslationSummaryQueuePayload",
+      "payloadContract": {
+        "fields": [
+          {
+            "name": "type",
+            "optional": false,
+            "type": "\"translation.summary\""
+          },
+          {
+            "name": "site_id",
+            "optional": false,
+            "type": "SiteId"
+          },
+          {
+            "name": "target_lang",
+            "optional": false,
+            "type": "LangTag"
+          },
+          {
+            "name": "period",
+            "optional": false,
+            "type": "\"daily\" | \"weekly\""
+          },
+          {
+            "name": "range_start",
+            "optional": false,
+            "type": "string"
+          },
+          {
+            "name": "range_end",
+            "optional": false,
+            "type": "string"
+          },
+          {
+            "name": "pages_translated",
+            "optional": false,
+            "type": "number"
+          },
+          {
+            "name": "pages_updated",
+            "optional": false,
+            "type": "number"
+          },
+          {
+            "name": "last_deployment_at",
+            "optional": true,
+            "type": "string | null"
+          }
+        ],
+        "interfaceName": "NotifyTranslationSummaryQueuePayload",
+        "kindLiteral": null
+      },
+      "stability": "Internal",
+      "summary": "Queue payload contract for notify worker messages.",
+      "userFacing": false
+    },
+    {
+      "family": "pipeline",
+      "group": "preview-email",
+      "id": "pipeline.PreviewEmailQueuePayload",
+      "name": "PreviewEmailQueuePayload",
+      "payloadContract": {
+        "fields": [
+          {
+            "name": "preview_id",
+            "optional": false,
+            "type": "PreviewRequestId"
+          }
+        ],
+        "interfaceName": "PreviewEmailQueuePayload",
+        "kindLiteral": null
+      },
+      "stability": "Internal",
+      "summary": "Queue payload contract for preview-email worker messages.",
+      "userFacing": false
+    },
+    {
+      "family": "pipeline",
+      "group": "preview",
+      "id": "pipeline.PreviewQueuePayload",
+      "name": "PreviewQueuePayload",
+      "payloadContract": {
+        "fields": [
+          {
+            "name": "preview_id",
+            "optional": false,
+            "type": "PreviewRequestId"
+          },
+          {
+            "name": "parent_request_id",
+            "optional": false,
+            "type": "string | null"
+          },
+          {
+            "name": "preview_request_url",
+            "optional": false,
+            "type": "string"
+          },
+          {
+            "name": "enqueued_at_ms",
+            "optional": true,
+            "type": "number"
+          }
+        ],
+        "interfaceName": "PreviewQueuePayload",
+        "kindLiteral": null
+      },
+      "stability": "Internal",
+      "summary": "Queue payload contract for preview worker messages.",
+      "userFacing": false
+    },
+    {
+      "family": "pipeline",
+      "group": "publish",
+      "id": "pipeline.PublishFinalizeQueuePayload",
+      "name": "PublishFinalizeQueuePayload",
+      "payloadContract": {
+        "fields": [
+          {
+            "name": "kind",
+            "optional": false,
+            "type": "\"finalize\""
+          },
+          {
+            "name": "site_id",
+            "optional": false,
+            "type": "SiteId"
+          },
+          {
+            "name": "target_lang",
+            "optional": false,
+            "type": "LangTag"
+          },
+          {
+            "name": "translation_run_id",
+            "optional": false,
+            "type": "TranslationRunId"
+          }
+        ],
+        "interfaceName": "PublishFinalizeQueuePayload",
+        "kindLiteral": "finalize"
+      },
+      "stability": "Internal",
+      "summary": "Queue payload contract for publish worker messages.",
+      "userFacing": false
+    },
+    {
+      "family": "pipeline",
+      "group": "publish",
+      "id": "pipeline.PublishPageQueuePayload",
+      "name": "PublishPageQueuePayload",
+      "payloadContract": {
+        "fields": [
+          {
+            "name": "kind",
+            "optional": false,
+            "type": "\"page\""
+          },
+          {
+            "name": "site_id",
+            "optional": false,
+            "type": "SiteId"
+          },
+          {
+            "name": "target_lang",
+            "optional": false,
+            "type": "LangTag"
+          },
+          {
+            "name": "page_version_id",
+            "optional": false,
+            "type": "PageVersionId"
+          },
+          {
+            "name": "source_path",
+            "optional": false,
+            "type": "string"
+          },
+          {
+            "name": "target_path",
+            "optional": true,
+            "type": "string | null"
+          },
+          {
+            "name": "timestamp",
+            "optional": true,
+            "type": "number"
+          },
+          {
+            "name": "translation_run_id",
+            "optional": true,
+            "type": "TranslationRunId"
+          }
+        ],
+        "interfaceName": "PublishPageQueuePayload",
+        "kindLiteral": "page"
+      },
+      "stability": "Internal",
+      "summary": "Queue payload contract for publish worker messages.",
+      "userFacing": false
+    },
+    {
+      "family": "pipeline",
+      "group": "render",
+      "id": "pipeline.RenderQueuePayload",
+      "name": "RenderQueuePayload",
+      "payloadContract": {
+        "fields": [
+          {
+            "name": "site_id",
+            "optional": false,
+            "type": "SiteId"
+          },
+          {
+            "name": "page_version_id",
+            "optional": false,
+            "type": "PageVersionId"
+          },
+          {
+            "name": "target_lang",
+            "optional": false,
+            "type": "LangTag"
+          },
+          {
+            "name": "translation_run_id",
+            "optional": true,
+            "type": "TranslationRunId"
+          }
+        ],
+        "interfaceName": "RenderQueuePayload",
+        "kindLiteral": null
+      },
+      "stability": "Internal",
+      "summary": "Queue payload contract for render worker messages.",
+      "userFacing": false
+    },
+    {
+      "family": "pipeline",
+      "group": "translate",
+      "id": "pipeline.TranslateQueuePayload",
+      "name": "TranslateQueuePayload",
+      "payloadContract": {
+        "fields": [
+          {
+            "name": "site_id",
+            "optional": false,
+            "type": "SiteId"
+          },
+          {
+            "name": "page_version_id",
+            "optional": false,
+            "type": "PageVersionId"
+          },
+          {
+            "name": "target_lang",
+            "optional": false,
+            "type": "LangTag"
+          },
+          {
+            "name": "translation_run_id",
+            "optional": true,
+            "type": "TranslationRunId"
+          }
+        ],
+        "interfaceName": "TranslateQueuePayload",
+        "kindLiteral": null
+      },
+      "stability": "Internal",
+      "summary": "Queue payload contract for translate worker messages.",
+      "userFacing": false
+    }
+  ],
+  "generatedFrom": {
+    "featureFlags": "packages/common/src/feature-flags.ts",
+    "pipelineTypes": "packages/common/src/pipeline-types.ts",
+    "playbooks": "docs/reference/API_PLAYBOOKS.md",
+    "routes": "workers/webhooks-worker/src/routes.ts"
+  },
+  "policy": {
+    "internalStability": [
+      "Internal"
+    ],
+    "userFacingStability": [
+      "GA",
+      "Beta"
+    ]
+  }
+}

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -1,0 +1,6262 @@
+{
+  "components": {
+    "schemas": {
+      "AccountClaimResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "accountId": {
+            "type": "string"
+          },
+          "planStatus": {
+            "$ref": "#/components/schemas/AccountPlanStatus"
+          },
+          "planType": {
+            "$ref": "#/components/schemas/AccountPlanType"
+          },
+          "status": {
+            "enum": [
+              "created",
+              "exists"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "accountId",
+          "status",
+          "planType",
+          "planStatus"
+        ],
+        "type": "object"
+      },
+      "AccountMeResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "accountId": {
+            "type": "string"
+          },
+          "dailyCrawlUsage": {
+            "$ref": "#/components/schemas/DailyCrawlUsage"
+          },
+          "featureFlags": {
+            "$ref": "#/components/schemas/ResolvedFeatureFlags"
+          },
+          "planStatus": {
+            "$ref": "#/components/schemas/AccountPlanStatus"
+          },
+          "planType": {
+            "$ref": "#/components/schemas/AccountPlanType"
+          },
+          "quotas": {
+            "$ref": "#/components/schemas/AccountQuotas"
+          }
+        },
+        "required": [
+          "accountId",
+          "planType",
+          "planStatus",
+          "featureFlags",
+          "dailyCrawlUsage",
+          "quotas"
+        ],
+        "type": "object"
+      },
+      "AccountPlanStatus": {
+        "$ref": "#/components/schemas/PlanStatus"
+      },
+      "AccountPlanType": {
+        "$ref": "#/components/schemas/PlanType"
+      },
+      "AccountQuotas": {
+        "additionalProperties": false,
+        "properties": {
+          "maxSites": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "proQuota": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "starterQuota": {
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "maxSites",
+          "starterQuota",
+          "proQuota"
+        ],
+        "type": "object"
+      },
+      "AgencyCustomer": {
+        "additionalProperties": false,
+        "properties": {
+          "activeSiteCount": {
+            "type": "number"
+          },
+          "agencyAccountId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "customerAccountId": {
+            "type": "string"
+          },
+          "customerEmail": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "customerPlan": {
+            "$ref": "#/components/schemas/AgencyCustomerPlan"
+          },
+          "planStatus": {
+            "$ref": "#/components/schemas/AccountPlanStatus"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AgencyCustomerStatus"
+          }
+        },
+        "required": [
+          "agencyAccountId",
+          "customerAccountId",
+          "customerPlan",
+          "planStatus",
+          "status",
+          "activeSiteCount"
+        ],
+        "type": "object"
+      },
+      "AgencyCustomerPlan": {
+        "enum": [
+          "starter",
+          "pro"
+        ],
+        "type": "string"
+      },
+      "AgencyCustomersSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "maxSites": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "totalActiveSites": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "totalActiveSites",
+          "maxSites"
+        ],
+        "type": "object"
+      },
+      "AgencyCustomerStatus": {
+        "enum": [
+          "active",
+          "suspended"
+        ],
+        "type": "string"
+      },
+      "AuthTokenRequest": {
+        "additionalProperties": false,
+        "example": {
+          "subjectAccountId": "00000000-0000-0000-0000-000000000001"
+        },
+        "examples": [
+          {
+            "subjectAccountId": "00000000-0000-0000-0000-000000000001"
+          }
+        ],
+        "properties": {
+          "subjectAccountId": {
+            "description": "Optional: agencies can request a token scoped to a customer account they manage. When omitted, the token is minted for the authenticated Supabase user (self).",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "AuthTokenResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "actorAccountId": {
+            "type": "string"
+          },
+          "entitlements": {
+            "$ref": "#/components/schemas/Entitlements"
+          },
+          "expiresAt": {
+            "type": "string"
+          },
+          "subjectAccountId": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "expiresAt",
+          "entitlements",
+          "actorAccountId",
+          "subjectAccountId"
+        ],
+        "type": "object"
+      },
+      "CancelTranslationRunResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "run": {
+            "$ref": "#/components/schemas/TranslationRun"
+          }
+        },
+        "required": [
+          "run"
+        ],
+        "type": "object"
+      },
+      "CloudflareHostnameState": {
+        "additionalProperties": false,
+        "properties": {
+          "certStatus": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "customHostnameId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "errorMessages": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "errors": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hostnameStatus": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lastSyncedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "customHostnameId",
+          "hostnameStatus",
+          "certStatus",
+          "lastSyncedAt",
+          "errors"
+        ],
+        "type": "object"
+      },
+      "CrawlCaptureMode": {
+        "enum": [
+          "template_plus_hydrated",
+          "template_only",
+          "hydrated_only"
+        ],
+        "type": "string"
+      },
+      "CrawlRunStatus": {
+        "enum": [
+          "in_progress",
+          "completed",
+          "failed"
+        ],
+        "type": "string"
+      },
+      "CrawlRunSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "crawlCaptureMode": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CrawlCaptureMode"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "finishedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "pagesDiscovered": {
+            "type": "number"
+          },
+          "pagesEnqueued": {
+            "type": "number"
+          },
+          "selectedCount": {
+            "type": "number"
+          },
+          "skippedDueToLimitCount": {
+            "type": "number"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "startedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/CrawlRunStatus"
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/CrawlRunTrigger"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "sourceUrl",
+          "trigger",
+          "status",
+          "pagesDiscovered",
+          "pagesEnqueued",
+          "selectedCount",
+          "skippedDueToLimitCount"
+        ],
+        "type": "object"
+      },
+      "CrawlRunTrigger": {
+        "enum": [
+          "cron",
+          "queue"
+        ],
+        "type": "string"
+      },
+      "CrawlStatus": {
+        "additionalProperties": false,
+        "properties": {
+          "enqueued": {
+            "type": "boolean"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "enqueued"
+        ],
+        "type": "object"
+      },
+      "CrawlTranslateRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "force": {
+            "type": "boolean"
+          },
+          "pageIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sourcePaths": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "targetLangs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "targetLangs"
+        ],
+        "type": "object"
+      },
+      "CrawlTranslateResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "crawlId": {
+            "type": "string"
+          },
+          "enqueuedCount": {
+            "type": "number"
+          },
+          "force": {
+            "type": "boolean"
+          },
+          "selectedCount": {
+            "type": "number"
+          },
+          "targetLangs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "crawlId",
+          "selectedCount",
+          "enqueuedCount",
+          "targetLangs",
+          "force"
+        ],
+        "type": "object"
+      },
+      "CrawlTriggerRequest": {
+        "additionalProperties": false,
+        "example": {
+          "force": true
+        },
+        "examples": [
+          {
+            "force": true
+          }
+        ],
+        "properties": {
+          "force": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "CreateAgencyCustomerRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "customerPlan": {
+            "$ref": "#/components/schemas/AgencyCustomerPlan"
+          },
+          "email": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "customerPlan"
+        ],
+        "type": "object"
+      },
+      "CreateAgencyCustomerResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "customer": {
+            "$ref": "#/components/schemas/AgencyCustomer"
+          },
+          "inviteLink": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "customer",
+          "inviteLink"
+        ],
+        "type": "object"
+      },
+      "CreateOverrideRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "contextHashScope": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "segmentId": {
+            "type": "string"
+          },
+          "targetLang": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "segmentId",
+          "targetLang",
+          "text"
+        ],
+        "type": "object"
+      },
+      "CreateOverrideResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "contextHashScope": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "segmentId": {
+            "type": "string"
+          },
+          "targetLang": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "segmentId",
+          "targetLang",
+          "contextHashScope"
+        ],
+        "type": "object"
+      },
+      "CreateSiteRequest": {
+        "additionalProperties": false,
+        "example": {
+          "maxLocales": 5,
+          "servingMode": "strict",
+          "sourceLang": "en",
+          "sourceUrl": "https://www.example.com",
+          "subdomainPattern": "{lang}.example.com",
+          "targetLangs": [
+            "fr",
+            "de"
+          ]
+        },
+        "examples": [
+          {
+            "maxLocales": 5,
+            "servingMode": "strict",
+            "sourceLang": "en",
+            "sourceUrl": "https://www.example.com",
+            "subdomainPattern": "{lang}.example.com",
+            "targetLangs": [
+              "fr",
+              "de"
+            ]
+          }
+        ],
+        "properties": {
+          "clientRuntimeEnabled": {
+            "type": "boolean"
+          },
+          "crawlCaptureMode": {
+            "$ref": "#/components/schemas/CrawlCaptureMode"
+          },
+          "localeAliases": {
+            "additionalProperties": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": "object"
+          },
+          "maxLocales": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "servingMode": {
+            "$ref": "#/components/schemas/ServingMode"
+          },
+          "siteProfile": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sourceLang": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "spaRefresh": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpaRefreshSettings"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "subdomainPattern": {
+            "type": "string"
+          },
+          "targetLangs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "translatableAttributes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "webhookSecret": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "webhookUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "sourceUrl",
+          "sourceLang",
+          "targetLangs",
+          "subdomainPattern",
+          "servingMode",
+          "maxLocales"
+        ],
+        "type": "object"
+      },
+      "DailyCrawlUsage": {
+        "additionalProperties": false,
+        "properties": {
+          "date": {
+            "type": "string"
+          },
+          "pageCrawls": {
+            "type": "number"
+          },
+          "siteCrawls": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "date",
+          "siteCrawls",
+          "pageCrawls"
+        ],
+        "type": "object"
+      },
+      "DashboardBootstrapRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "includeAgencyCustomers": {
+            "description": "Optional: include agency customer list when actor is an agency account.",
+            "type": "boolean"
+          },
+          "subjectAccountId": {
+            "description": "Optional: agencies can request a bootstrap scoped to a customer account they manage. When omitted, the bootstrap is scoped to the authenticated Supabase user (self).",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DashboardBootstrapResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "account": {
+            "$ref": "#/components/schemas/AccountMeResponse"
+          },
+          "actorAccountId": {
+            "type": "string"
+          },
+          "agencyCustomers": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ListAgencyCustomersResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "entitlements": {
+            "$ref": "#/components/schemas/Entitlements"
+          },
+          "expiresAt": {
+            "type": "string"
+          },
+          "subjectAccountId": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "expiresAt",
+          "entitlements",
+          "actorAccountId",
+          "subjectAccountId",
+          "account",
+          "agencyCustomers"
+        ],
+        "type": "object"
+      },
+      "Deployment": {
+        "additionalProperties": false,
+        "properties": {
+          "activatedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "activeDeploymentId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "artifactManifest": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "deploymentId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "domain": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "domainStatus": {
+            "enum": [
+              "pending",
+              "verified",
+              "failed",
+              null
+            ],
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "routePrefix": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "serveEnabled": {
+            "type": "boolean"
+          },
+          "servingStatus": {
+            "$ref": "#/components/schemas/DeploymentServingStatus"
+          },
+          "status": {
+            "type": "string"
+          },
+          "targetLang": {
+            "type": "string"
+          },
+          "translationRun": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TranslationRun"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "targetLang",
+          "status",
+          "serveEnabled",
+          "servingStatus"
+        ],
+        "type": "object"
+      },
+      "DeploymentServingStatus": {
+        "enum": [
+          "inactive",
+          "disabled",
+          "needs_domain",
+          "ready",
+          "serving"
+        ],
+        "type": "string"
+      },
+      "DigestSubscription": {
+        "additionalProperties": false,
+        "properties": {
+          "accountId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "frequency": {
+            "enum": [
+              "daily",
+              "weekly",
+              "off"
+            ],
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "accountId",
+          "email",
+          "frequency"
+        ],
+        "type": "object"
+      },
+      "DigestSubscriptionRequest": {
+        "additionalProperties": false,
+        "example": {
+          "email": "alerts@example.com",
+          "frequency": "weekly"
+        },
+        "examples": [
+          {
+            "email": "alerts@example.com",
+            "frequency": "weekly"
+          }
+        ],
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "frequency": {
+            "enum": [
+              "daily",
+              "weekly",
+              "off"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "frequency"
+        ],
+        "type": "object"
+      },
+      "DigestSubscriptionResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "subscription": {
+            "$ref": "#/components/schemas/DigestSubscription"
+          }
+        },
+        "required": [
+          "subscription"
+        ],
+        "type": "object"
+      },
+      "DlqListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "complete": {
+            "type": "boolean"
+          },
+          "cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/DlqMessage"
+            },
+            "type": "array"
+          },
+          "siteId": {
+            "type": "string"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/DlqSummary"
+          }
+        },
+        "required": [
+          "siteId",
+          "summary",
+          "messages",
+          "complete"
+        ],
+        "type": "object"
+      },
+      "DlqMessage": {
+        "additionalProperties": false,
+        "properties": {
+          "attempts": {
+            "type": "number"
+          },
+          "error": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "payload": {},
+          "timestamp": {
+            "type": "string"
+          },
+          "worker": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "worker",
+          "attempts",
+          "error",
+          "timestamp",
+          "payload"
+        ],
+        "type": "object"
+      },
+      "DlqReplayFailure": {
+        "additionalProperties": false,
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "error"
+        ],
+        "type": "object"
+      },
+      "DlqReplayRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "deleteOnSuccess": {
+            "type": "boolean"
+          },
+          "dryRun": {
+            "type": "boolean"
+          },
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "keys"
+        ],
+        "type": "object"
+      },
+      "DlqReplayResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "attempted": {
+            "type": "number"
+          },
+          "deleted": {
+            "type": "number"
+          },
+          "deleteOnSuccess": {
+            "type": "boolean"
+          },
+          "dryRun": {
+            "type": "boolean"
+          },
+          "failures": {
+            "items": {
+              "$ref": "#/components/schemas/DlqReplayFailure"
+            },
+            "type": "array"
+          },
+          "sent": {
+            "type": "number"
+          },
+          "siteId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "siteId",
+          "attempted",
+          "dryRun",
+          "deleteOnSuccess",
+          "sent",
+          "deleted",
+          "failures"
+        ],
+        "type": "object"
+      },
+      "DlqSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "errors": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object"
+          },
+          "newest": {
+            "type": "string"
+          },
+          "oldest": {
+            "type": "string"
+          },
+          "perWorker": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object"
+          },
+          "total": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "total",
+          "perWorker",
+          "errors"
+        ],
+        "type": "object"
+      },
+      "DnsInstructions": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          },
+          "type": {
+            "const": "CNAME",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "target"
+        ],
+        "type": "object"
+      },
+      "Entitlements": {
+        "additionalProperties": false,
+        "properties": {
+          "planStatus": {
+            "$ref": "#/components/schemas/AccountPlanStatus"
+          },
+          "planType": {
+            "$ref": "#/components/schemas/AccountPlanType"
+          }
+        },
+        "required": [
+          "planType",
+          "planStatus"
+        ],
+        "type": "object"
+      },
+      "ErrorResponse": {
+        "additionalProperties": false,
+        "example": {
+          "details": {
+            "code": "unauthorized"
+          },
+          "error": "Unauthorized"
+        },
+        "examples": [
+          {
+            "details": {
+              "code": "unauthorized"
+            },
+            "error": "Unauthorized"
+          }
+        ],
+        "properties": {
+          "details": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "GlossaryEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "caseSensitive": {
+            "type": "boolean"
+          },
+          "matchType": {
+            "type": "string"
+          },
+          "scope": {
+            "enum": [
+              "segment",
+              "in_segment"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          },
+          "targetLangs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "GlossaryResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "crawlStatus": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CrawlStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/GlossaryEntry"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "entries"
+        ],
+        "type": "object"
+      },
+      "ListAgencyCustomersResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "customers": {
+            "items": {
+              "$ref": "#/components/schemas/AgencyCustomer"
+            },
+            "type": "array"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/AgencyCustomersSummary"
+          }
+        },
+        "required": [
+          "customers",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "ListDeploymentsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "deployments": {
+            "items": {
+              "$ref": "#/components/schemas/Deployment"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "deployments"
+        ],
+        "type": "object"
+      },
+      "ListSitePagesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "pages": {
+            "items": {
+              "$ref": "#/components/schemas/SitePageSummary"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "pages"
+        ],
+        "type": "object"
+      },
+      "ListSitesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "sites": {
+            "items": {
+              "$ref": "#/components/schemas/Site"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "sites"
+        ],
+        "type": "object"
+      },
+      "ListSupportedLanguagesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "languages": {
+            "items": {
+              "$ref": "#/components/schemas/SupportedLanguage"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "languages"
+        ],
+        "type": "object"
+      },
+      "ListTranslationSummariesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "summaries": {
+            "items": {
+              "$ref": "#/components/schemas/TranslationSummary"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "summaries"
+        ],
+        "type": "object"
+      },
+      "PipelineStage": {
+        "enum": [
+          "crawl",
+          "extract",
+          "translate",
+          "render",
+          "publish",
+          "done"
+        ],
+        "type": "string"
+      },
+      "PipelineStageStatus": {
+        "enum": [
+          "pending",
+          "in_progress",
+          "succeeded",
+          "failed"
+        ],
+        "type": "string"
+      },
+      "PipelineStatusItem": {
+        "additionalProperties": false,
+        "properties": {
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "stage": {
+            "$ref": "#/components/schemas/PipelineStage"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PipelineStageStatus"
+          },
+          "targetLang": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "targetLang",
+          "stage",
+          "status",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "PipelineStatusResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "pageVersionId": {
+            "type": "string"
+          },
+          "siteId": {
+            "type": "string"
+          },
+          "statuses": {
+            "items": {
+              "$ref": "#/components/schemas/PipelineStatusItem"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "siteId",
+          "pageVersionId",
+          "statuses"
+        ],
+        "type": "object"
+      },
+      "PlanStatus": {
+        "description": "Subscription/account status",
+        "enum": [
+          "active",
+          "past_due",
+          "cancelled"
+        ],
+        "type": "string"
+      },
+      "PlanType": {
+        "description": "Account plan tiers",
+        "enum": [
+          "free",
+          "starter",
+          "pro",
+          "agency"
+        ],
+        "type": "string"
+      },
+      "PreviewRequest": {
+        "additionalProperties": false,
+        "example": {
+          "email": "owner@example.com",
+          "sourceLang": "en",
+          "sourceUrl": "https://example.com",
+          "targetLang": "fr"
+        },
+        "examples": [
+          {
+            "email": "owner@example.com",
+            "sourceLang": "en",
+            "sourceUrl": "https://example.com",
+            "targetLang": "fr"
+          }
+        ],
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "sourceLang": {
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "targetLang": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sourceUrl",
+          "sourceLang",
+          "targetLang"
+        ],
+        "type": "object"
+      },
+      "PreviewRequestStatus": {
+        "enum": [
+          "pending",
+          "processing",
+          "ready",
+          "failed"
+        ],
+        "type": "string"
+      },
+      "PreviewStatus": {
+        "additionalProperties": false,
+        "properties": {
+          "capture": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "hydratedBytes": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "hydratedFinalUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "hydratedHttpStatus": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "hydratedWaitUntilTimeout": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "pageFinalUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "templateBytes": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "templateFinalUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "templateHttpStatus": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "templateResponseUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "templateWaitUntilTimeout": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "wafDetected": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "errorCode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "errorStage": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "expiresAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "previewId": {
+            "type": "string"
+          },
+          "previewUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "stage": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/PreviewRequestStatus"
+          },
+          "statusToken": {
+            "description": "Per-preview status token required for status polling + SSE. Only returned on create.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "streamUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "previewId",
+          "status"
+        ],
+        "type": "object"
+      },
+      "ProvisionDomainResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "domain": {
+            "$ref": "#/components/schemas/SiteDomain"
+          }
+        },
+        "required": [
+          "domain"
+        ],
+        "type": "object"
+      },
+      "RefreshDomainResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "domain": {
+            "$ref": "#/components/schemas/SiteDomain"
+          }
+        },
+        "required": [
+          "domain"
+        ],
+        "type": "object"
+      },
+      "ResolvedFeatureFlags": {
+        "additionalProperties": false,
+        "properties": {
+          "agencyActionsEnabled": {
+            "type": "boolean"
+          },
+          "clientRuntimeToggleEnabled": {
+            "type": "boolean"
+          },
+          "crawlCaptureModeEnabled": {
+            "type": "boolean"
+          },
+          "crawlTriggerEnabled": {
+            "type": "boolean"
+          },
+          "demoMode": {
+            "type": "boolean"
+          },
+          "domainVerifyEnabled": {
+            "type": "boolean"
+          },
+          "editEnabled": {
+            "type": "boolean"
+          },
+          "featurePreview": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "glossaryEnabled": {
+            "type": "boolean"
+          },
+          "internalOpsEnabled": {
+            "type": "boolean"
+          },
+          "localeUpdateEnabled": {
+            "type": "boolean"
+          },
+          "maxDailyPageRecrawls": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "maxDailyRecrawls": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "maxGlossarySources": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "maxLocales": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "maxSites": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "overridesEnabled": {
+            "type": "boolean"
+          },
+          "pipelineAllowed": {
+            "type": "boolean"
+          },
+          "publishEnabled": {
+            "type": "boolean"
+          },
+          "renderEnabled": {
+            "type": "boolean"
+          },
+          "serveAllowed": {
+            "type": "boolean"
+          },
+          "siteCreateEnabled": {
+            "type": "boolean"
+          },
+          "slugEditEnabled": {
+            "type": "boolean"
+          },
+          "tmWriteEnabled": {
+            "type": "boolean"
+          },
+          "translatableAttributesEnabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "editEnabled",
+          "slugEditEnabled",
+          "glossaryEnabled",
+          "overridesEnabled",
+          "tmWriteEnabled",
+          "publishEnabled",
+          "pipelineAllowed",
+          "serveAllowed",
+          "siteCreateEnabled",
+          "localeUpdateEnabled",
+          "domainVerifyEnabled",
+          "crawlTriggerEnabled",
+          "crawlCaptureModeEnabled",
+          "clientRuntimeToggleEnabled",
+          "translatableAttributesEnabled",
+          "renderEnabled",
+          "agencyActionsEnabled",
+          "internalOpsEnabled",
+          "demoMode",
+          "maxSites",
+          "maxLocales",
+          "maxDailyRecrawls",
+          "maxDailyPageRecrawls",
+          "maxGlossarySources",
+          "featurePreview"
+        ],
+        "type": "object"
+      },
+      "ResumeTranslationRunResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "enqueued": {
+            "type": "number"
+          },
+          "enqueuedRender": {
+            "type": "number"
+          },
+          "enqueuedTranslate": {
+            "type": "number"
+          },
+          "run": {
+            "$ref": "#/components/schemas/TranslationRun"
+          }
+        },
+        "required": [
+          "run",
+          "enqueued",
+          "enqueuedTranslate",
+          "enqueuedRender"
+        ],
+        "type": "object"
+      },
+      "RouteConfig": {
+        "additionalProperties": false,
+        "properties": {
+          "clientRuntimeEnabled": {
+            "description": "Default: true",
+            "type": "boolean"
+          },
+          "crawlCaptureMode": {
+            "$ref": "#/components/schemas/CrawlCaptureMode",
+            "description": "Default: template_plus_hydrated"
+          },
+          "locales": {
+            "items": {
+              "$ref": "#/components/schemas/RouteLocale"
+            },
+            "type": "array"
+          },
+          "pattern": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sourceLang": {
+            "type": "string"
+          },
+          "sourceOrigin": {
+            "type": "string"
+          },
+          "spaRefresh": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpaRefreshSettings"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "translatableAttributes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "sourceLang",
+          "sourceOrigin",
+          "locales"
+        ],
+        "type": "object"
+      },
+      "RouteLocale": {
+        "additionalProperties": false,
+        "properties": {
+          "lang": {
+            "type": "string"
+          },
+          "origin": {
+            "type": "string"
+          },
+          "routePrefix": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "lang",
+          "origin"
+        ],
+        "type": "object"
+      },
+      "ServingMode": {
+        "enum": [
+          "strict",
+          "tolerant"
+        ],
+        "type": "string"
+      },
+      "SetLocaleServingRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enabled"
+        ],
+        "type": "object"
+      },
+      "SetLocaleServingResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "activeDeploymentId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "serveEnabled": {
+            "type": "boolean"
+          },
+          "servingStatus": {
+            "$ref": "#/components/schemas/DeploymentServingStatus"
+          },
+          "targetLang": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "targetLang",
+          "serveEnabled",
+          "servingStatus"
+        ],
+        "type": "object"
+      },
+      "SetSlugRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "lang": {
+            "type": "string"
+          },
+          "pageId": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pageId",
+          "lang",
+          "path"
+        ],
+        "type": "object"
+      },
+      "SetSlugResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "crawlStatus": {
+            "$ref": "#/components/schemas/CrawlStatus"
+          },
+          "lang": {
+            "type": "string"
+          },
+          "pageId": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pageId",
+          "lang",
+          "path",
+          "crawlStatus"
+        ],
+        "type": "object"
+      },
+      "SetTranslationSummaryPreferenceRequest": {
+        "additionalProperties": false,
+        "example": {
+          "frequency": "daily"
+        },
+        "examples": [
+          {
+            "frequency": "daily"
+          }
+        ],
+        "properties": {
+          "frequency": {
+            "$ref": "#/components/schemas/TranslationSummaryFrequency"
+          }
+        },
+        "required": [
+          "frequency"
+        ],
+        "type": "object"
+      },
+      "SetTranslationSummaryPreferenceResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "preference": {
+            "$ref": "#/components/schemas/TranslationSummaryPreference"
+          }
+        },
+        "required": [
+          "preference"
+        ],
+        "type": "object"
+      },
+      "Site": {
+        "additionalProperties": false,
+        "properties": {
+          "accountId": {
+            "type": "string"
+          },
+          "domains": {
+            "items": {
+              "$ref": "#/components/schemas/SiteDomain"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "latestCrawlRun": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CrawlRunSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "locales": {
+            "items": {
+              "$ref": "#/components/schemas/SiteLocale"
+            },
+            "type": "array"
+          },
+          "maxLocales": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "routeConfig": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RouteConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "servingMode": {
+            "$ref": "#/components/schemas/ServingMode"
+          },
+          "siteProfile": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "active",
+              "inactive"
+            ],
+            "type": "string"
+          },
+          "webhookSecret": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "webhookUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "accountId",
+          "sourceUrl",
+          "status",
+          "servingMode",
+          "maxLocales",
+          "locales",
+          "domains"
+        ],
+        "type": "object"
+      },
+      "SiteDomain": {
+        "additionalProperties": false,
+        "properties": {
+          "cloudflare": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CloudflareHostnameState"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "dnsInstructions": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DnsInstructions"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "domain": {
+            "type": "string"
+          },
+          "lastCheckedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "enum": [
+              "pending",
+              "verified",
+              "failed"
+            ],
+            "type": "string"
+          },
+          "verificationToken": {
+            "type": "string"
+          },
+          "verifiedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "domain",
+          "status",
+          "verificationToken"
+        ],
+        "type": "object"
+      },
+      "SiteLocale": {
+        "additionalProperties": false,
+        "properties": {
+          "alias": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "serveEnabled": {
+            "type": "boolean"
+          },
+          "sourceLang": {
+            "type": "string"
+          },
+          "targetLang": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sourceLang",
+          "targetLang",
+          "serveEnabled"
+        ],
+        "type": "object"
+      },
+      "SitePageSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "lastCrawledAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lastSeenAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lastSnapshotAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lastVersionAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "nextCrawlAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sourcePath": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "sourcePath"
+        ],
+        "type": "object"
+      },
+      "SiteWithCrawlStatus": {
+        "additionalProperties": false,
+        "properties": {
+          "accountId": {
+            "type": "string"
+          },
+          "crawlStatus": {
+            "$ref": "#/components/schemas/CrawlStatus"
+          },
+          "domains": {
+            "items": {
+              "$ref": "#/components/schemas/SiteDomain"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "latestCrawlRun": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CrawlRunSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "locales": {
+            "items": {
+              "$ref": "#/components/schemas/SiteLocale"
+            },
+            "type": "array"
+          },
+          "maxLocales": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "routeConfig": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RouteConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "servingMode": {
+            "$ref": "#/components/schemas/ServingMode"
+          },
+          "siteProfile": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "active",
+              "inactive"
+            ],
+            "type": "string"
+          },
+          "webhookSecret": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "webhookUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "accountId",
+          "crawlStatus",
+          "domains",
+          "id",
+          "locales",
+          "maxLocales",
+          "servingMode",
+          "sourceUrl",
+          "status"
+        ],
+        "type": "object"
+      },
+      "SpaRefreshFallback": {
+        "enum": [
+          "globalOnly",
+          "baseline"
+        ],
+        "type": "string"
+      },
+      "SpaRefreshSettings": {
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "enableSectionScope": {
+            "type": "boolean"
+          },
+          "errorFallback": {
+            "$ref": "#/components/schemas/SpaRefreshFallback"
+          },
+          "missingFallback": {
+            "$ref": "#/components/schemas/SpaRefreshFallback"
+          }
+        },
+        "required": [
+          "enabled"
+        ],
+        "type": "object"
+      },
+      "SupportedLanguage": {
+        "additionalProperties": false,
+        "properties": {
+          "direction": {
+            "enum": [
+              "ltr",
+              "rtl"
+            ],
+            "type": "string"
+          },
+          "englishName": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag",
+          "englishName",
+          "direction"
+        ],
+        "type": "object"
+      },
+      "TranslateSiteRequest": {
+        "additionalProperties": false,
+        "example": {
+          "intent": "translate_and_serve",
+          "targetLang": "fr"
+        },
+        "examples": [
+          {
+            "intent": "translate_and_serve",
+            "targetLang": "fr"
+          }
+        ],
+        "properties": {
+          "intent": {
+            "const": "translate_and_serve",
+            "type": "string"
+          },
+          "targetLang": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "targetLang"
+        ],
+        "type": "object"
+      },
+      "TranslateSiteResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "crawlEnqueued": {
+            "type": "boolean"
+          },
+          "enqueued": {
+            "type": "number"
+          },
+          "missingSnapshots": {
+            "type": "number"
+          },
+          "run": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TranslationRun"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "run",
+          "enqueued"
+        ],
+        "type": "object"
+      },
+      "TranslationRun": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "finishedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "pagesCompleted": {
+            "type": "number"
+          },
+          "pagesFailed": {
+            "type": "number"
+          },
+          "pagesTotal": {
+            "type": "number"
+          },
+          "siteId": {
+            "type": "string"
+          },
+          "startedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/TranslationRunStatus"
+          },
+          "targetLang": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "siteId",
+          "targetLang",
+          "status",
+          "pagesTotal",
+          "pagesCompleted",
+          "pagesFailed"
+        ],
+        "type": "object"
+      },
+      "TranslationRunResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "run": {
+            "$ref": "#/components/schemas/TranslationRun"
+          }
+        },
+        "required": [
+          "run"
+        ],
+        "type": "object"
+      },
+      "TranslationRunStatus": {
+        "enum": [
+          "queued",
+          "in_progress",
+          "completed",
+          "failed",
+          "cancelled"
+        ],
+        "type": "string"
+      },
+      "TranslationSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastDeploymentAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pagesTranslated": {
+            "type": "number"
+          },
+          "pagesUpdated": {
+            "type": "number"
+          },
+          "period": {
+            "enum": [
+              "daily",
+              "weekly"
+            ],
+            "type": "string"
+          },
+          "rangeEnd": {
+            "type": "string"
+          },
+          "rangeStart": {
+            "type": "string"
+          },
+          "siteId": {
+            "type": "string"
+          },
+          "targetLang": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "siteId",
+          "targetLang",
+          "period",
+          "rangeStart",
+          "rangeEnd",
+          "pagesTranslated",
+          "pagesUpdated"
+        ],
+        "type": "object"
+      },
+      "TranslationSummaryFrequency": {
+        "enum": [
+          "daily",
+          "weekly",
+          "off"
+        ],
+        "type": "string"
+      },
+      "TranslationSummaryPreference": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "frequency": {
+            "$ref": "#/components/schemas/TranslationSummaryFrequency"
+          },
+          "siteId": {
+            "type": "string"
+          },
+          "targetLang": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "siteId",
+          "targetLang",
+          "frequency"
+        ],
+        "type": "object"
+      },
+      "UpdateSiteRequest": {
+        "additionalProperties": false,
+        "example": {
+          "servingMode": "tolerant",
+          "targetLangs": [
+            "fr",
+            "de",
+            "it"
+          ]
+        },
+        "examples": [
+          {
+            "servingMode": "tolerant",
+            "targetLangs": [
+              "fr",
+              "de",
+              "it"
+            ]
+          }
+        ],
+        "properties": {
+          "clientRuntimeEnabled": {
+            "type": "boolean"
+          },
+          "crawlCaptureMode": {
+            "$ref": "#/components/schemas/CrawlCaptureMode"
+          },
+          "localeAliases": {
+            "additionalProperties": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": "object"
+          },
+          "maxLocales": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "servingMode": {
+            "$ref": "#/components/schemas/ServingMode"
+          },
+          "siteProfile": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "spaRefresh": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpaRefreshSettings"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "enum": [
+              "active",
+              "inactive"
+            ],
+            "type": "string"
+          },
+          "subdomainPattern": {
+            "type": "string"
+          },
+          "targetLangs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "translatableAttributes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "webhookSecret": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "webhookUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "UpsertGlossaryRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/GlossaryEntry"
+            },
+            "type": "array"
+          },
+          "retranslate": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "entries"
+        ],
+        "type": "object"
+      },
+      "VerifyDomainRequest": {
+        "additionalProperties": false,
+        "example": {
+          "token": "verification-token-from-create-site"
+        },
+        "examples": [
+          {
+            "token": "verification-token-from-create-site"
+          }
+        ],
+        "properties": {
+          "env": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "VerifyDomainResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "domain": {
+            "$ref": "#/components/schemas/SiteDomain"
+          }
+        },
+        "required": [
+          "domain"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "scheme": "bearer",
+        "type": "http"
+      },
+      "previewStatusToken": {
+        "in": "header",
+        "name": "x-preview-status-token",
+        "type": "apiKey"
+      },
+      "previewToken": {
+        "in": "header",
+        "name": "x-preview-token",
+        "type": "apiKey"
+      }
+    }
+  },
+  "info": {
+    "description": "API surface exposed by the webhooks-worker. Base path is /api; all endpoints require Authorization: Bearer <JWT> signed with WEBHOOK_SECRET unless noted.",
+    "title": "WebLingo Webhooks API",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/accounts/claim": {
+      "post": {
+        "operationId": "accounts.claim",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "accountId": "string",
+                  "planStatus": "active",
+                  "planType": "free",
+                  "status": "created"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AccountClaimResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create/link an account for the authenticated Supabase user",
+        "tags": [
+          "Accounts"
+        ]
+      }
+    },
+    "/accounts/me": {
+      "get": {
+        "operationId": "accounts.me",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "accountId": "string",
+                  "dailyCrawlUsage": {
+                    "date": "string",
+                    "pageCrawls": 1,
+                    "siteCrawls": 1
+                  },
+                  "featureFlags": {
+                    "agencyActionsEnabled": true,
+                    "clientRuntimeToggleEnabled": true,
+                    "crawlCaptureModeEnabled": true,
+                    "crawlTriggerEnabled": true,
+                    "demoMode": true,
+                    "domainVerifyEnabled": true,
+                    "editEnabled": true,
+                    "featurePreview": [
+                      "string"
+                    ],
+                    "glossaryEnabled": true,
+                    "internalOpsEnabled": true,
+                    "localeUpdateEnabled": true,
+                    "maxDailyPageRecrawls": 1,
+                    "maxDailyRecrawls": 1,
+                    "maxGlossarySources": 1,
+                    "maxLocales": 1,
+                    "maxSites": 1,
+                    "overridesEnabled": true,
+                    "pipelineAllowed": true,
+                    "publishEnabled": true,
+                    "renderEnabled": true,
+                    "serveAllowed": true,
+                    "siteCreateEnabled": true,
+                    "slugEditEnabled": true,
+                    "tmWriteEnabled": true,
+                    "translatableAttributesEnabled": true
+                  },
+                  "planStatus": "active",
+                  "planType": "free",
+                  "quotas": {
+                    "maxSites": 1,
+                    "proQuota": 1,
+                    "starterQuota": 1
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AccountMeResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get current account entitlements and quotas",
+        "tags": [
+          "Accounts"
+        ]
+      }
+    },
+    "/agency/customers": {
+      "get": {
+        "operationId": "agency.customers.list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "customers": [
+                    {
+                      "activeSiteCount": 1,
+                      "agencyAccountId": "string",
+                      "customerAccountId": "string",
+                      "customerPlan": "starter",
+                      "planStatus": "active",
+                      "status": "active"
+                    }
+                  ],
+                  "summary": {
+                    "maxSites": 1,
+                    "totalActiveSites": 1
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListAgencyCustomersResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List agency-managed customer accounts",
+        "tags": [
+          "Agency"
+        ]
+      },
+      "post": {
+        "operationId": "agency.customers.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "customerPlan": "starter",
+                "email": "string"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgencyCustomerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "customer": {
+                    "activeSiteCount": 1,
+                    "agencyAccountId": "string",
+                    "customerAccountId": "string",
+                    "customerPlan": "starter",
+                    "planStatus": "active",
+                    "status": "active"
+                  },
+                  "inviteLink": "string"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CreateAgencyCustomerResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create/invite a managed customer account",
+        "tags": [
+          "Agency"
+        ]
+      }
+    },
+    "/auth/token": {
+      "post": {
+        "description": "Mints a short-lived WebLingo dashboard JWT from a Supabase access token. Agencies can scope the token to a managed customer account.",
+        "operationId": "auth.token.mint",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "subjectAccountId": "00000000-0000-0000-0000-000000000001"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/AuthTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "actorAccountId": "00000000-0000-0000-0000-000000000010",
+                  "entitlements": {
+                    "planStatus": "active",
+                    "planType": "pro"
+                  },
+                  "expiresAt": "2026-02-12T20:00:00.000Z",
+                  "subjectAccountId": "00000000-0000-0000-0000-000000000001",
+                  "token": "<jwt>"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuthTokenResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Exchange Supabase access token for webhooks JWT",
+        "tags": [
+          "Authentication"
+        ]
+      }
+    },
+    "/dashboard/bootstrap": {
+      "post": {
+        "operationId": "dashboard.bootstrap",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "includeAgencyCustomers": true,
+                "subjectAccountId": "string"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/DashboardBootstrapRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "account": {
+                    "accountId": "string",
+                    "dailyCrawlUsage": {
+                      "date": "string",
+                      "pageCrawls": 1,
+                      "siteCrawls": 1
+                    },
+                    "featureFlags": {
+                      "agencyActionsEnabled": true,
+                      "clientRuntimeToggleEnabled": true,
+                      "crawlCaptureModeEnabled": true,
+                      "crawlTriggerEnabled": true,
+                      "demoMode": true,
+                      "domainVerifyEnabled": true,
+                      "editEnabled": true,
+                      "featurePreview": [
+                        "string"
+                      ],
+                      "glossaryEnabled": true,
+                      "internalOpsEnabled": true,
+                      "localeUpdateEnabled": true,
+                      "maxDailyPageRecrawls": 1,
+                      "maxDailyRecrawls": 1,
+                      "maxGlossarySources": 1,
+                      "maxLocales": 1,
+                      "maxSites": 1,
+                      "overridesEnabled": true,
+                      "pipelineAllowed": true,
+                      "publishEnabled": true,
+                      "renderEnabled": true,
+                      "serveAllowed": true,
+                      "siteCreateEnabled": true,
+                      "slugEditEnabled": true,
+                      "tmWriteEnabled": true,
+                      "translatableAttributesEnabled": true
+                    },
+                    "planStatus": "active",
+                    "planType": "free",
+                    "quotas": {
+                      "maxSites": 1,
+                      "proQuota": 1,
+                      "starterQuota": 1
+                    }
+                  },
+                  "actorAccountId": "string",
+                  "agencyCustomers": {
+                    "customers": [
+                      {
+                        "activeSiteCount": 1,
+                        "agencyAccountId": "string",
+                        "customerAccountId": "string",
+                        "customerPlan": "starter",
+                        "status": "active"
+                      }
+                    ],
+                    "summary": {
+                      "maxSites": 1,
+                      "totalActiveSites": 1
+                    }
+                  },
+                  "entitlements": {
+                    "planStatus": "active",
+                    "planType": "free"
+                  },
+                  "expiresAt": "string",
+                  "subjectAccountId": "string",
+                  "token": "string"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardBootstrapResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Bootstrap dashboard auth + account context",
+        "tags": [
+          "Dashboard"
+        ]
+      }
+    },
+    "/digests/subscription": {
+      "put": {
+        "description": "Creates or updates the account-level translation digest destination and frequency.",
+        "operationId": "digests.subscription.upsert",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "email": "alerts@example.com",
+                "frequency": "weekly"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/DigestSubscriptionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "subscription": {
+                    "accountId": "00000000-0000-0000-0000-000000000001",
+                    "email": "alerts@example.com",
+                    "frequency": "weekly",
+                    "id": "be8123c6-acde-46f5-9f15-42667da3f9e0"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/DigestSubscriptionResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Upsert digest subscription",
+        "tags": [
+          "Digests"
+        ]
+      }
+    },
+    "/meta/languages": {
+      "get": {
+        "operationId": "meta.languages.list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "languages": [
+                    {
+                      "direction": "ltr",
+                      "englishName": "string",
+                      "tag": "string"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListSupportedLanguagesResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [],
+        "summary": "List supported languages",
+        "tags": [
+          "Metadata"
+        ]
+      }
+    },
+    "/previews": {
+      "post": {
+        "description": "Creates an ephemeral preview translation request and enqueues preview processing. Supports either public preview token auth or dashboard bearer auth.",
+        "operationId": "previews.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "email": "owner@example.com",
+                "sourceLang": "en",
+                "sourceUrl": "https://example.com",
+                "targetLang": "fr"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/PreviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "expiresAt": "2026-02-12T21:00:00.000Z",
+                  "previewId": "9f27aa40-a2bc-4e8f-8f17-573b66195f1c",
+                  "previewUrl": null,
+                  "status": "queued",
+                  "statusToken": "<status-token>",
+                  "streamUrl": "/api/previews/9f27aa40-a2bc-4e8f-8f17-573b66195f1c/stream"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PreviewStatus"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "previewToken": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create try-now preview",
+        "tags": [
+          "Previews"
+        ]
+      }
+    },
+    "/previews/{previewId}": {
+      "get": {
+        "operationId": "previews.status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "previewId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "previewId": "string",
+                  "status": "pending"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PreviewStatus"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "previewStatusToken": []
+          }
+        ],
+        "summary": "Get preview status",
+        "tags": [
+          "Previews"
+        ]
+      }
+    },
+    "/sites": {
+      "get": {
+        "operationId": "sites.list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "sites": [
+                    {
+                      "accountId": "string",
+                      "domains": [
+                        {
+                          "domain": "string",
+                          "status": "pending",
+                          "verificationToken": "string"
+                        }
+                      ],
+                      "id": "string",
+                      "locales": [
+                        {
+                          "serveEnabled": true,
+                          "sourceLang": "string",
+                          "targetLang": "string"
+                        }
+                      ],
+                      "maxLocales": 1,
+                      "servingMode": "strict",
+                      "sourceUrl": "string",
+                      "status": "active"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListSitesResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List sites",
+        "tags": [
+          "Sites"
+        ]
+      },
+      "post": {
+        "description": "Registers a new source site, locale map, and domain onboarding metadata, then enqueues the first crawl.",
+        "operationId": "sites.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "maxLocales": 5,
+                "servingMode": "strict",
+                "sourceLang": "en",
+                "sourceUrl": "https://www.example.com",
+                "subdomainPattern": "{lang}.example.com",
+                "targetLangs": [
+                  "fr",
+                  "de"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CreateSiteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "accountId": "string",
+                  "crawlStatus": {
+                    "enqueued": true
+                  },
+                  "domains": [
+                    {
+                      "domain": "string",
+                      "status": "pending",
+                      "verificationToken": "string"
+                    }
+                  ],
+                  "id": "string",
+                  "locales": [
+                    {
+                      "serveEnabled": true,
+                      "sourceLang": "string",
+                      "targetLang": "string"
+                    }
+                  ],
+                  "maxLocales": 1,
+                  "servingMode": "strict",
+                  "sourceUrl": "string",
+                  "status": "active"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SiteWithCrawlStatus"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create site",
+        "tags": [
+          "Sites"
+        ]
+      }
+    },
+    "/sites/{siteId}": {
+      "get": {
+        "operationId": "sites.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "accountId": "string",
+                  "domains": [
+                    {
+                      "domain": "string",
+                      "status": "pending",
+                      "verificationToken": "string"
+                    }
+                  ],
+                  "id": "string",
+                  "locales": [
+                    {
+                      "serveEnabled": true,
+                      "sourceLang": "string",
+                      "targetLang": "string"
+                    }
+                  ],
+                  "maxLocales": 1,
+                  "servingMode": "strict",
+                  "sourceUrl": "string",
+                  "status": "active"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Site"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get site",
+        "tags": [
+          "Sites"
+        ]
+      },
+      "patch": {
+        "operationId": "sites.update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "servingMode": "tolerant",
+                "targetLangs": [
+                  "fr",
+                  "de",
+                  "it"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSiteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "accountId": "string",
+                  "domains": [
+                    {
+                      "domain": "string",
+                      "status": "pending",
+                      "verificationToken": "string"
+                    }
+                  ],
+                  "id": "string",
+                  "locales": [
+                    {
+                      "serveEnabled": true,
+                      "sourceLang": "string",
+                      "targetLang": "string"
+                    }
+                  ],
+                  "maxLocales": 1,
+                  "servingMode": "strict",
+                  "sourceUrl": "string",
+                  "status": "active"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Site"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Update site",
+        "tags": [
+          "Sites"
+        ]
+      }
+    },
+    "/sites/{siteId}/crawl": {
+      "post": {
+        "operationId": "sites.crawl.trigger",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "force": true
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CrawlTriggerRequest"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "enqueued": true
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CrawlStatus"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Trigger crawl",
+        "tags": [
+          "Sites",
+          "Crawl"
+        ]
+      }
+    },
+    "/sites/{siteId}/crawl-translate": {
+      "post": {
+        "operationId": "sites.crawl_translate.trigger",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "targetLangs": [
+                  "string"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CrawlTranslateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "crawlId": "string",
+                  "enqueuedCount": 1,
+                  "force": true,
+                  "selectedCount": 1,
+                  "targetLangs": [
+                    "string"
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CrawlTranslateResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Trigger crawl+translate for selected pages",
+        "tags": [
+          "Sites",
+          "Crawl"
+        ]
+      }
+    },
+    "/sites/{siteId}/deployments": {
+      "get": {
+        "operationId": "sites.deployments.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "deployments": [
+                    {
+                      "serveEnabled": true,
+                      "servingStatus": "inactive",
+                      "status": "string",
+                      "targetLang": "string"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListDeploymentsResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List deployments per locale",
+        "tags": [
+          "Sites",
+          "Deployments"
+        ]
+      }
+    },
+    "/sites/{siteId}/dlq": {
+      "get": {
+        "operationId": "sites.dlq.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "complete": true,
+                  "messages": [
+                    {
+                      "attempts": 1,
+                      "error": "string",
+                      "key": "string",
+                      "timestamp": "string",
+                      "worker": "string"
+                    }
+                  ],
+                  "siteId": "string",
+                  "summary": {
+                    "errors": {},
+                    "perWorker": {},
+                    "total": 1
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/DlqListResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List DLQ messages for a site",
+        "tags": [
+          "Sites",
+          "DLQ"
+        ]
+      }
+    },
+    "/sites/{siteId}/dlq/replay": {
+      "post": {
+        "operationId": "sites.dlq.replay",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "keys": [
+                  "string"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/DlqReplayRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "attempted": 1,
+                  "deleted": 1,
+                  "deleteOnSuccess": true,
+                  "dryRun": true,
+                  "failures": [
+                    {
+                      "error": "string",
+                      "key": "string"
+                    }
+                  ],
+                  "sent": 1,
+                  "siteId": "string"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/DlqReplayResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Replay DLQ messages for a site",
+        "tags": [
+          "Sites",
+          "DLQ"
+        ]
+      }
+    },
+    "/sites/{siteId}/domains/{domain}/provision": {
+      "post": {
+        "operationId": "sites.domains.provision",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "domain",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "domain": {
+                    "domain": "string",
+                    "status": "pending",
+                    "verificationToken": "string"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProvisionDomainResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Provision domain via Cloudflare for SaaS (CNAME + Custom Hostname)",
+        "tags": [
+          "Sites",
+          "Domains"
+        ]
+      }
+    },
+    "/sites/{siteId}/domains/{domain}/refresh": {
+      "post": {
+        "operationId": "sites.domains.refresh",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "domain",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "domain": {
+                    "domain": "string",
+                    "status": "pending",
+                    "verificationToken": "string"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/RefreshDomainResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Refresh Cloudflare validation and resync domain status",
+        "tags": [
+          "Sites",
+          "Domains"
+        ]
+      }
+    },
+    "/sites/{siteId}/domains/{domain}/verify": {
+      "post": {
+        "operationId": "sites.domains.verify",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "domain",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "token": "verification-token-from-create-site"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/VerifyDomainRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "domain": {
+                    "domain": "string",
+                    "status": "pending",
+                    "verificationToken": "string"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyDomainResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Verify domain via TXT or test token",
+        "tags": [
+          "Sites",
+          "Domains"
+        ]
+      }
+    },
+    "/sites/{siteId}/glossary": {
+      "get": {
+        "operationId": "sites.glossary.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "entries": [
+                    {
+                      "source": "string",
+                      "target": "string"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/GlossaryResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get glossary entries",
+        "tags": [
+          "Sites",
+          "Glossary"
+        ]
+      },
+      "put": {
+        "operationId": "sites.glossary.put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "entries": [
+                  {
+                    "source": "string",
+                    "target": "string"
+                  }
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/UpsertGlossaryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "entries": [
+                    {
+                      "source": "string",
+                      "target": "string"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/GlossaryResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Upsert glossary entries",
+        "tags": [
+          "Sites",
+          "Glossary"
+        ]
+      }
+    },
+    "/sites/{siteId}/locales/{targetLang}/serve": {
+      "post": {
+        "operationId": "sites.locales.serve",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "targetLang",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "enabled": true
+              },
+              "schema": {
+                "$ref": "#/components/schemas/SetLocaleServingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "serveEnabled": true,
+                  "servingStatus": "inactive",
+                  "targetLang": "string"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SetLocaleServingResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Enable or disable serving for a locale",
+        "tags": [
+          "Sites",
+          "Locales"
+        ]
+      }
+    },
+    "/sites/{siteId}/locales/{targetLang}/translation-summary": {
+      "put": {
+        "operationId": "sites.locales.translationSummary.put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "targetLang",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "frequency": "daily"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/SetTranslationSummaryPreferenceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "preference": {
+                    "frequency": "daily",
+                    "siteId": "string",
+                    "targetLang": "string"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SetTranslationSummaryPreferenceResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Configure translation summary notification frequency for a locale",
+        "tags": [
+          "Sites",
+          "Locales"
+        ]
+      }
+    },
+    "/sites/{siteId}/overrides": {
+      "post": {
+        "operationId": "sites.overrides.create",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "segmentId": "string",
+                "targetLang": "string",
+                "text": "string"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CreateOverrideRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "contextHashScope": "string",
+                  "segmentId": "string",
+                  "targetLang": "string"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CreateOverrideResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create segment override",
+        "tags": [
+          "Sites"
+        ]
+      }
+    },
+    "/sites/{siteId}/pages": {
+      "get": {
+        "operationId": "sites.pages.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "pages": [
+                    {
+                      "id": "string",
+                      "sourcePath": "string"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListSitePagesResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List discovered pages",
+        "tags": [
+          "Sites",
+          "Pages"
+        ]
+      }
+    },
+    "/sites/{siteId}/pages/{pageId}/crawl": {
+      "post": {
+        "operationId": "sites.pages.crawl",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pageId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "enqueued": true
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CrawlStatus"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Trigger extract for a single page",
+        "tags": [
+          "Sites",
+          "Pages"
+        ]
+      }
+    },
+    "/sites/{siteId}/pipeline/status/{pageVersionId}": {
+      "get": {
+        "operationId": "sites.pipeline.status.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pageVersionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "pageVersionId": "string",
+                  "siteId": "string",
+                  "statuses": [
+                    {
+                      "stage": "crawl",
+                      "status": "pending",
+                      "targetLang": "string",
+                      "timestamp": 1
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/PipelineStatusResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get pipeline status for a page version",
+        "tags": [
+          "Sites",
+          "Pipeline"
+        ]
+      }
+    },
+    "/sites/{siteId}/slugs": {
+      "post": {
+        "operationId": "sites.slugs.set",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "lang": "string",
+                "pageId": "string",
+                "path": "string"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/SetSlugRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "crawlStatus": {
+                    "enqueued": true
+                  },
+                  "lang": "string",
+                  "pageId": "string",
+                  "path": "string"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SetSlugResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Set translated slug path",
+        "tags": [
+          "Sites",
+          "Slugs"
+        ]
+      }
+    },
+    "/sites/{siteId}/translate": {
+      "post": {
+        "description": "Starts a translation run using existing page snapshots without launching a new crawl.",
+        "operationId": "sites.translate",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "intent": "translate_and_serve",
+                "targetLang": "fr"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/TranslateSiteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "enqueued": 1,
+                  "run": {
+                    "id": "string",
+                    "pagesCompleted": 1,
+                    "pagesFailed": 1,
+                    "pagesTotal": 1,
+                    "siteId": "string",
+                    "status": "queued",
+                    "targetLang": "string"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TranslateSiteResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Translate a site without recrawling",
+        "tags": [
+          "Sites",
+          "Translation Runs"
+        ]
+      }
+    },
+    "/sites/{siteId}/translation-runs/{runId}": {
+      "get": {
+        "operationId": "sites.translationRuns.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "runId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "run": {
+                    "id": "string",
+                    "pagesCompleted": 1,
+                    "pagesFailed": 1,
+                    "pagesTotal": 1,
+                    "siteId": "string",
+                    "status": "queued",
+                    "targetLang": "string"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TranslationRunResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get translation run status",
+        "tags": [
+          "Sites",
+          "Translation Runs"
+        ]
+      }
+    },
+    "/sites/{siteId}/translation-runs/{runId}/cancel": {
+      "post": {
+        "operationId": "sites.translationRuns.cancel",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "runId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "run": {
+                    "id": "string",
+                    "pagesCompleted": 1,
+                    "pagesFailed": 1,
+                    "pagesTotal": 1,
+                    "siteId": "string",
+                    "status": "queued",
+                    "targetLang": "string"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CancelTranslationRunResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Cancel a translation run",
+        "tags": [
+          "Sites",
+          "Translation Runs"
+        ]
+      }
+    },
+    "/sites/{siteId}/translation-runs/{runId}/resume": {
+      "post": {
+        "operationId": "sites.translationRuns.resume",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "runId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "enqueued": 1,
+                  "enqueuedRender": 1,
+                  "enqueuedTranslate": 1,
+                  "run": {
+                    "id": "string",
+                    "pagesCompleted": 1,
+                    "pagesFailed": 1,
+                    "pagesTotal": 1,
+                    "siteId": "string",
+                    "status": "queued",
+                    "targetLang": "string"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ResumeTranslationRunResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Resume a translation run",
+        "tags": [
+          "Sites",
+          "Translation Runs"
+        ]
+      }
+    },
+    "/sites/{siteId}/translation-summaries": {
+      "get": {
+        "operationId": "sites.translationSummaries.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "summaries": [
+                    {
+                      "id": "string",
+                      "pagesTranslated": 1,
+                      "pagesUpdated": 1,
+                      "period": "daily",
+                      "rangeEnd": "string",
+                      "rangeStart": "string",
+                      "siteId": "string",
+                      "targetLang": "string"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListTranslationSummariesResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List translation summary rollups for dashboard charts",
+        "tags": [
+          "Sites",
+          "Translation Summaries"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "servers": [
+    {
+      "description": "Local dev (wrangler dev:webhooks)",
+      "url": "http://127.0.0.1:8788/api"
+    },
+    {
+      "description": "Production/stage",
+      "url": "https://webhooks.example.com/api"
+    }
+  ]
+}

--- a/content/docs/_generated/backend-playbooks.snapshot.md
+++ b/content/docs/_generated/backend-playbooks.snapshot.md
@@ -1,0 +1,126 @@
+# API Playbooks
+
+Human workflow playbooks built on top of generated operation contracts. Payload schemas/examples live in `API_REFERENCE.md`.
+
+## Conventions
+
+- Base path: `/api`
+- Use dashboard JWTs in `Authorization: Bearer <token>` unless noted.
+- Refer to operations by OpenAPI `operationId`.
+
+## Playbook: Account & Language Setup
+
+1. Ensure account exists for current authenticated user:
+   - `operationId`: `accounts.claim`
+2. Fetch account context, entitlements, and quotas:
+   - `operationId`: `accounts.me`
+3. Load supported locale options for onboarding forms:
+   - `operationId`: `meta.languages.list`
+
+## Playbook: Site Portfolio Management
+
+1. List agency customer accounts (agency plans):
+   - `operationId`: `agency.customers.list`
+2. Create/invite agency customer account (agency plans):
+   - `operationId`: `agency.customers.create`
+3. List portfolio sites:
+   - `operationId`: `sites.list`
+4. Update site configuration:
+   - `operationId`: `sites.update`
+5. List discovered pages for a site:
+   - `operationId`: `sites.pages.list`
+
+## Playbook: Serving Access and Previews
+
+1. Ensure locale serving is enabled:
+   - `operationId`: `sites.locales.serve`
+2. Serve localized pages from deployment routes:
+   - `GET /{path}`
+3. Serve preview artifacts:
+   - `GET /_preview/{previewId}`
+
+## Playbook 1: Dashboard Bootstrap and Site Setup
+
+1. Mint dashboard token for API calls:
+   - `operationId`: `auth.token.mint`
+2. Optional bootstrap for actor/subject account context:
+   - `operationId`: `dashboard.bootstrap`
+3. Create site and locale/domain onboarding records:
+   - `operationId`: `sites.create`
+4. Inspect site and deployments:
+   - `operationId`: `sites.get`
+   - `operationId`: `sites.deployments.list`
+
+## Playbook 2: Domain Verification and Serving Activation
+
+Cloudflare for SaaS flow:
+
+1. Create site (if not already done):
+   - `operationId`: `sites.create`
+2. Provision custom hostname after customer CNAME is live:
+   - `operationId`: `sites.domains.provision`
+3. Refresh validation status if certificate/hostname lags:
+   - `operationId`: `sites.domains.refresh`
+4. Enable locale serving:
+   - `operationId`: `sites.locales.serve`
+
+Local/dev TXT verification flow:
+
+1. Verify domain token (`_weblingo.<domain>` TXT or test token):
+   - `operationId`: `sites.domains.verify`
+2. Enable locale serving:
+   - `operationId`: `sites.locales.serve`
+
+## Playbook 3: Crawl and Translate Lifecycle
+
+1. Trigger crawl run:
+   - `operationId`: `sites.crawl.trigger`
+2. Optional page-only crawl:
+   - `operationId`: `sites.pages.crawl`
+3. Optional crawl+translate for targeted pages:
+   - `operationId`: `sites.crawl_translate.trigger`
+4. Translate without recrawl (translation run):
+   - `operationId`: `sites.translate`
+5. Observe run status:
+   - `operationId`: `sites.translationRuns.get`
+6. Operational controls:
+   - `operationId`: `sites.translationRuns.cancel`
+   - `operationId`: `sites.translationRuns.resume`
+
+## Playbook 4: Translation Quality and Content Controls
+
+1. Read/update glossary terms:
+   - `operationId`: `sites.glossary.get`
+   - `operationId`: `sites.glossary.put`
+2. Apply manual override:
+   - `operationId`: `sites.overrides.create`
+3. Set translated slug path:
+   - `operationId`: `sites.slugs.set`
+4. Toggle locale serve state if needed:
+   - `operationId`: `sites.locales.serve`
+
+## Playbook 5: Previews and Notifications
+
+1. Create try-now preview:
+   - `operationId`: `previews.create`
+2. Poll preview status:
+   - `operationId`: `previews.status`
+3. Configure digest email subscription:
+   - `operationId`: `digests.subscription.upsert`
+4. Configure per-locale translation summary frequency:
+   - `operationId`: `sites.locales.translationSummary.put`
+5. Read translation summary rollups:
+   - `operationId`: `sites.translationSummaries.list`
+
+## Playbook 6: Operations and Incident Response
+
+1. Inspect pipeline status for a page version:
+   - `operationId`: `sites.pipeline.status.get`
+2. Inspect DLQ backlog for a site:
+   - `operationId`: `sites.dlq.list`
+3. Replay DLQ messages after root-cause fix:
+   - `operationId`: `sites.dlq.replay`
+
+## Deprecated Manual Endpoint Doc
+
+`API_ENDPOINTS.md` is retained only as a deprecation pointer. Use generated `API_REFERENCE.md` + this playbook document for all current workflows.

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,0 +1,38 @@
+{
+  "generatedAt": "2026-02-13T09:34:46+09:00",
+  "generatedFiles": {
+    "content/docs/_generated/backend-feature-catalog.snapshot.json": {
+      "bytes": 55170,
+      "sha256": "fe1ca5229e4f1cb213461c1b810ba262d507536851cd3cc2cec81be26dbdb731"
+    },
+    "content/docs/_generated/backend-openapi.snapshot.json": {
+      "bytes": 161055,
+      "sha256": "d05d80e6d524ffcf93c40563bed39c94b33ed9a1e3078a19ae610c9cd9f3ae11"
+    },
+    "content/docs/_generated/backend-playbooks.snapshot.md": {
+      "bytes": 4279,
+      "sha256": "1e8c5700644777899a1927f4897c23bc16214c56af84f0d06ab2c9d88a5ca1dd"
+    }
+  },
+  "requiredEnv": [
+    "WEBLINGO_REPO_PATH"
+  ],
+  "schemaVersion": 1,
+  "sourceFiles": {
+    "docs/reference/API_PLAYBOOKS.md": {
+      "bytes": 4279,
+      "sha256": "1e8c5700644777899a1927f4897c23bc16214c56af84f0d06ab2c9d88a5ca1dd"
+    },
+    "docs/reference/feature-catalog.generated.json": {
+      "bytes": 50402,
+      "sha256": "2634e68c75f13f84a21d30dbb256a179b8e7d52ff451a04aee1b0efa7a6c5d62"
+    },
+    "docs/reference/openapi.json": {
+      "bytes": 121197,
+      "sha256": "ab64398dfa8fed9073122761a955c53a2a40ae8142dbc5f0a105bfa0477bb4ea"
+    }
+  },
+  "sourceRepoCommitTimestamp": "2026-02-13T09:34:46+09:00",
+  "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
+  "sourceRepoSha": "d18f01878e16f23f796c98612e054cc473353afd"
+}

--- a/content/docs/api-reference.mdx
+++ b/content/docs/api-reference.mdx
@@ -1,62 +1,57 @@
+import { RedocApiReference } from "@/components/docs/redoc-api-reference";
+
 export const metadata = {
   title: "API Reference",
-  description: "Code-synced capabilities, auth requirements, and operation IDs.",
+  description: "OpenAPI-style reference with payload schemas, responses, and playbook context.",
   section: "Developer",
   order: 1,
 };
 
-# API Reference
+Use this page as your implementation reference. It shows user-facing API operations with auth,
+path/query parameters, request fields, and success response schema details sourced from the synced
+backend OpenAPI snapshot.
 
-This page is user-facing and syncs to backend-generated artifacts. Use it for capability discovery,
-then use backend OpenAPI for payload-level contracts.
-
-## Base path + auth model
+## Base URL + auth
 
 - Base path: `/api`
-- Most operations require `Authorization: Bearer <dashboard-token>`.
-- `POST /auth/token` mints dashboard tokens from a Supabase access token.
-- Preview creation can use `x-preview-token`; preview status can use `x-preview-status-token`.
-- Rate limits return `429` with a `Retry-After` header.
+- Default API auth: `Authorization: Bearer <dashboard-jwt>`
+- Preview creation auth: `x-preview-token` or bearer JWT
+- Preview status auth: `x-preview-status-token` or bearer JWT (when enabled)
+- Rate limiting: `429` with `Retry-After`
 
-## Synced source artifacts
+## Serve surfaces (outside `/api`)
 
-- `content/docs/_generated/backend-openapi.snapshot.json`
-- `content/docs/_generated/backend-feature-catalog.snapshot.json`
-- `content/docs/_generated/backend-playbooks.snapshot.md`
-- `content/docs/_generated/backend-sync-manifest.json`
+Serving endpoints are not in the OpenAPI `/api` group, but they are part of the user-facing
+feature set.
 
-## Capability Index (User-Facing)
+- Serving enable/disable operation: `POST /api/sites/{siteId}/locales/{targetLang}/serve`
+  (`sites.locales.serve`)
+- Localized pages: `GET /{path}`
+- Preview pages: `GET /_preview/{previewId}`
+- Surface auth: `None`
 
-### API capabilities (`/api/*`)
+For rollout sequencing, use the backend playbook label `Playbook: Serving Access and Previews`.
 
-| Capability                                      | operationId(s)                                                                                                                                                                              | Auth                                                               | Stability | Playbook                                                                          |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | --------- | --------------------------------------------------------------------------------- |
-| Account and language setup                      | `accounts.claim`, `accounts.me`, `meta.languages.list`                                                                                                                                      | Bearer JWT (none for `meta.languages.list`)                        | GA        | `Playbook: Account & Language Setup`                                              |
-| Dashboard bootstrap and token minting           | `auth.token.mint`, `dashboard.bootstrap`                                                                                                                                                    | Bearer JWT                                                         | GA        | `Playbook 1: Dashboard Bootstrap and Site Setup`                                  |
-| Agency customer portfolio                       | `agency.customers.list`, `agency.customers.create`                                                                                                                                          | Bearer JWT                                                         | GA        | `Playbook: Site Portfolio Management`                                             |
-| Site portfolio management                       | `sites.list`, `sites.get`, `sites.update`, `sites.pages.list`                                                                                                                               | Bearer JWT                                                         | GA        | `Playbook: Site Portfolio Management`                                             |
-| Site creation and deployment listing            | `sites.create`, `sites.deployments.list`                                                                                                                                                    | Bearer JWT                                                         | GA        | `Playbook 1: Dashboard Bootstrap and Site Setup`                                  |
-| Domain verification and provisioning            | `sites.domains.verify`, `sites.domains.provision`, `sites.domains.refresh`                                                                                                                  | Bearer JWT                                                         | GA        | `Playbook 2: Domain Verification and Serving Activation`                          |
-| Locale serving toggle and translation summaries | `sites.locales.serve`, `sites.locales.translationSummary.put`, `sites.translationSummaries.list`                                                                                            | Bearer JWT                                                         | GA/Beta   | `Playbook: Serving Access and Previews`, `Playbook 5: Previews and Notifications` |
-| Crawl and translation lifecycle                 | `sites.crawl.trigger`, `sites.pages.crawl`, `sites.crawl_translate.trigger`, `sites.translate`, `sites.translationRuns.get`, `sites.translationRuns.cancel`, `sites.translationRuns.resume` | Bearer JWT                                                         | GA/Beta   | `Playbook 3: Crawl and Translate Lifecycle`                                       |
-| Translation quality controls                    | `sites.glossary.get`, `sites.glossary.put`, `sites.overrides.create`, `sites.slugs.set`                                                                                                     | Bearer JWT                                                         | GA        | `Playbook 4: Translation Quality and Content Controls`                            |
-| Previews and digest settings                    | `previews.create`, `previews.status`, `digests.subscription.upsert`                                                                                                                         | `x-preview-token` or Bearer JWT; `x-preview-status-token` (status) | Beta      | `Playbook 5: Previews and Notifications`                                          |
+## Workflows
 
-### Serving capabilities (non-`/api` HTTP)
+Use [Workflow Playbooks](../workflows) when you need ordered, task-specific guidance (setup,
+domain verification, crawl/translate, previews). Use this page for schema-level contracts.
 
-| Capability               | Enabling operation / surface paths                                           | Auth | Stability | Playbook                                |
-| ------------------------ | ---------------------------------------------------------------------------- | ---- | --------- | --------------------------------------- |
-| Localized page serving   | `sites.locales.serve`, `GET /{path}` (`/{path}`)                             | None | GA        | `Playbook: Serving Access and Previews` |
-| Preview artifact serving | `sites.locales.serve`, `GET /_preview/{previewId}` (`/_preview/{previewId}`) | None | Beta      | `Playbook: Serving Access and Previews` |
+## OpenAPI Explorer
 
-## Playbooks and schema details
+<RedocApiReference />
 
-- Workflow sequencing lives in `content/docs/_generated/backend-playbooks.snapshot.md`.
-- Operation schemas/examples live in backend generated references:
-- `docs/reference/API_REFERENCE.md`
-- `docs/reference/openapi.json`
+## Error model
 
-Last sync metadata is recorded in `content/docs/_generated/backend-sync-manifest.json`.
+- Standard API errors return:
+  - `{"error":"<message>","details":...}`
+- Common statuses:
+  - `400` invalid request
+  - `401` auth invalid or expired
+  - `403` entitlement or permission issue
+  - `404` resource not found
+  - `429` rate limited
+  - `5xx` upstream or internal failure
 
 ## Related docs
 

--- a/content/docs/api-reference.mdx
+++ b/content/docs/api-reference.mdx
@@ -1,70 +1,62 @@
 export const metadata = {
   title: "API Reference",
-  description: "Endpoints, auth, and core request flows.",
+  description: "Code-synced capabilities, auth requirements, and operation IDs.",
   section: "Developer",
   order: 1,
 };
 
 # API Reference
 
-This page summarizes the WebLingo Webhooks API surface used by the dashboard and integrations.
+This page is user-facing and syncs to backend-generated artifacts. Use it for capability discovery,
+then use backend OpenAPI for payload-level contracts.
 
-## Base URL + auth
+## Base path + auth model
 
 - Base path: `/api`
-- Most endpoints require `Authorization: Bearer <JWT>` signed with `WEBHOOK_SECRET`.
-- Preview creation accepts `x-preview-token` as an alternative to bearer auth.
+- Most operations require `Authorization: Bearer <dashboard-token>`.
+- `POST /auth/token` mints dashboard tokens from a Supabase access token.
+- Preview creation can use `x-preview-token`; preview status can use `x-preview-status-token`.
 - Rate limits return `429` with a `Retry-After` header.
 
-## Authentication
+## Synced source artifacts
 
-- `POST /auth/token` exchanges a Supabase access token for a Webhooks JWT.
-- `GET /accounts/me` returns plan entitlements, feature flags, and quotas.
-- `POST /accounts/claim` creates or links an account for the authenticated user.
+- `content/docs/_generated/backend-openapi.snapshot.json`
+- `content/docs/_generated/backend-feature-catalog.snapshot.json`
+- `content/docs/_generated/backend-playbooks.snapshot.md`
+- `content/docs/_generated/backend-sync-manifest.json`
 
-## Supported languages
+## Capability Index (User-Facing)
 
-- `GET /meta/languages` returns supported language tags and direction (`ltr`/`rtl`).
+### API capabilities (`/api/*`)
 
-## Site lifecycle
+| Capability                                      | operationId(s)                                                                                                                                                                              | Auth                                                               | Stability | Playbook                                                                          |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | --------- | --------------------------------------------------------------------------------- |
+| Account and language setup                      | `accounts.claim`, `accounts.me`, `meta.languages.list`                                                                                                                                      | Bearer JWT (none for `meta.languages.list`)                        | GA        | `Playbook: Account & Language Setup`                                              |
+| Dashboard bootstrap and token minting           | `auth.token.mint`, `dashboard.bootstrap`                                                                                                                                                    | Bearer JWT                                                         | GA        | `Playbook 1: Dashboard Bootstrap and Site Setup`                                  |
+| Agency customer portfolio                       | `agency.customers.list`, `agency.customers.create`                                                                                                                                          | Bearer JWT                                                         | GA        | `Playbook: Site Portfolio Management`                                             |
+| Site portfolio management                       | `sites.list`, `sites.get`, `sites.update`, `sites.pages.list`                                                                                                                               | Bearer JWT                                                         | GA        | `Playbook: Site Portfolio Management`                                             |
+| Site creation and deployment listing            | `sites.create`, `sites.deployments.list`                                                                                                                                                    | Bearer JWT                                                         | GA        | `Playbook 1: Dashboard Bootstrap and Site Setup`                                  |
+| Domain verification and provisioning            | `sites.domains.verify`, `sites.domains.provision`, `sites.domains.refresh`                                                                                                                  | Bearer JWT                                                         | GA        | `Playbook 2: Domain Verification and Serving Activation`                          |
+| Locale serving toggle and translation summaries | `sites.locales.serve`, `sites.locales.translationSummary.put`, `sites.translationSummaries.list`                                                                                            | Bearer JWT                                                         | GA/Beta   | `Playbook: Serving Access and Previews`, `Playbook 5: Previews and Notifications` |
+| Crawl and translation lifecycle                 | `sites.crawl.trigger`, `sites.pages.crawl`, `sites.crawl_translate.trigger`, `sites.translate`, `sites.translationRuns.get`, `sites.translationRuns.cancel`, `sites.translationRuns.resume` | Bearer JWT                                                         | GA/Beta   | `Playbook 3: Crawl and Translate Lifecycle`                                       |
+| Translation quality controls                    | `sites.glossary.get`, `sites.glossary.put`, `sites.overrides.create`, `sites.slugs.set`                                                                                                     | Bearer JWT                                                         | GA        | `Playbook 4: Translation Quality and Content Controls`                            |
+| Previews and digest settings                    | `previews.create`, `previews.status`, `digests.subscription.upsert`                                                                                                                         | `x-preview-token` or Bearer JWT; `x-preview-status-token` (status) | Beta      | `Playbook 5: Previews and Notifications`                                          |
 
-- `POST /sites` creates a site (source URL, source language, target languages, subdomain pattern).
-- `GET /sites` lists sites; `GET /sites/{siteId}` fetches a single site.
-- `PATCH /sites/{siteId}` updates configuration (targets, status, profiles, serving settings).
-- `POST /sites/{siteId}/crawl` triggers a crawl (optional `force`).
-- `POST /sites/{siteId}/translate` translates existing snapshots without recrawling.
-- `GET /sites/{siteId}/translation-runs/{runId}` checks run status.
-- `POST /sites/{siteId}/translation-runs/{runId}/cancel` or `/resume` controls in-flight runs.
-- `GET /sites/{siteId}/pipeline/status/{pageVersionId}` inspects a single page version.
+### Serving capabilities (non-`/api` HTTP)
 
-## Domains + serving
+| Capability               | Enabling operation / surface paths                                           | Auth | Stability | Playbook                                |
+| ------------------------ | ---------------------------------------------------------------------------- | ---- | --------- | --------------------------------------- |
+| Localized page serving   | `sites.locales.serve`, `GET /{path}` (`/{path}`)                             | None | GA        | `Playbook: Serving Access and Previews` |
+| Preview artifact serving | `sites.locales.serve`, `GET /_preview/{previewId}` (`/_preview/{previewId}`) | None | Beta      | `Playbook: Serving Access and Previews` |
 
-- `POST /sites/{siteId}/domains/{domain}/verify` validates ownership (TXT or test token).
-- `POST /sites/{siteId}/domains/{domain}/provision` provisions Cloudflare for SaaS.
-- `POST /sites/{siteId}/domains/{domain}/refresh` rechecks Cloudflare validation.
-- `POST /sites/{siteId}/locales/{targetLang}/serve` toggles serving per locale.
+## Playbooks and schema details
 
-## Translation controls
+- Workflow sequencing lives in `content/docs/_generated/backend-playbooks.snapshot.md`.
+- Operation schemas/examples live in backend generated references:
+- `docs/reference/API_REFERENCE.md`
+- `docs/reference/openapi.json`
 
-- `GET /sites/{siteId}/glossary` and `PUT /sites/{siteId}/glossary` manage glossary entries.
-- `POST /sites/{siteId}/overrides` creates per-segment overrides.
-- `POST /sites/{siteId}/slugs` updates translated slugs and can trigger a crawl.
-
-## Observability + recovery
-
-- `GET /sites/{siteId}/pages` lists discovered pages.
-- `GET /sites/{siteId}/deployments` lists deployments per locale.
-- `GET /sites/{siteId}/dlq` lists failed queue messages.
-- `POST /sites/{siteId}/dlq/replay` replays DLQ messages.
-
-## Previews
-
-- `POST /previews` creates a Try Now preview.
-- `GET /previews/{previewId}` checks preview status.
-
-For the full schema, use the OpenAPI document generated by the webhooks worker.
-
-Last verified against OpenAPI version `0.1.0` on 2026-01-27.
+Last sync metadata is recorded in `content/docs/_generated/backend-sync-manifest.json`.
 
 ## Related docs
 

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -1,29 +1,44 @@
 export const metadata = {
   title: "Getting Started",
-  description: "Spin up your first localized site in minutes.",
+  description: "Launch your first localized site with a practical step-by-step path.",
   section: "Basics",
   order: 1,
 };
 
-# Getting Started
+Welcome to WebLingo. This guide is for teams shipping their first production locale and wanting a
+reliable rollout path.
 
-Welcome to WebLingo. This short guide walks through the minimal steps to go from a single-language
-site to a live, localized deployment.
+## Before you start
 
-## Quick checklist
+- A source site URL ready to crawl (for example, `https://www.example.com`).
+- One target locale to launch first (for example, `fr`).
+- A subdomain for localized traffic (for example, `fr.example.com`).
+- Dashboard access with API token support.
 
-- Decide the target locales you want to ship first.
-- Add a staging subdomain for the localized content.
-- Run a small crawl to verify segmentation and translations.
-- Publish when the preview looks right.
+## 15-minute launch path
 
-## What you will configure
+1. Create your site configuration:
+   - `POST /api/sites` (`sites.create`)
+2. Verify the customer domain:
+   - `POST /api/sites/{siteId}/domains/{domain}/verify` (`sites.domains.verify`)
+3. (If needed) provision managed hostname:
+   - `POST /api/sites/{siteId}/domains/{domain}/provision` (`sites.domains.provision`)
+4. Trigger the first crawl:
+   - `POST /api/sites/{siteId}/crawl` (`sites.crawl.trigger`)
+5. Trigger translation for one locale:
+   - `POST /api/sites/{siteId}/translate` (`sites.translate`)
+6. Enable serving for the locale:
+   - `POST /api/sites/{siteId}/locales/{targetLang}/serve` (`sites.locales.serve`)
+7. Validate live delivery:
+   - `GET /{path}` (localized serving surface)
 
-1. The primary domain for your source content.
-2. A CNAME target for localized traffic.
-3. A translation run that produces your first deployment.
+## First-launch acceptance checklist
 
-Once those are in place, WebLingo keeps translations fresh and your localized pages in sync.
+- Locale is reachable on your localized domain.
+- Navigation links and translated slugs resolve correctly.
+- Canonical + hreflang tags are present.
+- One full page render is visually validated.
+- A second crawl updates only changed content.
 
 ## Related docs
 

--- a/content/docs/site-setup.mdx
+++ b/content/docs/site-setup.mdx
@@ -1,31 +1,48 @@
 export const metadata = {
   title: "Domain + CNAME Setup",
-  description: "Point traffic to WebLingo and keep your source site intact.",
+  description: "Connect domains safely and enable locale serving.",
   section: "Basics",
   order: 2,
 };
 
-# Domain + CNAME Setup
+WebLingo serves translated pages at the edge while your source site remains unchanged on its
+existing host.
 
-WebLingo serves translated pages from the edge, but your source site stays exactly where it is.
+## Recommended domain model
 
-## Recommended flow
+- Keep source content on the primary domain.
+- Route localized traffic through subdomains (for example, `fr.example.com`).
+- Map each locale to one serving target.
 
-1. Keep your primary domain on the existing host.
-2. Add a subdomain for localized content (for example, `fr.example.com`).
-3. Point the subdomain CNAME to the WebLingo target provided in the dashboard.
+## Setup workflow
 
-## Validation tips
+1. Verify ownership:
+   - `POST /api/sites/{siteId}/domains/{domain}/verify` (`sites.domains.verify`)
+2. Provision managed hostname (Cloudflare for SaaS accounts):
+   - `POST /api/sites/{siteId}/domains/{domain}/provision` (`sites.domains.provision`)
+3. Refresh validation/certificate status if needed:
+   - `POST /api/sites/{siteId}/domains/{domain}/refresh` (`sites.domains.refresh`)
+4. Enable locale serving:
+   - `POST /api/sites/{siteId}/locales/{targetLang}/serve` (`sites.locales.serve`)
 
-- Verify the CNAME before launching production traffic. WebLingo can issue a verification token
-  and DNS instructions for TXT/CNAME checks.
-- Keep an eye on SSL propagation (typically a few minutes).
-- Start with a single locale before expanding to more markets.
+## Validation checklist
 
-## Cloudflare for SaaS (optional)
+- DNS records resolve publicly.
+- Domain status is verified in dashboard/API.
+- TLS certificate status is healthy.
+- Locale serving is enabled and deployment is active.
+- `GET /{path}` returns localized content.
 
-If your account uses Cloudflare for SaaS provisioning, you can request a managed hostname and
-refresh its validation state from the dashboard.
+## Common rollout issues
+
+- Domain stays pending:
+  - re-check TXT/CNAME values and TTL.
+- Certificate status lags:
+  - call refresh endpoint and wait for propagation.
+- Localized route returns source content:
+  - ensure locale serving is enabled and a deployment exists.
+- Localized route returns not found:
+  - confirm the source page was crawled and published.
 
 ## Related docs
 

--- a/content/docs/translation-pipeline.mdx
+++ b/content/docs/translation-pipeline.mdx
@@ -1,38 +1,56 @@
 export const metadata = {
   title: "Translation Pipeline",
-  description: "Understand how crawls become localized deployments.",
+  description: "Understand how crawl, translate, render, and serving fit together.",
   section: "Pipeline",
   order: 1,
 };
 
-# Translation Pipeline
+Every rollout follows the same deterministic flow so you can re-run safely and track status.
 
-Every translation run follows a deterministic flow so you can reproduce results. Depending on the
-request, WebLingo can crawl first or translate existing snapshots without recrawling.
+## Pipeline stages
 
-## 1. Crawl (when needed)
+1. Crawl source content
+   - `POST /api/sites/{siteId}/crawl` (`sites.crawl.trigger`)
+   - Optional selected-pages flow: `POST /api/sites/{siteId}/crawl-translate`
+     (`sites.crawl_translate.trigger`)
+2. Translate snapshots
+   - `POST /api/sites/{siteId}/translate` (`sites.translate`)
+3. Render and publish
+   - Artifacts are rendered and deployed per locale.
+4. Serve from edge
+   - Localized: `GET /{path}`
+   - Previews: `GET /_preview/{previewId}`
 
-We fetch your source HTML, respect `robots.txt`, and capture snapshots for processing.
+## Monitor and control runs
 
-## 2. Segment + translate
+- Check run status:
+  - `GET /api/sites/{siteId}/translation-runs/{runId}` (`sites.translationRuns.get`)
+- Pause or recover a run:
+  - `POST /api/sites/{siteId}/translation-runs/{runId}/cancel`
+    (`sites.translationRuns.cancel`)
+  - `POST /api/sites/{siteId}/translation-runs/{runId}/resume`
+    (`sites.translationRuns.resume`)
+- List pages and deployments:
+  - `GET /api/sites/{siteId}/pages` (`sites.pages.list`)
+  - `GET /api/sites/{siteId}/deployments` (`sites.deployments.list`)
 
-HTML is segmented into stable chunks, then translated with precedence rules for overrides,
-glossaries, and translation memory.
+## Quality controls
 
-## 3. Render + publish
+- Glossary:
+  - `GET /api/sites/{siteId}/glossary` (`sites.glossary.get`)
+  - `PUT /api/sites/{siteId}/glossary` (`sites.glossary.put`)
+- Overrides:
+  - `POST /api/sites/{siteId}/overrides` (`sites.overrides.create`)
+- Slugs:
+  - `POST /api/sites/{siteId}/slugs` (`sites.slugs.set`)
 
-Translated content is applied to the original snapshot and published to the edge with localized
-SEO metadata.
+## Summary digests (optional)
 
-## 3b. Translate without recrawl (optional)
-
-If you already have fresh snapshots, you can trigger translation without a new crawl. This keeps
-the pipeline deterministic while skipping the fetch step.
-
-## 4. Monitor
-
-When your source changes, WebLingo detects diffs and only re-translates what changed. Translation
-runs expose status updates and can be cancelled or resumed when needed.
+- Locale summary frequency:
+  - `PUT /api/sites/{siteId}/locales/{targetLang}/translation-summary`
+    (`sites.locales.translationSummary.put`)
+- Read range summaries:
+  - `GET /api/sites/{siteId}/translation-summaries` (`sites.translationSummaries.list`)
 
 ## Related docs
 

--- a/content/docs/workflow-playbooks.ts
+++ b/content/docs/workflow-playbooks.ts
@@ -1,0 +1,74 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import featureCatalog from "@/content/docs/_generated/backend-feature-catalog.snapshot.json";
+import {
+  getUserFacingApiOperationIds,
+  parsePlaybooksMarkdown,
+  toAnchor,
+  type FeatureCatalog,
+  type ParsedPlaybook,
+} from "@/components/docs/api-reference-data";
+
+const SERVE_SURFACE_PATHS = new Set(["/{path}", "/_preview/{previewId}"]);
+
+export type WorkflowPlaybook = ParsedPlaybook & {
+  slug: string;
+  shortTitle: string;
+};
+
+function readPlaybooksSnapshotOrThrow(): string {
+  const playbooksPath = resolve(
+    process.cwd(),
+    "content/docs/_generated/backend-playbooks.snapshot.md",
+  );
+  if (!existsSync(playbooksPath)) {
+    throw new Error(
+      "[docs] Missing generated playbooks snapshot: content/docs/_generated/backend-playbooks.snapshot.md",
+    );
+  }
+  return readFileSync(playbooksPath, "utf8");
+}
+
+function toShortTitle(title: string): string {
+  const trimmed = title.trim();
+  const withoutPrefix = trimmed.replace(/^Playbook(?:\s+\d+)?\s*:\s*/i, "").trim();
+  return withoutPrefix || trimmed;
+}
+
+function withStableSlugs(playbooks: ParsedPlaybook[]): WorkflowPlaybook[] {
+  const used = new Map<string, number>();
+  return playbooks.map((playbook) => {
+    const shortTitle = toShortTitle(playbook.title);
+    const baseSlug = toAnchor(shortTitle);
+    const previousCount = used.get(baseSlug) ?? 0;
+    const nextCount = previousCount + 1;
+    used.set(baseSlug, nextCount);
+    const slug = nextCount === 1 ? baseSlug : `${baseSlug}-${nextCount}`;
+    return {
+      ...playbook,
+      shortTitle,
+      slug,
+    };
+  });
+}
+
+export function getWorkflowPlaybooks(): WorkflowPlaybook[] {
+  const playbooks = parsePlaybooksMarkdown(readPlaybooksSnapshotOrThrow());
+  const userFacingOperationIds = getUserFacingApiOperationIds(
+    featureCatalog as unknown as FeatureCatalog,
+  );
+
+  const filtered = playbooks.filter((playbook) => {
+    if (playbook.operationIds.some((operationId) => userFacingOperationIds.has(operationId))) {
+      return true;
+    }
+    return playbook.surfacePaths.some((surfacePath) => SERVE_SURFACE_PATHS.has(surfacePath));
+  });
+
+  return withStableSlugs(filtered);
+}
+
+export function getWorkflowPlaybookBySlug(slug: string): WorkflowPlaybook | null {
+  return getWorkflowPlaybooks().find((playbook) => playbook.slug === slug) ?? null;
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,14 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
-  globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts", "types/database.ts"]),
+  globalIgnores([
+    ".next/**",
+    "out/**",
+    "build/**",
+    ".tmp/**",
+    "next-env.d.ts",
+    "types/database.ts",
+  ]),
   {
     files: [
       "app/api/**/*.{ts,tsx,js,jsx}",

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -24,7 +24,12 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       <p className={cn(paragraphBase, "mt-4", className)} {...props} />
     ),
     a: ({ className, href = "", ...props }: ComponentPropsWithoutRef<"a">) => {
-      const isInternal = (href.startsWith("/") && !href.startsWith("//")) || href.startsWith("#");
+      const isInternal =
+        ((href.startsWith("/") && !href.startsWith("//")) ||
+          href.startsWith("./") ||
+          href.startsWith("../") ||
+          href.startsWith("#")) &&
+        !href.startsWith("mailto:");
       const linkClass = cn(
         "font-medium text-primary underline-offset-4 hover:underline",
         className,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,7 @@ import createMDX from "@next/mdx";
 const nextConfig = {
   reactStrictMode: true,
   pageExtensions: ["ts", "tsx", "mdx"],
+  allowedDevOrigins: ["localhost", "127.0.0.1"],
 };
 
 const withMDX = createMDX({

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
     "type": "node scripts/ensure-next-types.cjs && tsc --noEmit",
     "typecheck": "pnpm run type",
     "test": "vitest run",
+    "test:contracts": "vitest run internal/dashboard/webhooks.openapi-contract.test.ts tests/docs/docs-feature-coverage.test.ts",
     "test:e2e": "playwright test",
+    "docs:sync:tsc": "tsc --pretty false --noEmit false --skipLibCheck true --types node --module commonjs --moduleResolution node --target ES2022 --outDir .tmp/docs-sync scripts/docs-sync-shared.ts scripts/docs-sync-weblingo.ts scripts/docs-sync-check.ts",
+    "docs:sync": "pnpm docs:sync:tsc && node .tmp/docs-sync/docs-sync-weblingo.js",
+    "docs:sync:check": "pnpm docs:sync:tsc && node .tmp/docs-sync/docs-sync-check.js",
     "check": "pnpm run lint && pnpm run format && pnpm run type",
     "supabase:types": "supabase gen types typescript --schema public --project-id \"$SUPABASE_PROJECT_ID\" > types/database.ts"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "supabase:types": "supabase gen types typescript --schema public --project-id \"$SUPABASE_PROJECT_ID\" > types/database.ts"
   },
   "dependencies": {
+    "@emotion/is-prop-valid": "^1.4.0",
     "@next/mdx": "16.1.6",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.1.0",
@@ -36,13 +37,17 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "core-js": "3",
     "lucide-react": "^0.562.0",
+    "mobx": "6",
     "next": "16.1.6",
     "posthog-js": "^1.313.0",
     "react": "19.2.4",
-    "react-dom": "19.2.3",
+    "react-dom": "19.2.4",
+    "redoc": "2.5.2",
     "sonner": "^2.0.7",
     "stripe": "^19.2.0",
+    "styled-components": "6",
     "tailwind-merge": "^2.5.4",
     "zod": "^4.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,15 @@ importers:
 
   .:
     dependencies:
+      '@emotion/is-prop-valid':
+        specifier: ^1.4.0
+        version: 1.4.0
       '@next/mdx':
         specifier: 16.1.6
         version: 16.1.6(@mdx-js/loader@3.1.1)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
-        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
@@ -40,13 +43,19 @@ importers:
         version: 2.1.1
       cmdk:
         specifier: ^1.1.1
-        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      core-js:
+        specifier: '3'
+        version: 3.46.0
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.4)
+      mobx:
+        specifier: '6'
+        version: 6.15.0
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       posthog-js:
         specifier: ^1.313.0
         version: 1.313.0
@@ -54,14 +63,20 @@ importers:
         specifier: 19.2.4
         version: 19.2.4
       react-dom:
-        specifier: 19.2.3
-        version: 19.2.3(react@19.2.4)
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+      redoc:
+        specifier: 2.5.2
+        version: 2.5.2(core-js@3.46.0)(mobx@6.15.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       sonner:
         specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       stripe:
         specifier: ^19.2.0
         version: 19.2.0(@types/node@25.2.3)
+      styled-components:
+        specifier: '6'
+        version: 6.3.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.6.0
@@ -77,7 +92,7 @@ importers:
         version: 1.57.0
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/mdx':
         specifier: ^2.0.13
         version: 2.0.13
@@ -110,13 +125,13 @@ importers:
         version: 3.7.4
       tailwindcss:
         specifier: ^3.4.13
-        version: 3.4.18
+        version: 3.4.18(yaml@2.8.2)
       typescript:
         specifier: ^5.6.2
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.2.3)(happy-dom@20.3.0)(jiti@1.21.7)(jsdom@27.4.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(happy-dom@20.3.0)(jiti@1.21.7)(jsdom@27.4.0)(yaml@2.8.2)
 
 packages:
 
@@ -250,6 +265,15 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emotion/is-prop-valid@1.4.0':
+    resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
+
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
+
+  '@emotion/unitless@0.10.0':
+    resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -453,6 +477,9 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@exodus/schemasafe@1.3.0':
+    resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -726,6 +753,10 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -991,6 +1022,16 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@redocly/ajv@8.17.4':
+    resolution: {integrity: sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==}
+
+  '@redocly/config@0.22.2':
+    resolution: {integrity: sha512-roRDai8/zr2S9YfmzUfNhKjOF0NdcOIqF7bhf4MVC5UxpjIysDjyudvlAiVbpPHp3eDRWbdzUgtkK1a7YiDNyQ==}
+
+  '@redocly/openapi-core@1.34.6':
+    resolution: {integrity: sha512-2+O+riuIUgVSuLl3Lyh5AplWZyVMNuG2F98/o6NrutKJfW4/GTZdPpZlIphS0HGgcOHgmWcCSHj+dWFlZaGSHw==}
+    engines: {node: '>=18.17.0', npm: '>=9.5.0'}
+
   '@rollup/rollup-android-arm-eabi@4.55.1':
     resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
     cpu: [arm]
@@ -1228,6 +1269,12 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/stylis@4.2.7':
+    resolution: {integrity: sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1601,6 +1648,9 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -1608,6 +1658,9 @@ packages:
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
+
+  camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
   caniuse-lite@1.0.30001762:
     resolution: {integrity: sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==}
@@ -1642,8 +1695,15 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -1664,6 +1724,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -1688,6 +1751,13 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+
+  css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
@@ -1744,6 +1814,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decko@1.2.0:
+    resolution: {integrity: sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==}
+
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
@@ -1784,6 +1857,9 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dompurify@3.3.1:
+    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1839,6 +1915,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es6-promise@3.3.1:
+    resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -1996,6 +2075,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2019,6 +2101,16 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-xml-parser@4.5.3:
+    resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
+    hasBin: true
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -2058,6 +2150,9 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreach@2.0.6:
+    resolution: {integrity: sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -2092,6 +2187,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -2197,6 +2296,9 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  http2-client@1.3.5:
+    resolution: {integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -2376,6 +2478,10 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  js-levenshtein@1.1.6:
+    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
+    engines: {node: '>=0.10.0'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2400,8 +2506,14 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-pointer@0.6.2:
+    resolution: {integrity: sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2469,6 +2581,9 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -2476,9 +2591,17 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mark.js@8.11.1:
+    resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
+
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
+
+  marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2609,6 +2732,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2619,6 +2746,35 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mobx-react-lite@4.1.1:
+    resolution: {integrity: sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==}
+    peerDependencies:
+      mobx: ^6.9.0
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
+  mobx-react@9.2.0:
+    resolution: {integrity: sha512-dkGWCx+S0/1mfiuFfHRH8D9cplmwhxOV5CkXMp38u6rQGG2Pv3FWYztS0M7ncR6TyPRQKaTG/pnitInoYE9Vrw==}
+    peerDependencies:
+      mobx: ^6.9.0
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
+  mobx@6.15.0:
+    resolution: {integrity: sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2660,12 +2816,44 @@ packages:
       sass:
         optional: true
 
+  node-fetch-h2@2.3.0:
+    resolution: {integrity: sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==}
+    engines: {node: 4.x || >=6.0.0}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-readfiles@0.2.0:
+    resolution: {integrity: sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  oas-kit-common@1.0.8:
+    resolution: {integrity: sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==}
+
+  oas-linter@3.2.2:
+    resolution: {integrity: sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==}
+
+  oas-resolver@2.5.6:
+    resolution: {integrity: sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==}
+    hasBin: true
+
+  oas-schema-walker@1.1.5:
+    resolution: {integrity: sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==}
+
+  oas-validator@5.0.8:
+    resolution: {integrity: sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2706,6 +2894,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  openapi-sampler@1.6.2:
+    resolution: {integrity: sha512-NyKGiFKfSWAZr4srD/5WDhInOWDhfml32h/FKUqLpEwKJt0kG0LGUU0MdyNkKrVGuJnw6DuPWq/sHCwAMpiRxg==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2735,6 +2926,9 @@ packages:
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2752,6 +2946,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  perfect-scrollbar@1.5.6:
+    resolution: {integrity: sha512-rixgxw3SxyJbCaSpo1n35A/fwI1r2rdwMKOTCg/AcG+xOEyZcE8UHVjpZMFCVImzsFoCZeJTT+M/rdEIQYO2nw==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2781,6 +2978,14 @@ packages:
     resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+
+  polished@4.3.1:
+    resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
+    engines: {node: '>=10'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2833,6 +3038,10 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.4.49:
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2856,6 +3065,10 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2873,10 +3086,10 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  react-dom@19.2.3:
-    resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
-      react: ^19.2.3
+      react: ^19.2.4
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -2914,6 +3127,11 @@ packages:
       '@types/react':
         optional: true
 
+  react-tabs@6.1.0:
+    resolution: {integrity: sha512-6QtbTRDKM+jA/MZTTefvigNxo0zz+gnBTVFw2CFVvq+f2BuH0nF0vDLNClL045nuTAdOoK/IL1vTP0ZLX0DAyQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -2939,9 +3157,22 @@ packages:
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
 
+  redoc@2.5.2:
+    resolution: {integrity: sha512-sTJfItvRkcDTojB6wdLN4M+Ua6mlZwElV21Tf8Mn7IbQF/1Os6GvgQpZyLWPGZZHbhy7GC1Or1hTMHfz1vKh5A==}
+    engines: {node: '>=6.9', npm: '>=3.0.0'}
+    peerDependencies:
+      core-js: ^3.1.4
+      mobx: ^6.0.4
+      react: ^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      styled-components: ^4.1.1 || ^5.1.1 || ^6.0.5
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  reftools@1.1.9:
+    resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -2958,6 +3189,10 @@ packages:
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -3031,6 +3266,9 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
+  shallowequal@1.1.0:
+    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
+
   sharp@0.34.4:
     resolution: {integrity: sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -3042,6 +3280,24 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  should-equal@2.0.0:
+    resolution: {integrity: sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==}
+
+  should-format@3.0.3:
+    resolution: {integrity: sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==}
+
+  should-type-adaptors@1.1.0:
+    resolution: {integrity: sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==}
+
+  should-type@1.4.0:
+    resolution: {integrity: sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==}
+
+  should-util@1.0.1:
+    resolution: {integrity: sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==}
+
+  should@13.2.3:
+    resolution: {integrity: sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -3065,6 +3321,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  slugify@1.4.7:
+    resolution: {integrity: sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==}
+    engines: {node: '>=8.0.0'}
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -3091,6 +3351,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stickyfill@1.1.1:
+    resolution: {integrity: sha512-GCp7vHAfpao+Qh/3Flh9DXEJ/qSi0KJwJw6zYlZOtRYXWUIpMM6mC2rIep/dK8RQqwW0KxGJIllmjPIBOGN8AA==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3155,11 +3418,24 @@ packages:
       '@types/node':
         optional: true
 
+  strnum@1.1.2:
+    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  styled-components@6.3.9:
+    resolution: {integrity: sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      react: '>= 16.8.0'
+      react-dom: '>= 16.8.0'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -3174,6 +3450,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  stylis@4.3.6:
+    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
+
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3186,6 +3465,10 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  swagger2openapi@7.0.8:
+    resolution: {integrity: sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==}
+    hasBin: true
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -3234,6 +3517,9 @@ packages:
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -3338,6 +3624,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -3357,6 +3646,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -3448,6 +3742,9 @@ packages:
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -3467,6 +3764,9 @@ packages:
   whatwg-url@15.1.0:
     resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
     engines: {node: '>=20'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3537,8 +3837,32 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml-ast-parser@0.0.43:
+    resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
+
+  yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3736,6 +4060,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emotion/is-prop-valid@1.4.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+
+  '@emotion/memoize@0.9.0': {}
+
+  '@emotion/unitless@0.10.0': {}
+
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
@@ -3863,6 +4195,8 @@ snapshots:
   '@exodus/bytes@1.14.0':
     optional: true
 
+  '@exodus/schemasafe@1.3.0': {}
+
   '@floating-ui/core@1.7.3':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -3872,11 +4206,11 @@ snapshots:
       '@floating-ui/core': 1.7.3
       '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/react-dom@2.1.6(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@floating-ui/react-dom@2.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@floating-ui/dom': 1.7.4
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
 
   '@floating-ui/utils@0.2.10': {}
 
@@ -4102,6 +4436,9 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@opentelemetry/api@1.9.0':
+    optional: true
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4115,11 +4452,11 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -4136,37 +4473,37 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       aria-hidden: 1.2.6
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -4177,13 +4514,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -4195,81 +4532,81 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       aria-hidden: 1.2.6
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/rect': 1.1.1
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -4337,6 +4674,29 @@ snapshots:
       '@types/react': 19.2.14
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@redocly/ajv@8.17.4':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  '@redocly/config@0.22.2': {}
+
+  '@redocly/openapi-core@1.34.6':
+    dependencies:
+      '@redocly/ajv': 8.17.4
+      '@redocly/config': 0.22.2
+      colorette: 1.4.0
+      https-proxy-agent: 7.0.6
+      js-levenshtein: 1.1.6
+      js-yaml: 4.1.1
+      minimatch: 5.1.6
+      pluralize: 8.0.0
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - supports-color
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
     optional: true
@@ -4475,12 +4835,12 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@testing-library/dom': 10.4.1
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -4542,6 +4902,11 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/stylis@4.2.7': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@2.0.11': {}
 
@@ -4720,13 +5085,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.2.3)(jiti@1.21.7)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -4756,8 +5121,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  agent-base@7.1.4:
-    optional: true
+  agent-base@7.1.4: {}
 
   ajv@6.12.6:
     dependencies:
@@ -4942,9 +5306,13 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  call-me-maybe@1.0.2: {}
+
   callsites@3.1.0: {}
 
   camelcase-css@2.0.1: {}
+
+  camelize@1.0.1: {}
 
   caniuse-lite@1.0.30001762: {}
 
@@ -4981,18 +5349,26 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classnames@2.5.1: {}
+
   client-only@0.0.1: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
 
-  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4):
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -5004,6 +5380,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  colorette@1.4.0: {}
 
   comma-separated-tokens@2.0.3: {}
 
@@ -5022,6 +5400,14 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-color-keywords@1.0.0: {}
+
+  css-to-react-native@3.2.0:
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
 
   css-tree@3.1.0:
     dependencies:
@@ -5078,6 +5464,8 @@ snapshots:
   decimal.js@10.6.0:
     optional: true
 
+  decko@1.2.0: {}
+
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
@@ -5116,6 +5504,10 @@ snapshots:
       esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
+
+  dompurify@3.3.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -5236,6 +5628,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es6-promise@3.3.1: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -5520,6 +5914,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.4: {}
+
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
@@ -5545,6 +5941,14 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
+
+  fast-uri@3.1.0: {}
+
+  fast-xml-parser@4.5.3:
+    dependencies:
+      strnum: 1.1.2
 
   fastq@1.19.1:
     dependencies:
@@ -5580,6 +5984,8 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreach@2.0.6: {}
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -5609,6 +6015,8 @@ snapshots:
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -5769,13 +6177,14 @@ snapshots:
       - supports-color
     optional: true
 
+  http2-client@1.3.5: {}
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   iceberg-js@0.8.1: {}
 
@@ -5953,6 +6362,8 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  js-levenshtein@1.1.6: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -5992,7 +6403,13 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-pointer@0.6.2:
+    dependencies:
+      foreach: 2.0.6
+
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -6053,13 +6470,19 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  lunr@2.3.9: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mark.js@8.11.1: {}
+
   markdown-extensions@2.0.0: {}
+
+  marked@4.3.0: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -6382,6 +6805,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@5.1.6:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
@@ -6389,6 +6816,24 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  mobx-react-lite@4.1.1(mobx@6.15.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      mobx: 6.15.0
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
+  mobx-react@9.2.0(mobx@6.15.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      mobx: 6.15.0
+      mobx-react-lite: 4.1.1(mobx@6.15.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
+  mobx@6.15.0: {}
 
   ms@2.1.3: {}
 
@@ -6404,7 +6849,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.1.6(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4):
+  next@16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -6412,7 +6857,7 @@ snapshots:
       caniuse-lite: 1.0.30001762
       postcss: 8.4.31
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.6
@@ -6423,15 +6868,59 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.57.0
       sharp: 0.34.4
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-fetch-h2@2.3.0:
+    dependencies:
+      http2-client: 1.3.5
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-readfiles@0.2.0:
+    dependencies:
+      es6-promise: 3.3.1
+
   node-releases@2.0.27: {}
 
   normalize-path@3.0.0: {}
+
+  oas-kit-common@1.0.8:
+    dependencies:
+      fast-safe-stringify: 2.1.1
+
+  oas-linter@3.2.2:
+    dependencies:
+      '@exodus/schemasafe': 1.3.0
+      should: 13.2.3
+      yaml: 1.10.2
+
+  oas-resolver@2.5.6:
+    dependencies:
+      node-fetch-h2: 2.3.0
+      oas-kit-common: 1.0.8
+      reftools: 1.1.9
+      yaml: 1.10.2
+      yargs: 17.7.2
+
+  oas-schema-walker@1.1.5: {}
+
+  oas-validator@5.0.8:
+    dependencies:
+      call-me-maybe: 1.0.2
+      oas-kit-common: 1.0.8
+      oas-linter: 3.2.2
+      oas-resolver: 2.5.6
+      oas-schema-walker: 1.1.5
+      reftools: 1.1.9
+      should: 13.2.3
+      yaml: 1.10.2
 
   object-assign@4.1.1: {}
 
@@ -6479,6 +6968,12 @@ snapshots:
 
   obug@2.1.1: {}
 
+  openapi-sampler@1.6.2:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      fast-xml-parser: 4.5.3
+      json-pointer: 0.6.2
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -6523,6 +7018,8 @@ snapshots:
       entities: 6.0.1
     optional: true
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -6535,6 +7032,8 @@ snapshots:
       minipass: 7.1.2
 
   pathe@2.0.3: {}
+
+  perfect-scrollbar@1.5.6: {}
 
   picocolors@1.1.1: {}
 
@@ -6554,6 +7053,12 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  pluralize@8.0.0: {}
+
+  polished@4.3.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+
   possible-typed-array-names@1.1.0: {}
 
   postcss-import@15.1.0(postcss@8.5.6):
@@ -6568,12 +7073,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.6
+      yaml: 2.8.2
 
   postcss-nested@6.2.0(postcss@8.5.6):
     dependencies:
@@ -6588,6 +7094,12 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.4.49:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -6619,6 +7131,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  prismjs@1.30.0: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -6635,7 +7149,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-dom@19.2.3(react@19.2.4):
+  react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
@@ -6670,6 +7184,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  react-tabs@6.1.0(react@19.2.4):
+    dependencies:
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.4
 
   react@19.2.4: {}
 
@@ -6710,6 +7230,39 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  redoc@2.5.2(core-js@3.46.0)(mobx@6.15.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+    dependencies:
+      '@redocly/openapi-core': 1.34.6
+      classnames: 2.5.1
+      core-js: 3.46.0
+      decko: 1.2.0
+      dompurify: 3.3.1
+      eventemitter3: 5.0.4
+      json-pointer: 0.6.2
+      lunr: 2.3.9
+      mark.js: 8.11.1
+      marked: 4.3.0
+      mobx: 6.15.0
+      mobx-react: 9.2.0(mobx@6.15.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      openapi-sampler: 1.6.2
+      path-browserify: 1.0.1
+      perfect-scrollbar: 1.5.6
+      polished: 4.3.1
+      prismjs: 1.30.0
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-tabs: 6.1.0(react@19.2.4)
+      slugify: 1.4.7
+      stickyfill: 1.1.1
+      styled-components: 6.3.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      swagger2openapi: 7.0.8
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - encoding
+      - react-native
+      - supports-color
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -6720,6 +7273,8 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  reftools@1.1.9: {}
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -6762,8 +7317,9 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
-  require-from-string@2.0.2:
-    optional: true
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -6870,6 +7426,8 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
+  shallowequal@1.1.0: {}
+
   sharp@0.34.4:
     dependencies:
       '@img/colour': 1.0.0
@@ -6906,6 +7464,32 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  should-equal@2.0.0:
+    dependencies:
+      should-type: 1.4.0
+
+  should-format@3.0.3:
+    dependencies:
+      should-type: 1.4.0
+      should-type-adaptors: 1.1.0
+
+  should-type-adaptors@1.1.0:
+    dependencies:
+      should-type: 1.4.0
+      should-util: 1.0.1
+
+  should-type@1.4.0: {}
+
+  should-util@1.0.1: {}
+
+  should@13.2.3:
+    dependencies:
+      should-equal: 2.0.0
+      should-format: 3.0.3
+      should-type: 1.4.0
+      should-type-adaptors: 1.1.0
+      should-util: 1.0.1
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -6938,10 +7522,12 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sonner@2.0.7(react-dom@19.2.3(react@19.2.4))(react@19.2.4):
+  slugify@1.4.7: {}
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 
@@ -6954,6 +7540,8 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  stickyfill@1.1.1: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -7045,6 +7633,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.2.3
 
+  strnum@1.1.2: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -7053,12 +7643,29 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  styled-components@6.3.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@emotion/is-prop-valid': 1.4.0
+      '@emotion/unitless': 0.10.0
+      '@types/stylis': 4.2.7
+      css-to-react-native: 3.2.0
+      csstype: 3.2.3
+      postcss: 8.4.49
+      react: 19.2.4
+      shallowequal: 1.1.0
+      stylis: 4.3.6
+      tslib: 2.8.1
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
   styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.28.5
+
+  stylis@4.3.6: {}
 
   sucrase@3.35.0:
     dependencies:
@@ -7076,12 +7683,28 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swagger2openapi@7.0.8:
+    dependencies:
+      call-me-maybe: 1.0.2
+      node-fetch: 2.7.0
+      node-fetch-h2: 2.3.0
+      node-readfiles: 0.2.0
+      oas-kit-common: 1.0.8
+      oas-resolver: 2.5.6
+      oas-schema-walker: 1.1.5
+      oas-validator: 5.0.8
+      reftools: 1.1.9
+      yaml: 1.10.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - encoding
+
   symbol-tree@3.2.4:
     optional: true
 
   tailwind-merge@2.6.0: {}
 
-  tailwindcss@3.4.18:
+  tailwindcss@3.4.18(yaml@2.8.2):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -7100,7 +7723,7 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.8.2)
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -7144,6 +7767,8 @@ snapshots:
     dependencies:
       tldts: 7.0.23
     optional: true
+
+  tr46@0.0.3: {}
 
   tr46@6.0.0:
     dependencies:
@@ -7303,6 +7928,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-template@2.0.8: {}
+
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -7318,6 +7945,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   util-deprecate@1.0.2: {}
 
   vfile-message@4.0.3:
@@ -7330,7 +7961,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7):
+  vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -7342,11 +7973,12 @@ snapshots:
       '@types/node': 25.2.3
       fsevents: 2.3.3
       jiti: 1.21.7
+      yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@25.2.3)(happy-dom@20.3.0)(jiti@1.21.7)(jsdom@27.4.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(happy-dom@20.3.0)(jiti@1.21.7)(jsdom@27.4.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -7363,9 +7995,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.2.3)(jiti@1.21.7)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@1.21.7)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 25.2.3
       happy-dom: 20.3.0
       jsdom: 27.4.0
@@ -7389,6 +8022,8 @@ snapshots:
 
   web-vitals@4.2.4: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@8.0.1:
     optional: true
 
@@ -7405,6 +8040,11 @@ snapshots:
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     optional: true
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -7481,7 +8121,28 @@ snapshots:
   xmlchars@2.2.0:
     optional: true
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
+
+  yaml-ast-parser@0.0.43: {}
+
+  yaml@1.10.2: {}
+
+  yaml@2.8.2:
+    optional: true
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/scripts/docs-sync-check.ts
+++ b/scripts/docs-sync-check.ts
@@ -1,0 +1,44 @@
+import {
+  buildSnapshots,
+  readSnapshot,
+  resolveWeblingoRepoPathOrThrow,
+  SNAPSHOT_FILE_PATHS,
+} from "./docs-sync-shared";
+
+function quoteCommandPath(value: string): string {
+  return value.includes(" ") ? `"${value}"` : value;
+}
+
+function main(): void {
+  const sourceRepoPath = resolveWeblingoRepoPathOrThrow();
+  const expectedSnapshots = buildSnapshots(sourceRepoPath);
+
+  const stalePaths: string[] = [];
+  for (const [relativePath, expectedContent] of Object.entries(expectedSnapshots)) {
+    const currentContent = readSnapshot(relativePath);
+    if (currentContent !== expectedContent) {
+      stalePaths.push(relativePath);
+    }
+  }
+
+  if (stalePaths.length > 0) {
+    const refreshCommand = `WEBLINGO_REPO_PATH=${quoteCommandPath(sourceRepoPath)} pnpm docs:sync`;
+    throw new Error(
+      `[docs:sync:check] Stale or missing synced docs artifacts:\n${stalePaths
+        .sort((left, right) => left.localeCompare(right))
+        .map((entry) => `- ${entry}`)
+        .join("\n")}\nRefresh with:\n${refreshCommand}`,
+    );
+  }
+
+  const snapshotCount = Object.keys(SNAPSHOT_FILE_PATHS).length;
+  console.info(`[docs:sync:check] Synced artifacts are up to date (${snapshotCount} files).`);
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+}

--- a/scripts/docs-sync-shared.ts
+++ b/scripts/docs-sync-shared.ts
@@ -1,0 +1,186 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+
+export const REQUIRED_BACKEND_FILES = [
+  "docs/reference/openapi.json",
+  "docs/reference/feature-catalog.generated.json",
+  "docs/reference/API_PLAYBOOKS.md",
+] as const;
+
+export const GENERATED_DOCS_DIR = "content/docs/_generated";
+
+export const SNAPSHOT_FILE_PATHS = {
+  openApi: `${GENERATED_DOCS_DIR}/backend-openapi.snapshot.json`,
+  featureCatalog: `${GENERATED_DOCS_DIR}/backend-feature-catalog.snapshot.json`,
+  playbooks: `${GENERATED_DOCS_DIR}/backend-playbooks.snapshot.md`,
+  manifest: `${GENERATED_DOCS_DIR}/backend-sync-manifest.json`,
+} as const;
+
+type SnapshotMap = Record<string, string>;
+
+type HashedFile = {
+  bytes: number;
+  sha256: string;
+};
+
+function normalizeNewlines(value: string): string {
+  return value.replace(/\r\n/g, "\n");
+}
+
+function ensureTrailingNewline(value: string): string {
+  return value.endsWith("\n") ? value : `${value}\n`;
+}
+
+function stableSortValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableSortValue(item));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const source = value as Record<string, unknown>;
+  const sortedKeys = Object.keys(source).sort((left, right) => left.localeCompare(right));
+  const out: Record<string, unknown> = {};
+  for (const key of sortedKeys) {
+    out[key] = stableSortValue(source[key]);
+  }
+  return out;
+}
+
+function stableJson(value: unknown): string {
+  return `${JSON.stringify(stableSortValue(value), null, 2)}\n`;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function readRequiredBackendFile(repoPath: string, relativePath: string): string {
+  const absolutePath = path.join(repoPath, relativePath);
+  return readFileSync(absolutePath, "utf8");
+}
+
+function gitOutput(repoPath: string, args: string[]): string {
+  return execFileSync("git", ["-C", repoPath, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+export function resolveWeblingoRepoPathOrThrow(cwd = process.cwd()): string {
+  const configured = process.env.WEBLINGO_REPO_PATH?.trim();
+  if (!configured) {
+    throw new Error(
+      "[docs-sync] WEBLINGO_REPO_PATH is required. Example: WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync",
+    );
+  }
+
+  const absolutePath = path.resolve(cwd, configured);
+  if (!existsSync(absolutePath)) {
+    throw new Error(`[docs-sync] WEBLINGO_REPO_PATH does not exist: ${absolutePath}`);
+  }
+
+  const missing = REQUIRED_BACKEND_FILES.filter(
+    (relativePath) => !existsSync(path.join(absolutePath, relativePath)),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `[docs-sync] WEBLINGO_REPO_PATH is invalid (${absolutePath}). Missing required files:\n${missing
+        .map((entry) => `- ${entry}`)
+        .join("\n")}`,
+    );
+  }
+
+  try {
+    const isGitRepo = gitOutput(absolutePath, ["rev-parse", "--is-inside-work-tree"]);
+    if (isGitRepo !== "true") {
+      throw new Error("[docs-sync] WEBLINGO_REPO_PATH is not inside a git worktree.");
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`[docs-sync] WEBLINGO_REPO_PATH must point to a git repository: ${message}`);
+  }
+
+  return absolutePath;
+}
+
+function buildSourceFileHashes(repoPath: string): Record<string, HashedFile> {
+  const out: Record<string, HashedFile> = {};
+  for (const relativePath of REQUIRED_BACKEND_FILES) {
+    const raw = readRequiredBackendFile(repoPath, relativePath);
+    const normalized = normalizeNewlines(raw);
+    out[relativePath] = {
+      bytes: Buffer.byteLength(normalized, "utf8"),
+      sha256: sha256(normalized),
+    };
+  }
+  return out;
+}
+
+function buildGeneratedFileHashes(snapshotMap: SnapshotMap): Record<string, HashedFile> {
+  const out: Record<string, HashedFile> = {};
+  for (const [relativePath, content] of Object.entries(snapshotMap)) {
+    out[relativePath] = {
+      bytes: Buffer.byteLength(content, "utf8"),
+      sha256: sha256(content),
+    };
+  }
+  return out;
+}
+
+export function buildSnapshots(repoPath: string): SnapshotMap {
+  const openApiRaw = readRequiredBackendFile(repoPath, "docs/reference/openapi.json");
+  const featureCatalogRaw = readRequiredBackendFile(
+    repoPath,
+    "docs/reference/feature-catalog.generated.json",
+  );
+  const playbooksRaw = readRequiredBackendFile(repoPath, "docs/reference/API_PLAYBOOKS.md");
+
+  const openApiSnapshot = stableJson(JSON.parse(openApiRaw) as unknown);
+  const featureCatalogSnapshot = stableJson(JSON.parse(featureCatalogRaw) as unknown);
+  const playbooksSnapshot = ensureTrailingNewline(normalizeNewlines(playbooksRaw));
+
+  const contentSnapshots: SnapshotMap = {
+    [SNAPSHOT_FILE_PATHS.openApi]: openApiSnapshot,
+    [SNAPSHOT_FILE_PATHS.featureCatalog]: featureCatalogSnapshot,
+    [SNAPSHOT_FILE_PATHS.playbooks]: playbooksSnapshot,
+  };
+
+  const sourceRepoSha = gitOutput(repoPath, ["rev-parse", "HEAD"]);
+  const sourceRepoCommitTimestamp = gitOutput(repoPath, ["show", "-s", "--format=%cI", "HEAD"]);
+
+  const manifest = {
+    schemaVersion: 1,
+    sourceRepoPath: repoPath,
+    sourceRepoSha,
+    sourceRepoCommitTimestamp,
+    generatedAt: sourceRepoCommitTimestamp,
+    sourceFiles: buildSourceFileHashes(repoPath),
+    generatedFiles: buildGeneratedFileHashes(contentSnapshots),
+    requiredEnv: ["WEBLINGO_REPO_PATH"],
+  };
+
+  return {
+    ...contentSnapshots,
+    [SNAPSHOT_FILE_PATHS.manifest]: stableJson(manifest),
+  };
+}
+
+export async function writeSnapshots(snapshotMap: SnapshotMap, cwd = process.cwd()): Promise<void> {
+  for (const [relativePath, content] of Object.entries(snapshotMap)) {
+    const absolutePath = path.resolve(cwd, relativePath);
+    await mkdir(path.dirname(absolutePath), { recursive: true });
+    await writeFile(absolutePath, content, "utf8");
+  }
+}
+
+export function readSnapshot(relativePath: string, cwd = process.cwd()): string | null {
+  const absolutePath = path.resolve(cwd, relativePath);
+  if (!existsSync(absolutePath)) {
+    return null;
+  }
+  return readFileSync(absolutePath, "utf8");
+}

--- a/scripts/docs-sync-weblingo.ts
+++ b/scripts/docs-sync-weblingo.ts
@@ -1,0 +1,19 @@
+import { buildSnapshots, resolveWeblingoRepoPathOrThrow, writeSnapshots } from "./docs-sync-shared";
+
+async function main(): Promise<void> {
+  const sourceRepoPath = resolveWeblingoRepoPathOrThrow();
+  const snapshots = buildSnapshots(sourceRepoPath);
+  await writeSnapshots(snapshots);
+
+  const writtenPaths = Object.keys(snapshots).sort((left, right) => left.localeCompare(right));
+  console.info(`[docs:sync] Synced ${writtenPaths.length} file(s) from ${sourceRepoPath}:`);
+  for (const relativePath of writtenPaths) {
+    console.info(`- ${relativePath}`);
+  }
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});

--- a/tests/docs/docs-feature-coverage.test.ts
+++ b/tests/docs/docs-feature-coverage.test.ts
@@ -1,0 +1,104 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+type CatalogEntry = {
+  family: string;
+  userFacing: boolean;
+  endpoint?: {
+    operationId?: string;
+  };
+  surfaces?: Array<{
+    path?: string;
+  }>;
+};
+
+type FeatureCatalog = {
+  features: CatalogEntry[];
+};
+
+function readUtf8OrThrow(relativePath: string): string {
+  const absolutePath = resolve(process.cwd(), relativePath);
+  if (!existsSync(absolutePath)) {
+    throw new Error(`[docs] Required file is missing: ${relativePath}`);
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+function parseOperationIdsFromPlaybooks(playbooksMarkdown: string): Set<string> {
+  const ids = new Set<string>();
+  const matcher = /`operationId`:\s*`([^`]+)`/g;
+  for (const match of playbooksMarkdown.matchAll(matcher)) {
+    const operationId = match[1]?.trim();
+    if (operationId) {
+      ids.add(operationId);
+    }
+  }
+  return ids;
+}
+
+describe("docs feature coverage", () => {
+  const featureCatalog = JSON.parse(
+    readUtf8OrThrow("content/docs/_generated/backend-feature-catalog.snapshot.json"),
+  ) as FeatureCatalog;
+  const playbooksMarkdown = readUtf8OrThrow(
+    "content/docs/_generated/backend-playbooks.snapshot.md",
+  );
+  const apiReferenceMarkdown = readUtf8OrThrow("content/docs/api-reference.mdx");
+  const playbookOperationIds = parseOperationIdsFromPlaybooks(playbooksMarkdown);
+
+  it("documents every user-facing API capability operationId", () => {
+    const userFacingOperationIds = featureCatalog.features
+      .filter((entry) => entry.family === "api" && entry.userFacing)
+      .map((entry) => entry.endpoint?.operationId)
+      .filter((operationId): operationId is string => typeof operationId === "string")
+      .sort((left, right) => left.localeCompare(right));
+
+    const missing = userFacingOperationIds.filter(
+      (operationId) => !apiReferenceMarkdown.includes(`\`${operationId}\``),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("documents all user-facing serve surface paths and serving playbook", () => {
+    const userFacingHttpPaths = featureCatalog.features
+      .filter((entry) => entry.family === "http" && entry.userFacing)
+      .flatMap((entry) => entry.surfaces ?? [])
+      .map((surface) => surface.path)
+      .filter((pathValue): pathValue is string => typeof pathValue === "string")
+      .sort((left, right) => left.localeCompare(right));
+
+    const missingPaths = userFacingHttpPaths.filter(
+      (pathValue) => !apiReferenceMarkdown.includes(`\`${pathValue}\``),
+    );
+    expect(missingPaths).toEqual([]);
+    expect(apiReferenceMarkdown).toContain("Playbook: Serving Access and Previews");
+  });
+
+  it("does not expose internal API operationIds in the user-facing API reference", () => {
+    const internalOperationIds = featureCatalog.features
+      .filter((entry) => entry.family === "api" && !entry.userFacing)
+      .map((entry) => entry.endpoint?.operationId)
+      .filter((operationId): operationId is string => typeof operationId === "string");
+
+    const leaked = internalOperationIds.filter((operationId) =>
+      apiReferenceMarkdown.includes(`\`${operationId}\``),
+    );
+    expect(leaked).toEqual([]);
+  });
+
+  it("only references operationIds that exist in the synced feature catalog", () => {
+    const knownOperationIds = new Set(
+      featureCatalog.features
+        .filter((entry) => entry.family === "api")
+        .map((entry) => entry.endpoint?.operationId)
+        .filter((operationId): operationId is string => typeof operationId === "string"),
+    );
+
+    const unknownInPlaybooks = [...playbookOperationIds]
+      .filter((operationId) => !knownOperationIds.has(operationId))
+      .sort((left, right) => left.localeCompare(right));
+
+    expect(unknownInPlaybooks).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a strict code-first docs sync workflow from backend (`weblingo`) into website snapshots, with no fallback path behavior.
- Require `WEBLINGO_REPO_PATH` for all sync/check commands and fail fast when unset or invalid.
- Generate and commit backend snapshots under `content/docs/_generated`:
  - OpenAPI snapshot
  - feature-catalog snapshot
  - API playbooks snapshot
  - sync manifest (source SHA/timestamp + file hashes)
- Make contract validation default to synced OpenAPI snapshot and add docs integrity tests that enforce:
  - all user-facing API operationIds are represented in website docs
  - serve capabilities (`/{path}`, `/_preview/{previewId}`) are documented
  - internal-only API operations are not exposed in user-facing docs
- Update `content/docs/api-reference.mdx` to a concise capability index aligned to generated backend artifacts and corrected auth wording.
- Add dedicated CI job `docs-sync-check` (separate from global `check`) that runs with explicit `WEBLINGO_REPO_PATH`.

## Testing

- [x] `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo pnpm docs:sync`
- [x] `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo pnpm docs:sync:check`
- [x] `pnpm test:contracts`
- [x] `pnpm check`
- [x] Other: `pnpm docs:sync:check` (without `WEBLINGO_REPO_PATH`) fails fast as expected