### PR TITLE
feat(dashboard): paginate pages and remove URL error redirects (M14.6)

### DIFF
--- a/app/dashboard/_lib/workspace-actions.ts
+++ b/app/dashboard/_lib/workspace-actions.ts
@@ -37,7 +37,7 @@ export async function setWorkspaceAction(formData: FormData) {
   }
 
   if (!allowedIds.has(subjectAccountId)) {
-    redirect("/dashboard?error=Unsupported workspace selection.");
+    redirect("/dashboard");
   }
 
   const cookieStore = await cookies();

--- a/app/dashboard/actions.ts
+++ b/app/dashboard/actions.ts
@@ -426,6 +426,7 @@ export async function translateAndServeAction(
     const result = await withWebhooksAuth(async (auth) => {
       if (shouldActivate) {
         await updateSite(auth, siteId, { status: "active" });
+        await invalidateSitesCache(auth);
       }
       return translateSite(auth, siteId, targetLang, { intent: "translate_and_serve" });
     });

--- a/app/dashboard/no-account/actions.ts
+++ b/app/dashboard/no-account/actions.ts
@@ -3,10 +3,27 @@
 import { redirect } from "next/navigation";
 
 import { createClient } from "@/lib/supabase/server";
+import type { ActionResponse } from "@/app/dashboard/actions";
 import { envServer } from "@internal/core/env-server";
 import { FetchTimeoutError, fetchWithTimeout } from "@internal/core/fetch-timeout";
 
-export async function claimAccount() {
+const failed = (message: string): ActionResponse => ({
+  ok: false,
+  message,
+});
+
+const succeeded = (message: string, meta?: Record<string, unknown>): ActionResponse => ({
+  ok: true,
+  message,
+  meta,
+});
+
+export async function claimAccount(
+  _prevState: ActionResponse | undefined,
+  _formData: FormData,
+): Promise<ActionResponse> {
+  void _prevState;
+  void _formData;
   if (envServer.PUBLIC_PORTAL_MODE !== "enabled") {
     redirect("/");
   }
@@ -61,10 +78,11 @@ export async function claimAccount() {
   }
 
   if (shouldRedirectToDashboard) {
-    redirect("/dashboard");
+    return succeeded("Account linked. Redirecting to dashboard.", {
+      redirectTo: "/dashboard",
+      refresh: false,
+    });
   }
 
-  redirect(
-    `/dashboard/no-account?error=${encodeURIComponent(errorMessage ?? "Unable to claim account")}`,
-  );
+  return failed(errorMessage ?? "Unable to claim account");
 }

--- a/app/dashboard/no-account/page.tsx
+++ b/app/dashboard/no-account/page.tsx
@@ -5,6 +5,7 @@ import { PricingTableEmbed } from "./pricing-table";
 
 import { claimAccount } from "@/app/dashboard/no-account/actions";
 import { logout } from "@/app/auth/logout/actions";
+import { ActionForm } from "@/components/dashboard/action-form";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -12,36 +13,13 @@ import { envServer } from "@internal/core/env-server";
 import { getPricingTableId } from "@internal/billing";
 import { i18nConfig } from "@internal/i18n";
 
-type NoAccountPageProps = {
-  searchParams?: Promise<{
-    error?: string;
-  }>;
-};
-
-export default async function NoAccountPage({ searchParams }: NoAccountPageProps) {
+export default async function NoAccountPage() {
   if (envServer.PUBLIC_PORTAL_MODE !== "enabled") {
     notFound();
   }
   const locale = i18nConfig.defaultLocale;
   const pricingTableId = getPricingTableId(locale);
   const publishableKey = envServer.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
-
-  const resolvedSearchParams = await searchParams;
-  const rawError = resolvedSearchParams?.error;
-  const errorMessages: Record<string, string> = {
-    claim_failed: "We could not create your account yet. Please try again.",
-    session_expired: "Your session expired. Please sign in again.",
-  };
-  let error: string | null = null;
-  if (typeof rawError === "string") {
-    let decoded = rawError;
-    try {
-      decoded = decodeURIComponent(rawError);
-    } catch {
-      decoded = rawError;
-    }
-    error = errorMessages[decoded] ?? "An unexpected error occurred.";
-  }
 
   return (
     <div className="mx-auto flex min-h-[60vh] w-full max-w-5xl flex-col gap-8 px-4 py-12">
@@ -57,15 +35,16 @@ export default async function NoAccountPage({ searchParams }: NoAccountPageProps
           <Badge variant="outline">Status: pending access</Badge>
         </CardHeader>
         <CardContent className="space-y-4">
-          {error ? (
-            <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-              {error}
-            </div>
-          ) : null}
           <div className="flex flex-wrap gap-3">
-            <form action={claimAccount}>
+            <ActionForm
+              action={claimAccount}
+              loading="Creating account..."
+              success="Account linked. Redirecting to dashboard."
+              error="Unable to create your account."
+              refreshOnSuccess={false}
+            >
               <Button type="submit">Create your account</Button>
-            </form>
+            </ActionForm>
             <Button asChild>
               <Link href={`/${locale}/pricing`}>View pricing page</Link>
             </Button>

--- a/app/dashboard/sites/[id]/page.tsx
+++ b/app/dashboard/sites/[id]/page.tsx
@@ -108,7 +108,7 @@ export default async function SitePage({ params }: SitePageProps) {
   }
 
   if (pagesResult.status === "fulfilled") {
-    pages = pagesResult.value;
+    pages = pagesResult.value.pages;
   } else {
     const err = pagesResult.reason;
     if (err instanceof WebhooksApiError) {

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -1280,10 +1280,35 @@
               "$ref": "#/components/schemas/SitePageSummary"
             },
             "type": "array"
+          },
+          "pagination": {
+            "additionalProperties": false,
+            "properties": {
+              "hasMore": {
+                "type": "boolean"
+              },
+              "limit": {
+                "type": "number"
+              },
+              "offset": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "limit",
+              "offset",
+              "total",
+              "hasMore"
+            ],
+            "type": "object"
           }
         },
         "required": [
-          "pages"
+          "pages",
+          "pagination"
         ],
         "type": "object"
       },
@@ -5398,6 +5423,29 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Maximum number of pages to return (1-200). Defaults to 25.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "maximum": 200,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of pages to skip before returning results. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -5410,7 +5458,13 @@
                       "id": "string",
                       "sourcePath": "string"
                     }
-                  ]
+                  ],
+                  "pagination": {
+                    "hasMore": true,
+                    "limit": 1,
+                    "offset": 1,
+                    "total": 1
+                  }
                 },
                 "schema": {
                   "$ref": "#/components/schemas/ListSitePagesResponse"

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-02-13T09:34:46+09:00",
+  "generatedAt": "2026-02-13T16:12:06+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 55170,
       "sha256": "fe1ca5229e4f1cb213461c1b810ba262d507536851cd3cc2cec81be26dbdb731"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 161055,
-      "sha256": "d05d80e6d524ffcf93c40563bed39c94b33ed9a1e3078a19ae610c9cd9f3ae11"
+      "bytes": 162551,
+      "sha256": "181138b40e7b24dcdd0f8a5e8e57714314251189518a2c230c55903430823213"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
       "bytes": 4279,
@@ -28,11 +28,11 @@
       "sha256": "2634e68c75f13f84a21d30dbb256a179b8e7d52ff451a04aee1b0efa7a6c5d62"
     },
     "docs/reference/openapi.json": {
-      "bytes": 121197,
-      "sha256": "ab64398dfa8fed9073122761a955c53a2a40ae8142dbc5f0a105bfa0477bb4ea"
+      "bytes": 122307,
+      "sha256": "e822a6b041134d94b979bce72d728efa0dfbed485b3ec788e8393b9c77e335d6"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-02-13T09:34:46+09:00",
+  "sourceRepoCommitTimestamp": "2026-02-13T16:12:06+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "d18f01878e16f23f796c98612e054cc473353afd"
+  "sourceRepoSha": "b41333d71864b311071c1b96ab9b2c90fbc5b28b"
 }

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -246,6 +246,14 @@ const authResponseSchema = z.object({
 const listSitePagesResponseSchema = z
   .object({
     pages: z.array(sitePageSummarySchema),
+    pagination: z
+      .object({
+        limit: z.number().int().nonnegative(),
+        offset: z.number().int().nonnegative(),
+        total: z.number().int().nonnegative(),
+        hasMore: z.boolean(),
+      })
+      .strict(),
   })
   .strict();
 
@@ -402,6 +410,8 @@ export type CrawlStatus = z.infer<typeof crawlStatusSchema>;
 export type Deployment = z.infer<typeof deploymentSchema>;
 export type TranslationRun = z.infer<typeof translationRunSchema>;
 export type SitePageSummary = z.infer<typeof sitePageSummarySchema>;
+export type SitePagesPagination = z.infer<typeof listSitePagesResponseSchema.shape.pagination>;
+export type SitePagesResponse = z.infer<typeof listSitePagesResponseSchema>;
 export type GlossaryEntry = z.infer<typeof glossaryEntrySchema>;
 export type AccountMe = z.infer<typeof accountMeSchema>;
 export type SupportedLanguage = z.infer<typeof supportedLanguageSchema>;
@@ -922,7 +932,7 @@ export async function fetchSitePages(
   auth: AuthInput,
   siteId: string,
   options?: { limit?: number; offset?: number },
-): Promise<SitePageSummary[]> {
+): Promise<SitePagesResponse> {
   const qs = new URLSearchParams();
 
   if (typeof options?.limit === "number") {
@@ -939,7 +949,7 @@ export async function fetchSitePages(
     schema: listSitePagesResponseSchema,
   });
 
-  return data.pages;
+  return data;
 }
 
 export async function fetchGlossary(auth: AuthInput, siteId: string): Promise<GlossaryEntry[]> {


### PR DESCRIPTION
## Summary

- Consume paginated site-pages API in dashboard webhooks client and add server-rendered pager (`?page=`) for site pages.
- Remove remaining URL error-param redirect flows in dashboard actions/pages in favor of direct action responses/toast handling.
- Covers the M14.6 frontend UX/perf quick-win portion paired with backend pagination changes.

## Testing

- [x] `corepack pnpm run check`
- [x] `corepack pnpm run test`
- [x] Other: `N/A`

> Replace the checkboxes with the commands you actually ran (or `N/A` when justified).
