### PR TITLE
feat(dashboard): stream overview and adopt sites summary API (M14.7)

### DIFF
--- a/app/api/dashboard/sites/[siteId]/status/route.test.ts
+++ b/app/api/dashboard/sites/[siteId]/status/route.test.ts
@@ -38,6 +38,7 @@ const makeAuth = (subjectAccountId: string): DashboardAuth => ({
   webhooksAuth: {
     token: "token",
     expiresAt: "2025-01-01T00:00:00Z",
+    subjectAccountId,
     refresh: async () => "token",
   },
   account: null,

--- a/app/api/dashboard/sites/[siteId]/status/route.test.ts
+++ b/app/api/dashboard/sites/[siteId]/status/route.test.ts
@@ -4,7 +4,7 @@ import type { Site } from "@internal/dashboard/webhooks";
 
 import { GET } from "./route";
 import { requireDashboardAuth } from "@internal/dashboard/auth";
-import { fetchDeployments, fetchSite } from "@internal/dashboard/webhooks";
+import { fetchSite } from "@internal/dashboard/webhooks";
 
 vi.mock("@internal/dashboard/auth", () => ({
   requireDashboardAuth: vi.fn(),
@@ -23,14 +23,12 @@ vi.mock("@internal/dashboard/webhooks", () => {
   }
   return {
     fetchSite: vi.fn(),
-    fetchDeployments: vi.fn(),
     WebhooksApiError,
   };
 });
 
 const mockedRequireDashboardAuth = vi.mocked(requireDashboardAuth);
 const mockedFetchSite = vi.mocked(fetchSite);
-const mockedFetchDeployments = vi.mocked(fetchDeployments);
 
 const makeAuth = (subjectAccountId: string): DashboardAuth => ({
   user: null,
@@ -86,13 +84,11 @@ describe("GET /api/dashboard/sites/[siteId]/status", () => {
     expect(response.status).toBe(403);
     const body = await response.json();
     expect(body.error).toMatch(/forbidden/i);
-    expect(mockedFetchDeployments).not.toHaveBeenCalled();
   });
 
-  it("returns site and deployments when account matches", async () => {
+  it("returns site when account matches", async () => {
     mockedRequireDashboardAuth.mockResolvedValue(makeAuth("acct-owner"));
     mockedFetchSite.mockResolvedValue(makeSite("acct-owner"));
-    mockedFetchDeployments.mockResolvedValue([]);
 
     const response = await GET(new Request("http://localhost"), {
       params: Promise.resolve({ siteId: "site-1" }),
@@ -101,6 +97,6 @@ describe("GET /api/dashboard/sites/[siteId]/status", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.site.accountId).toBe("acct-owner");
-    expect(Array.isArray(body.deployments)).toBe(true);
+    expect(body).not.toHaveProperty("deployments");
   });
 });

--- a/app/api/dashboard/sites/[siteId]/status/route.ts
+++ b/app/api/dashboard/sites/[siteId]/status/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { requireDashboardAuth } from "@internal/dashboard/auth";
-import { fetchDeployments, fetchSite, WebhooksApiError } from "@internal/dashboard/webhooks";
+import { fetchSite, WebhooksApiError } from "@internal/dashboard/webhooks";
 
 type RouteParams = {
   params: Promise<{
@@ -25,8 +25,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
     if (site.accountId !== auth.subjectAccountId) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
-    const deployments = await fetchDeployments(token, siteId);
-    return NextResponse.json({ site, deployments });
+    return NextResponse.json({ site });
   } catch (error) {
     if (error instanceof WebhooksApiError && error.status === 404) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/app/dashboard/_components/sites-list.test.tsx
+++ b/app/dashboard/_components/sites-list.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SiteSummary } from "@internal/dashboard/webhooks";
+
+vi.mock("next/link", async () => {
+  const React = await import("react");
+  type LinkProps = {
+    href: string;
+    prefetch?: boolean;
+    children?: ReactNode;
+  } & Record<string, unknown>;
+  return {
+    default: ({ href, prefetch, children, ...props }: LinkProps) =>
+      React.createElement(
+        "a",
+        {
+          href,
+          "data-prefetch": String(prefetch),
+          ...props,
+        },
+        children,
+      ),
+  };
+});
+
+import { SitesList } from "./sites-list";
+
+describe("SitesList", () => {
+  it("disables prefetch on high-cardinality site links", () => {
+    const sites: SiteSummary[] = [
+      {
+        id: "site-1",
+        accountId: "acct-1",
+        sourceUrl: "https://example.com",
+        status: "active",
+        servingMode: "strict",
+        maxLocales: null,
+        siteProfile: null,
+        sourceLang: "en",
+        targetLangs: ["fr"],
+        localeCount: 1,
+        serveEnabledLocaleCount: 1,
+        domainCount: 1,
+        verifiedDomainCount: 1,
+      },
+    ];
+
+    render(<SitesList sites={sites} />);
+
+    const manageLink = screen.getByRole("link", { name: "Manage" });
+    expect(manageLink.getAttribute("href")).toBe("/dashboard/sites/site-1");
+    expect(manageLink.getAttribute("data-prefetch")).toBe("false");
+  });
+});

--- a/app/dashboard/_components/sites-list.tsx
+++ b/app/dashboard/_components/sites-list.tsx
@@ -3,9 +3,9 @@ import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import type { Site } from "@internal/dashboard/webhooks";
+import type { SiteSummary } from "@internal/dashboard/webhooks";
 
-export function SitesList({ sites }: { sites: Site[] }) {
+export function SitesList({ sites }: { sites: SiteSummary[] }) {
   return (
     <div className="grid gap-4">
       {sites.map((site) => (
@@ -17,15 +17,14 @@ export function SitesList({ sites }: { sites: Site[] }) {
                 <StatusBadge status={site.status} />
               </div>
               <CardDescription>
-                {site.locales
-                  .map((locale) => `${locale.sourceLang}→${locale.targetLang}`)
-                  .join(" · ")}
+                {site.sourceLang
+                  ? `${site.sourceLang}→${site.targetLangs.join(" · ")}`
+                  : site.targetLangs.join(" · ")}
               </CardDescription>
             </div>
             <div className="flex flex-wrap items-center gap-2">
               <Badge variant="outline">
-                Domains: {site.domains.filter((domain) => domain.status === "verified").length} /{" "}
-                {site.domains.length}
+                Domains: {site.verifiedDomainCount} / {site.domainCount}
               </Badge>
               <Button asChild size="sm" variant="outline">
                 <Link href={`/dashboard/sites/${site.id}`} title="Manage">
@@ -34,25 +33,16 @@ export function SitesList({ sites }: { sites: Site[] }) {
               </Button>
             </div>
           </CardHeader>
-          <CardContent className="grid gap-3 md:grid-cols-[2fr_1fr] md:items-start">
+          <CardContent className="grid gap-3 md:grid-cols-2 md:items-start">
             <div className="space-y-1 text-sm">
-              <p className="font-semibold text-foreground">Domains</p>
-              <div className="flex flex-wrap gap-2">
-                {site.domains.map((domain) => (
-                  <Badge
-                    key={domain.domain}
-                    variant={domain.status === "verified" ? "secondary" : "outline"}
-                  >
-                    {domain.domain} ({domain.status})
-                  </Badge>
-                ))}
-              </div>
+              <p className="font-semibold text-foreground">Languages</p>
+              <p className="text-muted-foreground">
+                {site.localeCount} locale(s), {site.serveEnabledLocaleCount} serving enabled
+              </p>
             </div>
             <div className="space-y-1 text-sm">
-              <p className="font-semibold text-foreground">Route config</p>
-              <p className="text-muted-foreground">
-                {site.routeConfig?.pattern ?? "No subdomain pattern recorded"}
-              </p>
+              <p className="font-semibold text-foreground">Serving mode</p>
+              <p className="text-muted-foreground">{site.servingMode}</p>
             </div>
           </CardContent>
         </Card>
@@ -61,7 +51,7 @@ export function SitesList({ sites }: { sites: Site[] }) {
   );
 }
 
-function StatusBadge({ status }: { status: Site["status"] }) {
+function StatusBadge({ status }: { status: SiteSummary["status"] }) {
   if (status === "active") {
     return <Badge className="bg-emerald-100 text-emerald-700">Active</Badge>;
   }

--- a/app/dashboard/_components/sites-list.tsx
+++ b/app/dashboard/_components/sites-list.tsx
@@ -23,7 +23,7 @@ export function SitesList({ sites }: { sites: SiteSummary[] }) {
                 Domains: {site.verifiedDomainCount} / {site.domainCount}
               </Badge>
               <Button asChild size="sm" variant="outline">
-                <Link href={`/dashboard/sites/${site.id}`} title="Manage">
+                <Link href={`/dashboard/sites/${site.id}`} prefetch={false} title="Manage">
                   Manage
                 </Link>
               </Button>

--- a/app/dashboard/_components/sites-list.tsx
+++ b/app/dashboard/_components/sites-list.tsx
@@ -16,11 +16,7 @@ export function SitesList({ sites }: { sites: SiteSummary[] }) {
                 <CardTitle className="text-lg font-semibold">{site.sourceUrl}</CardTitle>
                 <StatusBadge status={site.status} />
               </div>
-              <CardDescription>
-                {site.sourceLang
-                  ? `${site.sourceLang}→${site.targetLangs.join(" · ")}`
-                  : site.targetLangs.join(" · ")}
-              </CardDescription>
+              <CardDescription>{renderLanguageDescription(site)}</CardDescription>
             </div>
             <div className="flex flex-wrap items-center gap-2">
               <Badge variant="outline">
@@ -57,4 +53,14 @@ function StatusBadge({ status }: { status: SiteSummary["status"] }) {
   }
 
   return <Badge variant="outline">Inactive</Badge>;
+}
+
+function renderLanguageDescription(site: SiteSummary): string {
+  if (site.targetLangs.length > 0) {
+    return site.sourceLang
+      ? `${site.sourceLang}→${site.targetLangs.join(" · ")}`
+      : site.targetLangs.join(" · ");
+  }
+
+  return site.sourceLang ?? "No target languages";
 }

--- a/app/dashboard/_components/sites-list.tsx
+++ b/app/dashboard/_components/sites-list.tsx
@@ -62,5 +62,9 @@ function renderLanguageDescription(site: SiteSummary): string {
       : site.targetLangs.join(" · ");
   }
 
-  return site.sourceLang ?? "No target languages";
+  if (site.sourceLang) {
+    return site.sourceLang;
+  }
+
+  return "No languages configured";
 }

--- a/app/dashboard/_components/sites-nav.test.tsx
+++ b/app/dashboard/_components/sites-nav.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard/sites/site-1",
+}));
+
+vi.mock("@/components/ui/sidebar", async () => {
+  const React = await import("react");
+  return {
+    SidebarMenu: ({ children }: { children: ReactNode }) =>
+      React.createElement("div", null, children),
+    SidebarMenuItem: ({ children }: { children: ReactNode }) =>
+      React.createElement("div", null, children),
+    SidebarMenuButton: ({
+      children,
+      asChild,
+      ...props
+    }: {
+      children: ReactNode;
+      asChild?: boolean;
+      [key: string]: unknown;
+    }) => {
+      if (asChild && React.isValidElement(children)) {
+        const passthroughProps = {
+          "aria-current":
+            typeof props["aria-current"] === "string" ? props["aria-current"] : undefined,
+        };
+        return React.cloneElement(children, passthroughProps);
+      }
+      const buttonProps = {
+        type: props.type === "button" ? "button" : undefined,
+        onClick: typeof props.onClick === "function" ? props.onClick : undefined,
+        "aria-expanded":
+          typeof props["aria-expanded"] === "boolean" ? props["aria-expanded"] : undefined,
+        "aria-controls":
+          typeof props["aria-controls"] === "string" ? props["aria-controls"] : undefined,
+      };
+      return React.createElement("button", buttonProps, children);
+    },
+    useSidebar: () => ({ state: "expanded" as const }),
+  };
+});
+
+vi.mock("next/link", async () => {
+  const React = await import("react");
+  type LinkProps = {
+    href: string;
+    prefetch?: boolean;
+    children?: ReactNode;
+  } & Record<string, unknown>;
+  return {
+    default: ({ href, prefetch, children, ...props }: LinkProps) =>
+      React.createElement(
+        "a",
+        {
+          href,
+          "data-prefetch": String(prefetch),
+          ...props,
+        },
+        children,
+      ),
+  };
+});
+
+import { SitesNav } from "./sites-nav";
+
+describe("SitesNav", () => {
+  it("disables prefetch for per-site submenu links", () => {
+    render(
+      <SitesNav
+        sites={[
+          {
+            id: "site-1",
+            label: "Example Site",
+            status: "active",
+          },
+        ]}
+      />,
+    );
+
+    for (const label of ["Configuration", "Pages", "Overrides", "Admin"]) {
+      const link = screen.getByRole("link", { name: label });
+      expect(link.getAttribute("data-prefetch")).toBe("false");
+    }
+  });
+});

--- a/app/dashboard/_components/sites-nav.tsx
+++ b/app/dashboard/_components/sites-nav.tsx
@@ -105,7 +105,11 @@ function SiteNavItem({ site, pathname }: SiteNavItemProps) {
               return (
                 <SidebarMenuItem key={item.href}>
                   <SidebarMenuButton asChild isActive={isItemActive} size="sm">
-                    <Link href={item.href} aria-current={isItemActive ? "page" : undefined}>
+                    <Link
+                      href={item.href}
+                      prefetch={false}
+                      aria-current={isItemActive ? "page" : undefined}
+                    >
                       <span className="truncate group-data-[collapsible=icon]:sr-only">
                         {item.label}
                       </span>

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -25,7 +25,7 @@ import { logout } from "@/app/auth/logout/actions";
 import { requireDashboardAuth, type DashboardAuth } from "@internal/dashboard/auth";
 import { listSitesCached } from "@internal/dashboard/data";
 import { i18nConfig } from "@internal/i18n";
-import type { Site } from "@internal/dashboard/webhooks";
+import type { SiteSummary } from "@internal/dashboard/webhooks";
 
 export const metadata: Metadata = {
   title: "Customer Dashboard",
@@ -252,7 +252,7 @@ export default async function DashboardLayout({ children }: DashboardLayoutProps
 
 // Async component for sidebar sites navigation - streams in while layout shell renders
 async function SitesNavAsync({ auth }: { auth: DashboardAuth }) {
-  let sites: Site[] = [];
+  let sites: SiteSummary[] = [];
   try {
     if (auth.webhooksAuth) {
       sites = await listSitesCached(auth.webhooksAuth);

--- a/app/dashboard/ops/page.tsx
+++ b/app/dashboard/ops/page.tsx
@@ -47,7 +47,7 @@ export default async function OpsPage() {
       <Card>
         <CardHeader>
           <CardTitle>Sites</CardTitle>
-          <CardDescription>Source, status, and latest crawl info.</CardDescription>
+          <CardDescription>Source, status, locale coverage, and domain readiness.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
           {sites.length === 0 ? (
@@ -58,12 +58,6 @@ export default async function OpsPage() {
                 typeof site.siteProfile?.label === "string"
                   ? (site.siteProfile.label as string)
                   : site.sourceUrl;
-              const latest = site.latestCrawlRun;
-              const latestLabel = latest
-                ? latest.pagesDiscovered == null
-                  ? `${latest.status}`
-                  : `${latest.status} · ${latest.pagesDiscovered} discovered`
-                : "—";
               return (
                 <div key={site.id} className="rounded-lg border border-border/60 bg-muted/30 p-3">
                   <div className="flex flex-wrap items-center gap-2">
@@ -77,20 +71,15 @@ export default async function OpsPage() {
                     <InfoRow label="Source URL" value={site.sourceUrl} />
                     <InfoRow
                       label="Locales"
-                      value={`${site.locales.length} (${site.locales
-                        .map((locale) => locale.targetLang)
-                        .join(", ")})`}
-                    />
-                    <InfoRow label="Latest crawl" value={latestLabel} />
-                    <InfoRow
-                      label="Last crawl update"
-                      value={latest?.updatedAt ? formatTimestamp(latest.updatedAt) : "—"}
+                      value={`${site.localeCount} (${site.targetLangs.join(", ") || "—"})`}
                     />
                     <InfoRow
                       label="Domains"
-                      value={`${site.domains.filter((d) => d.status === "verified").length} / ${
-                        site.domains.length
-                      } verified`}
+                      value={`${site.verifiedDomainCount} / ${site.domainCount} verified`}
+                    />
+                    <InfoRow
+                      label="Serving locales"
+                      value={`${site.serveEnabledLocaleCount} enabled`}
                     />
                   </div>
                 </div>
@@ -118,15 +107,4 @@ function InfoRow({ label, value }: { label: string; value: string }) {
       <span className="font-semibold text-foreground">{label}:</span> <span>{value}</span>
     </div>
   );
-}
-
-function formatTimestamp(value?: string | null): string {
-  if (!value) {
-    return "—";
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-  return date.toISOString();
 }

--- a/app/dashboard/ops/page.tsx
+++ b/app/dashboard/ops/page.tsx
@@ -58,6 +58,9 @@ export default async function OpsPage() {
                 typeof site.siteProfile?.label === "string"
                   ? (site.siteProfile.label as string)
                   : site.sourceUrl;
+              const targetLangs = Array.isArray(site.targetLangs)
+                ? site.targetLangs.join(", ")
+                : "";
               return (
                 <div key={site.id} className="rounded-lg border border-border/60 bg-muted/30 p-3">
                   <div className="flex flex-wrap items-center gap-2">
@@ -71,7 +74,7 @@ export default async function OpsPage() {
                     <InfoRow label="Source URL" value={site.sourceUrl} />
                     <InfoRow
                       label="Locales"
-                      value={`${site.localeCount} (${site.targetLangs.join(", ") || "—"})`}
+                      value={`${site.localeCount} (${targetLangs || "—"})`}
                     />
                     <InfoRow
                       label="Domains"

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,36 +1,38 @@
 import Link from "next/link";
+import { Suspense, cache } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { SitesList } from "./_components/sites-list";
+import { requireDashboardAuth, type DashboardAuth } from "@internal/dashboard/auth";
 import { listSitesCached } from "@internal/dashboard/data";
-import { type Site } from "@internal/dashboard/webhooks";
-import { requireDashboardAuth } from "@internal/dashboard/auth";
 import { i18nConfig } from "@internal/i18n";
+import type { SiteSummary } from "@internal/dashboard/webhooks";
+
+const getOverviewData = cache(async (auth: DashboardAuth) => {
+  if (!auth.webhooksAuth) {
+    throw new Error("Webhooks authentication is unavailable.");
+  }
+  const sites = await listSitesCached(auth.webhooksAuth);
+  const billingBlocked = !auth.mutationsAllowed;
+  const maxSites = auth.account?.featureFlags.maxSites ?? null;
+  const activeSites = sites.filter((site) => site.status === "active").length;
+  const hasAvailableSlot = maxSites === null || activeSites < maxSites;
+  const atSiteLimit = maxSites !== null && activeSites >= maxSites;
+  const canCreateSite = auth.has({ feature: "site_create" }) && !billingBlocked && hasAvailableSlot;
+  return {
+    sites,
+    billingBlocked,
+    maxSites,
+    atSiteLimit,
+    canCreateSite,
+  };
+});
 
 export default async function DashboardPage() {
-  let sites: Site[] = [];
-  let loadError: string | null = null;
-  let canCreateSite = false;
-  let billingBlocked = false;
-  let atSiteLimit = false;
-  let maxSites: number | null = null;
+  const auth = await requireDashboardAuth();
   const pricingPath = `/${i18nConfig.defaultLocale}/pricing`;
-
-  try {
-    const auth = await requireDashboardAuth();
-    sites = await listSitesCached(auth.webhooksAuth!);
-    billingBlocked = !auth.mutationsAllowed;
-    maxSites = auth.account?.featureFlags.maxSites ?? null;
-    const activeSites = sites.filter((site) => site.status === "active").length;
-    const hasAvailableSlot = maxSites === null || activeSites < maxSites;
-    atSiteLimit = maxSites !== null && activeSites >= maxSites;
-    canCreateSite = auth.has({ feature: "site_create" }) && !billingBlocked && hasAvailableSlot;
-  } catch (error) {
-    loadError =
-      error instanceof Error ? error.message : "Unable to load sites from the webhooks worker.";
-  }
 
   return (
     <div className="space-y-6">
@@ -46,89 +48,166 @@ export default async function DashboardPage() {
             <Badge variant="outline">Human-friendly UX</Badge>
           </div>
         </div>
-        <div className="flex flex-wrap gap-3">
-          {canCreateSite ? (
-            <Button asChild>
-              <Link href="/dashboard/sites/new">Add a site</Link>
-            </Button>
-          ) : billingBlocked ? (
-            <div className="flex flex-wrap items-center gap-2">
-              <Button disabled variant="outline">
-                Add a site
-              </Button>
-              <Button asChild variant="secondary">
-                <Link href={pricingPath}>Update billing</Link>
-              </Button>
-            </div>
-          ) : atSiteLimit ? (
-            <div className="flex flex-wrap items-center gap-2">
-              <Button disabled variant="outline">
-                Add a site
-              </Button>
-              <Button asChild variant="secondary">
-                <Link href={pricingPath}>Upgrade for more sites</Link>
-              </Button>
-            </div>
-          ) : (
-            <div className="flex flex-wrap items-center gap-2">
-              <Button disabled variant="outline">
-                Add a site
-              </Button>
-              <Button asChild variant="secondary">
-                <Link href={pricingPath}>Upgrade to unlock</Link>
-              </Button>
-            </div>
-          )}
-          <Button asChild variant="outline">
-            <Link href="/dashboard/sites">All sites</Link>
-          </Button>
-        </div>
+        <Suspense fallback={<OverviewActionsSkeleton />}>
+          <OverviewActions auth={auth} pricingPath={pricingPath} />
+        </Suspense>
       </div>
 
-      {loadError ? (
-        <Card className="border-destructive/40 bg-destructive/5">
-          <CardHeader>
-            <CardTitle className="text-destructive">Could not load sites</CardTitle>
-            <CardDescription>{loadError}</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Check that{" "}
-              <code className="rounded bg-muted px-1 py-0.5">NEXT_PUBLIC_WEBHOOKS_API_BASE</code> is
-              reachable and that your Supabase session is valid.
-            </p>
-          </CardContent>
-        </Card>
-      ) : sites.length === 0 ? (
-        <Card>
-          <CardHeader>
-            <CardTitle>Get set up in minutes</CardTitle>
-            <CardDescription>
-              Connect your source site, choose target languages, and verify your domains.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-wrap gap-3">
-            {canCreateSite ? (
-              <Button asChild>
-                <Link href="/dashboard/sites/new">Start onboarding</Link>
-              </Button>
-            ) : billingBlocked ? (
-              <Button asChild variant="secondary">
-                <Link href={pricingPath}>Update billing</Link>
-              </Button>
-            ) : (
-              <Button asChild variant="secondary">
-                <Link href={pricingPath}>Upgrade to start onboarding</Link>
-              </Button>
-            )}
-            <Button asChild variant="outline">
-              <Link href="/dashboard/developer-tools">View API docs</Link>
-            </Button>
-          </CardContent>
-        </Card>
+      <Suspense fallback={<OverviewSitesSkeleton />}>
+        <OverviewSites auth={auth} pricingPath={pricingPath} />
+      </Suspense>
+    </div>
+  );
+}
+
+async function OverviewActions({
+  auth,
+  pricingPath,
+}: {
+  auth: DashboardAuth;
+  pricingPath: string;
+}) {
+  const data = await getOverviewData(auth).catch((error) => {
+    console.warn("[dashboard] overview actions failed:", error);
+    return null;
+  });
+
+  if (!data) {
+    return (
+      <div className="flex flex-wrap gap-3">
+        <Button disabled variant="outline">
+          Add a site
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/dashboard/sites">All sites</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      {data.canCreateSite ? (
+        <Button asChild>
+          <Link href="/dashboard/sites/new">Add a site</Link>
+        </Button>
+      ) : data.billingBlocked ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <Button disabled variant="outline">
+            Add a site
+          </Button>
+          <Button asChild variant="secondary">
+            <Link href={pricingPath}>Update billing</Link>
+          </Button>
+        </div>
+      ) : data.atSiteLimit ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <Button disabled variant="outline">
+            Add a site
+          </Button>
+          <Button asChild variant="secondary">
+            <Link href={pricingPath}>Upgrade for more sites</Link>
+          </Button>
+        </div>
       ) : (
-        <SitesList sites={sites} />
+        <div className="flex flex-wrap items-center gap-2">
+          <Button disabled variant="outline">
+            Add a site
+          </Button>
+          <Button asChild variant="secondary">
+            <Link href={pricingPath}>Upgrade to unlock</Link>
+          </Button>
+        </div>
       )}
+      <Button asChild variant="outline">
+        <Link href="/dashboard/sites">All sites</Link>
+      </Button>
+    </div>
+  );
+}
+
+async function OverviewSites({ auth, pricingPath }: { auth: DashboardAuth; pricingPath: string }) {
+  let sites: SiteSummary[] = [];
+  let canCreateSite = false;
+  let billingBlocked = false;
+
+  try {
+    const data = await getOverviewData(auth);
+    sites = data.sites;
+    canCreateSite = data.canCreateSite;
+    billingBlocked = data.billingBlocked;
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unable to load sites from the webhooks worker.";
+    return (
+      <Card className="border-destructive/40 bg-destructive/5">
+        <CardHeader>
+          <CardTitle className="text-destructive">Could not load sites</CardTitle>
+          <CardDescription>{message}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Check that{" "}
+            <code className="rounded bg-muted px-1 py-0.5">NEXT_PUBLIC_WEBHOOKS_API_BASE</code> is
+            reachable and that your Supabase session is valid.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (sites.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Get set up in minutes</CardTitle>
+          <CardDescription>
+            Connect your source site, choose target languages, and verify your domains.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-3">
+          {canCreateSite ? (
+            <Button asChild>
+              <Link href="/dashboard/sites/new">Start onboarding</Link>
+            </Button>
+          ) : billingBlocked ? (
+            <Button asChild variant="secondary">
+              <Link href={pricingPath}>Update billing</Link>
+            </Button>
+          ) : (
+            <Button asChild variant="secondary">
+              <Link href={pricingPath}>Upgrade to start onboarding</Link>
+            </Button>
+          )}
+          <Button asChild variant="outline">
+            <Link href="/dashboard/developer-tools">View API docs</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return <SitesList sites={sites} />;
+}
+
+function OverviewActionsSkeleton() {
+  return (
+    <div className="flex flex-wrap gap-3">
+      <Button disabled variant="outline">
+        Add a site
+      </Button>
+      <Button disabled variant="outline">
+        All sites
+      </Button>
+    </div>
+  );
+}
+
+function OverviewSitesSkeleton() {
+  return (
+    <div className="grid gap-4">
+      <div className="h-28 animate-pulse rounded-lg border border-border/60 bg-muted/40" />
+      <div className="h-28 animate-pulse rounded-lg border border-border/60 bg-muted/40" />
     </div>
   );
 }

--- a/app/dashboard/sites/[id]/admin/page.tsx
+++ b/app/dashboard/sites/[id]/admin/page.tsx
@@ -377,6 +377,7 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
                   loading="Pausing localization..."
                   success="Localization paused."
                   error="Unable to pause localization."
+                  refreshOnSuccess={true}
                 >
                   <>
                     <input name="siteId" type="hidden" value={site.id} />
@@ -396,6 +397,7 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
                 loading="Enabling localization..."
                 success="Localization enabled."
                 error="Unable to enable localization."
+                refreshOnSuccess={true}
               >
                 <>
                   <input name="siteId" type="hidden" value={site.id} />

--- a/app/dashboard/sites/[id]/loading.tsx
+++ b/app/dashboard/sites/[id]/loading.tsx
@@ -1,0 +1,36 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+function PulseBar({ className }: { className: string }) {
+  return <div className={`animate-pulse rounded bg-muted ${className}`} />;
+}
+
+export default function SiteRouteLoading() {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-3">
+        <PulseBar className="h-8 w-72" />
+        <PulseBar className="h-4 w-56" />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <PulseBar className="h-6 w-40" />
+          <PulseBar className="h-4 w-64" />
+        </CardHeader>
+        <CardContent>
+          <PulseBar className="h-24 w-full" />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <PulseBar className="h-6 w-48" />
+          <PulseBar className="h-4 w-72" />
+        </CardHeader>
+        <CardContent>
+          <PulseBar className="h-32 w-full" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/dashboard/sites/[id]/pages/page.tsx
+++ b/app/dashboard/sites/[id]/pages/page.tsx
@@ -116,7 +116,7 @@ export default async function SitePagesPage({ params, searchParams }: SitePagesP
     pages = payload.pages ?? [];
     pageTotal = payload.pagination?.total ?? 0;
     pageHasMore = payload.pagination?.hasMore ?? false;
-    deployments = payload.deployments;
+    deployments = payload.deployments ?? [];
   } catch (err) {
     error = err instanceof Error ? err.message : "Unable to load site pages.";
     if (err instanceof WebhooksApiError) {

--- a/app/dashboard/sites/page.tsx
+++ b/app/dashboard/sites/page.tsx
@@ -3,13 +3,13 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { listSitesCached } from "@internal/dashboard/data";
-import { type Site } from "@internal/dashboard/webhooks";
+import { type SiteSummary } from "@internal/dashboard/webhooks";
 import { requireDashboardAuth } from "@internal/dashboard/auth";
 import { i18nConfig } from "@internal/i18n";
 import { SitesList } from "../_components/sites-list";
 
 export default async function SitesPage() {
-  let sites: Site[] = [];
+  let sites: SiteSummary[] = [];
   let error: string | null = null;
   let canCreateSite = false;
   let billingBlocked = false;

--- a/components/dashboard/action-form.test.tsx
+++ b/components/dashboard/action-form.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ActionResponse } from "@/app/dashboard/actions";
+
+const refreshSpy = vi.fn();
+const pushSpy = vi.fn();
+
+let mockState: ActionResponse = { ok: false, message: "" };
+let mockPending = false;
+
+const formActionMock = vi.fn(async () => ({ ok: true, message: "ok" }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: refreshSpy,
+    push: pushSpy,
+  }),
+}));
+
+vi.mock("@internal/dashboard/use-action-toast", () => ({
+  useActionToast: ({ formAction }: { formAction: (formData: FormData) => unknown }) => formAction,
+}));
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useActionState: () => [mockState, formActionMock, mockPending] as const,
+  };
+});
+
+import { ActionForm } from "./action-form";
+
+function renderActionForm(extraProps?: {
+  refreshOnSuccess?: boolean;
+  meta?: Record<string, unknown>;
+}) {
+  const action = async (
+    prev: ActionResponse | undefined,
+    formData: FormData,
+  ): Promise<ActionResponse> => {
+    void prev;
+    void formData;
+    return {
+      ok: true,
+      message: "ok",
+    };
+  };
+
+  const children: ReactNode = <button type="submit">Submit</button>;
+
+  return render(
+    <ActionForm
+      action={action}
+      loading="Loading"
+      success="Success"
+      error="Error"
+      refreshOnSuccess={extraProps?.refreshOnSuccess}
+    >
+      {children}
+    </ActionForm>,
+  );
+}
+
+function completeAction(
+  rerender: (ui: ReactNode) => void,
+  props?: { refreshOnSuccess?: boolean; meta?: Record<string, unknown> },
+) {
+  mockPending = true;
+  mockState = { ok: false, message: "pending" };
+  rerender(
+    <ActionForm
+      action={async () => ({ ok: true, message: "ok" })}
+      loading="Loading"
+      success="Success"
+      error="Error"
+      refreshOnSuccess={props?.refreshOnSuccess}
+    >
+      <button type="submit">Submit</button>
+    </ActionForm>,
+  );
+
+  mockPending = false;
+  mockState = {
+    ok: true,
+    message: "done",
+    meta: props?.meta,
+  };
+  rerender(
+    <ActionForm
+      action={async () => ({ ok: true, message: "ok" })}
+      loading="Loading"
+      success="Success"
+      error="Error"
+      refreshOnSuccess={props?.refreshOnSuccess}
+    >
+      <button type="submit">Submit</button>
+    </ActionForm>,
+  );
+}
+
+beforeEach(() => {
+  refreshSpy.mockReset();
+  pushSpy.mockReset();
+  formActionMock.mockReset();
+  mockPending = false;
+  mockState = { ok: false, message: "" };
+});
+
+describe("ActionForm refresh policy", () => {
+  it("does not refresh by default after successful action", () => {
+    const { rerender } = renderActionForm();
+    completeAction(rerender);
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it("refreshes when refreshOnSuccess is true", () => {
+    const { rerender } = renderActionForm({ refreshOnSuccess: true });
+    completeAction(rerender, { refreshOnSuccess: true });
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors action metadata refresh override", () => {
+    const { rerender } = renderActionForm();
+    completeAction(rerender, { meta: { refresh: true } });
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("prioritizes redirect metadata over refresh", () => {
+    const { rerender } = renderActionForm({ refreshOnSuccess: true });
+    completeAction(rerender, {
+      refreshOnSuccess: true,
+      meta: { redirectTo: "/dashboard/sites/site-1", refresh: true },
+    });
+    expect(pushSpy).toHaveBeenCalledWith("/dashboard/sites/site-1");
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+});

--- a/components/dashboard/action-form.test.tsx
+++ b/components/dashboard/action-form.test.tsx
@@ -34,10 +34,7 @@ vi.mock("react", async () => {
 
 import { ActionForm } from "./action-form";
 
-function renderActionForm(extraProps?: {
-  refreshOnSuccess?: boolean;
-  meta?: Record<string, unknown>;
-}) {
+function renderActionForm(extraProps?: { refreshOnSuccess?: boolean }) {
   const action = async (
     prev: ActionResponse | undefined,
     formData: FormData,

--- a/components/dashboard/action-form.tsx
+++ b/components/dashboard/action-form.tsx
@@ -60,7 +60,7 @@ export function ActionForm({
       const metaRefresh =
         typeof state.meta?.refresh === "boolean" ? (state.meta.refresh as boolean) : undefined;
 
-      const shouldRefresh = refreshOnSuccess ?? metaRefresh ?? true;
+      const shouldRefresh = refreshOnSuccess ?? metaRefresh ?? false;
 
       if (shouldRefresh) {
         router.refresh();

--- a/components/dashboard/site-status-toggle-form.tsx
+++ b/components/dashboard/site-status-toggle-form.tsx
@@ -35,6 +35,7 @@ export function SiteStatusToggleForm({
       success="Status updated."
       error="Unable to update status."
       confirmMessage={confirmMessage}
+      refreshOnSuccess={true}
     >
       <>
         <input name="siteId" type="hidden" value={siteId} />

--- a/content/docs/_generated/backend-feature-catalog.snapshot.json
+++ b/content/docs/_generated/backend-feature-catalog.snapshot.json
@@ -357,6 +357,37 @@
       "endpoint": {
         "auth": "bearer",
         "method": "GET",
+        "operationId": "sites.dashboard.get",
+        "path": "/sites/:siteId/dashboard"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.dashboard",
+      "id": "api.sites.dashboard.get",
+      "name": "Get dashboard payload for a site",
+      "playbooks": [
+        {
+          "anchor": "playbook-site-portfolio-management",
+          "id": "playbook-site-portfolio-management",
+          "title": "Playbook: Site Portfolio Management"
+        },
+        {
+          "anchor": "playbook-1-dashboard-bootstrap-and-site-setup",
+          "id": "playbook-1",
+          "title": "Playbook 1: Dashboard Bootstrap and Site Setup"
+        }
+      ],
+      "routeIds": [
+        "sites.dashboard.get"
+      ],
+      "stability": "GA",
+      "summary": "Returns a consolidated dashboard payload (site + deployments) and optional paginated pages when `includePages=true`.",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
         "operationId": "sites.deployments.list",
         "path": "/sites/:siteId/deployments"
       },
@@ -620,7 +651,7 @@
         "sites.list"
       ],
       "stability": "GA",
-      "summary": "List sites",
+      "summary": "Returns summary records for dashboard/navigation use. Breaking change: this response no longer includes full `Site` fields (`locales`, `domains`, `routeConfig`, `webhookUrl`, `webhookSecret`, `latestCrawlRun`). Call `GET /api/sites/{siteId}` for full site details.",
       "userFacing": true
     },
     {

--- a/content/docs/_generated/backend-feature-catalog.snapshot.json
+++ b/content/docs/_generated/backend-feature-catalog.snapshot.json
@@ -651,7 +651,7 @@
         "sites.list"
       ],
       "stability": "GA",
-      "summary": "Returns summary records for dashboard/navigation use. Breaking change: this response no longer includes full `Site` fields (`locales`, `domains`, `routeConfig`, `webhookUrl`, `webhookSecret`, `latestCrawlRun`). Call `GET /sites/{siteId}` for full site details.",
+      "summary": "Returns summary records for dashboard/navigation use. Breaking change: this response no longer includes full `Site` fields (`locales`, `domains`, `routeConfig`, `webhookUrl`, `webhookSecret`, `latestCrawlRun`). Call `GET /api/sites/{siteId}` for full site details.",
       "userFacing": true
     },
     {

--- a/content/docs/_generated/backend-feature-catalog.snapshot.json
+++ b/content/docs/_generated/backend-feature-catalog.snapshot.json
@@ -651,7 +651,7 @@
         "sites.list"
       ],
       "stability": "GA",
-      "summary": "Returns summary records for dashboard/navigation use. Breaking change: this response no longer includes full `Site` fields (`locales`, `domains`, `routeConfig`, `webhookUrl`, `webhookSecret`, `latestCrawlRun`). Call `GET /api/sites/{siteId}` for full site details.",
+      "summary": "Returns summary records for dashboard/navigation use. Breaking change: this response no longer includes full `Site` fields (`locales`, `domains`, `routeConfig`, `webhookUrl`, `webhookSecret`, `latestCrawlRun`). Call `GET /sites/{siteId}` for full site details.",
       "userFacing": true
     },
     {

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -1317,7 +1317,7 @@
         "properties": {
           "sites": {
             "items": {
-              "$ref": "#/components/schemas/Site"
+              "$ref": "#/components/schemas/SiteSummary"
             },
             "type": "array"
           }
@@ -2244,6 +2244,86 @@
         "required": [
           "id",
           "sourcePath"
+        ],
+        "type": "object"
+      },
+      "SiteSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "accountId": {
+            "type": "string"
+          },
+          "domainCount": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "localeCount": {
+            "type": "number"
+          },
+          "maxLocales": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "serveEnabledLocaleCount": {
+            "type": "number"
+          },
+          "servingMode": {
+            "$ref": "#/components/schemas/ServingMode"
+          },
+          "siteProfile": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sourceLang": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "active",
+              "inactive"
+            ],
+            "type": "string"
+          },
+          "targetLangs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "verifiedDomainCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "accountId",
+          "sourceUrl",
+          "status",
+          "servingMode",
+          "maxLocales",
+          "sourceLang",
+          "targetLangs",
+          "localeCount",
+          "serveEnabledLocaleCount",
+          "domainCount",
+          "verifiedDomainCount"
         ],
         "type": "object"
       },
@@ -3747,25 +3827,19 @@
                   "sites": [
                     {
                       "accountId": "string",
-                      "domains": [
-                        {
-                          "domain": "string",
-                          "status": "pending",
-                          "verificationToken": "string"
-                        }
-                      ],
+                      "domainCount": 1,
                       "id": "string",
-                      "locales": [
-                        {
-                          "serveEnabled": true,
-                          "sourceLang": "string",
-                          "targetLang": "string"
-                        }
-                      ],
+                      "localeCount": 1,
                       "maxLocales": 1,
+                      "serveEnabledLocaleCount": 1,
                       "servingMode": "strict",
+                      "sourceLang": "string",
                       "sourceUrl": "string",
-                      "status": "active"
+                      "status": "active",
+                      "targetLangs": [
+                        "string"
+                      ],
+                      "verifiedDomainCount": 1
                     }
                   ]
                 },

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -2298,17 +2298,20 @@
       },
       "SiteSummary": {
         "additionalProperties": false,
+        "description": "Summary shape returned by `GET /api/sites`. Excludes detail/sensitive fields such as `locales`, `domains`, `routeConfig`, `webhookUrl`, `webhookSecret`, and `latestCrawlRun`.",
         "properties": {
           "accountId": {
             "type": "string"
           },
           "domainCount": {
+            "description": "Total number of domains configured for this site.",
             "type": "number"
           },
           "id": {
             "type": "string"
           },
           "localeCount": {
+            "description": "Total number of locales configured for this site.",
             "type": "number"
           },
           "maxLocales": {
@@ -2318,6 +2321,7 @@
             ]
           },
           "serveEnabledLocaleCount": {
+            "description": "Number of configured locales where serving is currently enabled.",
             "type": "number"
           },
           "servingMode": {
@@ -2335,6 +2339,7 @@
             ]
           },
           "sourceLang": {
+            "description": "Primary source locale for the site summary. Derived from the first configured locale record; null when no locales exist.",
             "type": [
               "string",
               "null"
@@ -2357,6 +2362,7 @@
             "type": "array"
           },
           "verifiedDomainCount": {
+            "description": "Number of configured domains currently in verified status.",
             "type": "number"
           }
         },

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -2118,6 +2118,55 @@
         ],
         "type": "object"
       },
+      "SiteDashboardResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "deployments": {
+            "items": {
+              "$ref": "#/components/schemas/Deployment"
+            },
+            "type": "array"
+          },
+          "pages": {
+            "items": {
+              "$ref": "#/components/schemas/SitePageSummary"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "additionalProperties": false,
+            "properties": {
+              "hasMore": {
+                "type": "boolean"
+              },
+              "limit": {
+                "type": "number"
+              },
+              "offset": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "limit",
+              "offset",
+              "total",
+              "hasMore"
+            ],
+            "type": "object"
+          },
+          "site": {
+            "$ref": "#/components/schemas/Site"
+          }
+        },
+        "required": [
+          "site",
+          "deployments"
+        ],
+        "type": "object"
+      },
       "SiteDomain": {
         "additionalProperties": false,
         "properties": {
@@ -3818,6 +3867,7 @@
     },
     "/sites": {
       "get": {
+        "description": "Returns summary records for dashboard/navigation use. Breaking change: this response no longer includes full `Site` fields (`locales`, `domains`, `routeConfig`, `webhookUrl`, `webhookSecret`, `latestCrawlRun`). Call `GET /api/sites/{siteId}` for full site details.",
         "operationId": "sites.list",
         "responses": {
           "200": {
@@ -4416,6 +4466,148 @@
         "tags": [
           "Sites",
           "Crawl"
+        ]
+      }
+    },
+    "/sites/{siteId}/dashboard": {
+      "get": {
+        "description": "Returns a consolidated dashboard payload (site + deployments) and optional paginated pages when `includePages=true`.",
+        "operationId": "sites.dashboard.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "When true, include `pages` + `pagination` in the response. Defaults to false.",
+            "in": "query",
+            "name": "includePages",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Maximum number of pages to return when includePages=true (1-200). Defaults to 25.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "maximum": 200,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of pages to skip when includePages=true. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "deployments": [
+                    {
+                      "serveEnabled": true,
+                      "servingStatus": "inactive",
+                      "status": "string",
+                      "targetLang": "string"
+                    }
+                  ],
+                  "site": {
+                    "accountId": "string",
+                    "domains": [
+                      {
+                        "domain": "string",
+                        "status": "pending",
+                        "verificationToken": "string"
+                      }
+                    ],
+                    "id": "string",
+                    "locales": [
+                      {
+                        "serveEnabled": true,
+                        "sourceLang": "string",
+                        "targetLang": "string"
+                      }
+                    ],
+                    "maxLocales": 1,
+                    "servingMode": "strict",
+                    "sourceUrl": "string",
+                    "status": "active"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SiteDashboardResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get dashboard payload for a site",
+        "tags": [
+          "Sites"
         ]
       }
     },

--- a/content/docs/_generated/backend-playbooks.snapshot.md
+++ b/content/docs/_generated/backend-playbooks.snapshot.md
@@ -25,9 +25,11 @@ Human workflow playbooks built on top of generated operation contracts. Payload 
    - `operationId`: `agency.customers.create`
 3. List portfolio sites:
    - `operationId`: `sites.list`
-4. Update site configuration:
+4. Load consolidated site dashboard payload (detail + deployments, optional pages):
+   - `operationId`: `sites.dashboard.get`
+5. Update site configuration:
    - `operationId`: `sites.update`
-5. List discovered pages for a site:
+6. List discovered pages for a site:
    - `operationId`: `sites.pages.list`
 
 ## Playbook: Serving Access and Previews
@@ -48,6 +50,7 @@ Human workflow playbooks built on top of generated operation contracts. Payload 
 3. Create site and locale/domain onboarding records:
    - `operationId`: `sites.create`
 4. Inspect site and deployments:
+   - `operationId`: `sites.dashboard.get`
    - `operationId`: `sites.get`
    - `operationId`: `sites.deployments.list`
 

--- a/content/docs/_generated/backend-playbooks.snapshot.md
+++ b/content/docs/_generated/backend-playbooks.snapshot.md
@@ -50,6 +50,7 @@ Human workflow playbooks built on top of generated operation contracts. Payload 
 3. Create site and locale/domain onboarding records:
    - `operationId`: `sites.create`
 4. Inspect site and deployments:
+   - Recommendation: use `sites.dashboard.get` for dashboard/detail screens to minimize round trips; use `sites.get` + `sites.deployments.list` when you need separate caching or independent refresh cadence.
    - `operationId`: `sites.dashboard.get`
    - `operationId`: `sites.get`
    - `operationId`: `sites.deployments.list`

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,17 +1,17 @@
 {
-  "generatedAt": "2026-02-13T19:47:25+09:00",
+  "generatedAt": "2026-02-14T21:47:47+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
-      "bytes": 55170,
-      "sha256": "fe1ca5229e4f1cb213461c1b810ba262d507536851cd3cc2cec81be26dbdb731"
+      "bytes": 56427,
+      "sha256": "9205df1186d8f73869ea7e6768fd51b59011c239fb72f531a67485dc9c48f497"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 164185,
-      "sha256": "24e5420943285396557efcfe608aa1f89471fffb74ec8945dc0b6dbcc3a40c60"
+      "bytes": 169986,
+      "sha256": "fcd113cab18e7bdb29e759fafede70da3c6855b6771183601825a6f428fdb0c6"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
-      "bytes": 4279,
-      "sha256": "1e8c5700644777899a1927f4897c23bc16214c56af84f0d06ab2c9d88a5ca1dd"
+      "bytes": 4447,
+      "sha256": "d006e851bbb96d8c480f4fe30959e7414a5036859d57f3195fcf8f6cd3b382fa"
     }
   },
   "requiredEnv": [
@@ -20,19 +20,19 @@
   "schemaVersion": 1,
   "sourceFiles": {
     "docs/reference/API_PLAYBOOKS.md": {
-      "bytes": 4279,
-      "sha256": "1e8c5700644777899a1927f4897c23bc16214c56af84f0d06ab2c9d88a5ca1dd"
+      "bytes": 4447,
+      "sha256": "d006e851bbb96d8c480f4fe30959e7414a5036859d57f3195fcf8f6cd3b382fa"
     },
     "docs/reference/feature-catalog.generated.json": {
-      "bytes": 50402,
-      "sha256": "2634e68c75f13f84a21d30dbb256a179b8e7d52ff451a04aee1b0efa7a6c5d62"
+      "bytes": 51643,
+      "sha256": "d7dc115c724bb17520d8539641aaa0c793343cc6d2ecb10a0b192a99cce9ff7e"
     },
     "docs/reference/openapi.json": {
-      "bytes": 123539,
-      "sha256": "b66e36528efeb112547d329c98a49099bcbcaeb29e65a3c6cc5f4049a096a384"
+      "bytes": 128200,
+      "sha256": "9858109f9e8ea1ed229a23df5e1c1676a933dc81166916a546123429d69fa6d7"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-02-13T19:47:25+09:00",
+  "sourceRepoCommitTimestamp": "2026-02-14T21:47:47+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "4746399af7f736a5518aec844959390872f7dee7"
+  "sourceRepoSha": "14eb3c10401116f4d0788350369ee8e8358a774c"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-02-13T16:12:06+09:00",
+  "generatedAt": "2026-02-13T19:47:25+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 55170,
       "sha256": "fe1ca5229e4f1cb213461c1b810ba262d507536851cd3cc2cec81be26dbdb731"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 162551,
-      "sha256": "181138b40e7b24dcdd0f8a5e8e57714314251189518a2c230c55903430823213"
+      "bytes": 164185,
+      "sha256": "24e5420943285396557efcfe608aa1f89471fffb74ec8945dc0b6dbcc3a40c60"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
       "bytes": 4279,
@@ -28,11 +28,11 @@
       "sha256": "2634e68c75f13f84a21d30dbb256a179b8e7d52ff451a04aee1b0efa7a6c5d62"
     },
     "docs/reference/openapi.json": {
-      "bytes": 122307,
-      "sha256": "e822a6b041134d94b979bce72d728efa0dfbed485b3ec788e8393b9c77e335d6"
+      "bytes": 123539,
+      "sha256": "b66e36528efeb112547d329c98a49099bcbcaeb29e65a3c6cc5f4049a096a384"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-02-13T16:12:06+09:00",
+  "sourceRepoCommitTimestamp": "2026-02-13T19:47:25+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "b41333d71864b311071c1b96ab9b2c90fbc5b28b"
+  "sourceRepoSha": "4746399af7f736a5518aec844959390872f7dee7"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,17 +1,17 @@
 {
-  "generatedAt": "2026-02-14T23:22:38+09:00",
+  "generatedAt": "2026-02-14T23:52:17+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
-      "bytes": 56423,
-      "sha256": "fddac71784ec5ccb5386d991e2bcbc10038ad4f2cbe024dd75faf0d580994db0"
+      "bytes": 56427,
+      "sha256": "9205df1186d8f73869ea7e6768fd51b59011c239fb72f531a67485dc9c48f497"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 169986,
-      "sha256": "fcd113cab18e7bdb29e759fafede70da3c6855b6771183601825a6f428fdb0c6"
+      "bytes": 170682,
+      "sha256": "fc8da0eaf01a3771022c1270972fffb85df9379d6b29b7ecdb922812f710896f"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
-      "bytes": 4447,
-      "sha256": "d006e851bbb96d8c480f4fe30959e7414a5036859d57f3195fcf8f6cd3b382fa"
+      "bytes": 4654,
+      "sha256": "1668b3246c8719f78237fa6387b357d7b20266299de5ab9dd2662f82d95c93b2"
     }
   },
   "requiredEnv": [
@@ -20,19 +20,19 @@
   "schemaVersion": 1,
   "sourceFiles": {
     "docs/reference/API_PLAYBOOKS.md": {
-      "bytes": 4447,
-      "sha256": "d006e851bbb96d8c480f4fe30959e7414a5036859d57f3195fcf8f6cd3b382fa"
+      "bytes": 4654,
+      "sha256": "1668b3246c8719f78237fa6387b357d7b20266299de5ab9dd2662f82d95c93b2"
     },
     "docs/reference/feature-catalog.generated.json": {
-      "bytes": 51639,
-      "sha256": "09ce3ac8faf35770741a8b3b5bfd5936fc6d6879f04e31cdc03ad3d75956a42a"
+      "bytes": 51643,
+      "sha256": "d7dc115c724bb17520d8539641aaa0c793343cc6d2ecb10a0b192a99cce9ff7e"
     },
     "docs/reference/openapi.json": {
-      "bytes": 128200,
-      "sha256": "9858109f9e8ea1ed229a23df5e1c1676a933dc81166916a546123429d69fa6d7"
+      "bytes": 129006,
+      "sha256": "de6c60ed2f3a3310bf6a7ef39f738e555aa223b310d69b8d4a823986a8a253ee"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-02-14T23:22:38+09:00",
+  "sourceRepoCommitTimestamp": "2026-02-14T23:52:17+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "69757c36de66e337311cea1d808dee09882144a4"
+  "sourceRepoSha": "e4614836e91f000d0b49e16dc45dfaa1faab4dfd"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-02-14T21:47:47+09:00",
+  "generatedAt": "2026-02-14T23:22:38+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
-      "bytes": 56427,
-      "sha256": "9205df1186d8f73869ea7e6768fd51b59011c239fb72f531a67485dc9c48f497"
+      "bytes": 56423,
+      "sha256": "fddac71784ec5ccb5386d991e2bcbc10038ad4f2cbe024dd75faf0d580994db0"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
       "bytes": 169986,
@@ -24,15 +24,15 @@
       "sha256": "d006e851bbb96d8c480f4fe30959e7414a5036859d57f3195fcf8f6cd3b382fa"
     },
     "docs/reference/feature-catalog.generated.json": {
-      "bytes": 51643,
-      "sha256": "d7dc115c724bb17520d8539641aaa0c793343cc6d2ecb10a0b192a99cce9ff7e"
+      "bytes": 51639,
+      "sha256": "09ce3ac8faf35770741a8b3b5bfd5936fc6d6879f04e31cdc03ad3d75956a42a"
     },
     "docs/reference/openapi.json": {
       "bytes": 128200,
       "sha256": "9858109f9e8ea1ed229a23df5e1c1676a933dc81166916a546123429d69fa6d7"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-02-14T21:47:47+09:00",
+  "sourceRepoCommitTimestamp": "2026-02-14T23:22:38+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "14eb3c10401116f4d0788350369ee8e8358a774c"
+  "sourceRepoSha": "69757c36de66e337311cea1d808dee09882144a4"
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - Development Guide — `docs/DEVELOPMENT_GUIDE.md`
 - Architecture Overview — `docs/ARCHITECTURE.md`
 - Dashboard Flows & Use Cases — `docs/dashboard-flow-and-use-cases.md`
+- Dashboard Latency Remediation Report (2026-02-14) — `docs/reports/dashboard-latency-remediation-2026-02-14.md`
 - Recommended Structure Reference — `docs/recommended_structure.md`
 
 Reading order:

--- a/docs/backend/DASHBOARD_SPECS.md
+++ b/docs/backend/DASHBOARD_SPECS.md
@@ -73,7 +73,7 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
   - `id`, `sourcePath`.
   - `lastSeenAt`, `lastCrawledAt`, `lastSnapshotAt`, `nextCrawlAt`, `lastVersionAt` (ISO strings or `null`).
 - **Pagination**:
-  - Returned alongside `pages` when pagination is enabled.
+  - Returned alongside `pages` on paginated page-list responses (`GET /api/sites/:id/pages` and `GET /api/sites/:id/dashboard` when `includePages=true`).
   - `{ limit, offset, total, hasMore }`.
 - **RouteConfig**:
   - `sourceLang`, `sourceOrigin`, `pattern` (string or `null`).
@@ -134,6 +134,7 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
 - Response `201`: `{ ...site, crawlStatus }` (typically `{ enqueued: false }` until activation).
 
 `GET /api/sites` → `{ sites: SiteSummary[] }` scoped to account.
+
 - **Breaking change:** list responses are summary-only and exclude detail fields such as `locales`, `domains`, `routeConfig`, `webhookSecret`, and `verificationToken`. For full details, call `GET /api/sites/:id` or `GET /api/sites/:id/dashboard`.
 
 `GET /api/sites/:id` → `Site`.
@@ -141,7 +142,12 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
 `GET /api/sites/:id/dashboard`
 
 - Consolidated detail payload for dashboard screens.
-- Query: `includePages` (`true|false`, default `false`), `limit` (1..200), `offset` (>=0).
+- Query:
+  - `includePages` (optional boolean, default `false`).
+  - `limit` (optional integer, default `25`, valid range `1..200`; used only when `includePages=true`).
+  - `offset` (optional integer, default `0`, must be `>=0`; used only when `includePages=true`).
+  - When `includePages=false`, `limit` and `offset` are ignored.
+  - Invalid query values return `400` (for example: `includePages` not boolean, `limit` out of range, `offset` negative).
 - Response:
   - Default: `{ site, deployments }`.
   - With `includePages=true`: `{ site, deployments, pages, pagination }`.
@@ -184,7 +190,8 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
 
 `GET /api/sites/:id/pages`
 
-- Response: `{ pages: [{ id, sourcePath, lastSeenAt?, lastCrawledAt?, lastSnapshotAt?, nextCrawlAt?, lastVersionAt? }] }`.
+- Query: `limit` (optional integer, default `25`, valid range `1..200`) and `offset` (optional integer, default `0`, must be `>=0`).
+- Response: `{ pages: [{ id, sourcePath, lastSeenAt?, lastCrawledAt?, lastSnapshotAt?, nextCrawlAt?, lastVersionAt? }], pagination: { limit, offset, total, hasMore } }`.
 
 `GET /api/sites/:id/pipeline/status/:pageVersionId`
 

--- a/docs/backend/DASHBOARD_SPECS.md
+++ b/docs/backend/DASHBOARD_SPECS.md
@@ -68,6 +68,13 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
   - `id`, `accountId`, `sourceUrl`, `status`, `servingMode`, `maxLocales`, `siteProfile`.
   - List-level aggregates: `sourceLang`, `targetLangs`, `localeCount`, `serveEnabledLocaleCount`, `domainCount`, `verifiedDomainCount`.
   - Does **not** include sensitive/detail fields (`webhookSecret`, `verificationToken`, full route internals, domains/locales arrays).
+- **PageSummary**:
+  - Returned by `GET /api/sites/:id/pages` and `GET /api/sites/:id/dashboard` when `includePages=true`.
+  - `id`, `sourcePath`.
+  - `lastSeenAt`, `lastCrawledAt`, `lastSnapshotAt`, `nextCrawlAt`, `lastVersionAt` (ISO strings or `null`).
+- **Pagination**:
+  - Returned alongside `pages` when pagination is enabled.
+  - `{ limit, offset, total, hasMore }`.
 - **RouteConfig**:
   - `sourceLang`, `sourceOrigin`, `pattern` (string or `null`).
   - `locales`: `[{ lang, origin, routePrefix }]`.
@@ -127,6 +134,7 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
 - Response `201`: `{ ...site, crawlStatus }` (typically `{ enqueued: false }` until activation).
 
 `GET /api/sites` → `{ sites: SiteSummary[] }` scoped to account.
+- **Breaking change:** list responses are summary-only and exclude detail fields such as `locales`, `domains`, `routeConfig`, `webhookSecret`, and `verificationToken`. For full details, call `GET /api/sites/:id` or `GET /api/sites/:id/dashboard`.
 
 `GET /api/sites/:id` → `Site`.
 

--- a/docs/dashboard-flow-and-use-cases.md
+++ b/docs/dashboard-flow-and-use-cases.md
@@ -133,7 +133,7 @@ Workspace switcher (header):
 
 - `/accounts/me`: plan status, feature flags, quotas for the current subject account.
 - `/sites`: list sites for the current subject account.
-- `/sites/{siteId}/dashboard`: consolidated detail payload (`site + deployments`, optional paginated pages).
+- `/api/sites/{siteId}/dashboard`: consolidated detail payload (`site + deployments`, optional paginated pages).
 - `/agency/customers`: agency list and summary (plan status + active site counts + totals).
 - `/auth/token` with `subjectAccountId` for agency context switching.
 - `/sites/{siteId}/translate`: translate without recrawl.

--- a/docs/dashboard-flow-and-use-cases.md
+++ b/docs/dashboard-flow-and-use-cases.md
@@ -51,12 +51,16 @@ The current dashboard is implemented in `app/dashboard` and uses the webhooks wo
 - Overview: summary cards for active sites, unverified domains, and configured locales (`app/dashboard/page.tsx`).
 - Sites list: list + summary per site; plan + usage badges live in the shared header (`app/dashboard/sites/page.tsx`).
 - Site detail: domains, deployments, trigger crawl, glossary, overrides, slugs (`app/dashboard/sites/[id]/page.tsx`).
+- Detail data path: site detail/admin/pages routes consume consolidated `GET /api/sites/{siteId}/dashboard` payloads to avoid duplicate site + deployments fetches.
 - Feature gating: locked sections show disabled cards with upgrade CTAs instead of disappearing.
 - Onboarding: uses `maxLocales` from `/accounts/me` and blocks adding targets past the cap (`app/dashboard/sites/new/onboarding-form.tsx`).
 - Domain onboarding: handles CNAME instructions (provision/refresh) or TXT verification (`app/dashboard/sites/[id]/page.tsx`).
 - Agency surface: workspace switcher + agency overview/customers list (with filters and invite flow).
 - Auth refresh policy: dashboard exchanges Supabase tokens for webhooks JWTs server-side on each request, refreshes pre-expiry (5-minute buffer), and retries once on 401.
 - Billing policy: mutations require both actor and subject plans to be active; billing banners warn the billing owner (agency when acting as agency, customer when in own workspace) without showing agency billing warnings to customer workspaces.
+- Polling policy: `/api/dashboard/sites/[siteId]/status` returns only `{ site }` so crawl-status polling does not overfetch deployments.
+- Cache policy: sites list uses long-lived account-scoped cache; site dashboard payload uses short-TTL per-site cache with indexed invalidation for paginated variants.
+- Prefetch policy: disable implicit route prefetch on high-cardinality site links; keep prefetch only for low-cardinality/static navigation.
 
 ## Recommended UX (future)
 
@@ -129,8 +133,10 @@ Workspace switcher (header):
 
 - `/accounts/me`: plan status, feature flags, quotas for the current subject account.
 - `/sites`: list sites for the current subject account.
+- `/sites/{siteId}/dashboard`: consolidated detail payload (`site + deployments`, optional paginated pages).
 - `/agency/customers`: agency list and summary (plan status + active site counts + totals).
 - `/auth/token` with `subjectAccountId` for agency context switching.
 - `/sites/{siteId}/translate`: translate without recrawl.
 - `/sites/{siteId}/translation-runs/{runId}`: status, cancel, resume.
 - `/sites/{siteId}/locales/{targetLang}/serve`: per-locale serving toggle.
+- `/api/dashboard/sites/{siteId}/status`: polling proxy returning minimal crawl status (`{ site }`).

--- a/docs/dashboard-flow-and-use-cases.md
+++ b/docs/dashboard-flow-and-use-cases.md
@@ -58,7 +58,7 @@ The current dashboard is implemented in `app/dashboard` and uses the webhooks wo
 - Agency surface: workspace switcher + agency overview/customers list (with filters and invite flow).
 - Auth refresh policy: dashboard exchanges Supabase tokens for webhooks JWTs server-side on each request, refreshes pre-expiry (5-minute buffer), and retries once on 401.
 - Billing policy: mutations require both actor and subject plans to be active; billing banners warn the billing owner (agency when acting as agency, customer when in own workspace) without showing agency billing warnings to customer workspaces.
-- Polling policy: `/api/dashboard/sites/[siteId]/status` returns only `{ site }` so crawl-status polling does not overfetch deployments.
+- Polling policy: `/api/dashboard/sites/{siteId}/status` returns only `{ site }` so crawl-status polling does not overfetch deployments.
 - Cache policy: sites list uses long-lived account-scoped cache; site dashboard payload uses short-TTL per-site cache with indexed invalidation for paginated variants.
 - Prefetch policy: disable implicit route prefetch on high-cardinality site links; keep prefetch only for low-cardinality/static navigation.
 

--- a/docs/reports/dashboard-latency-remediation-2026-02-14.md
+++ b/docs/reports/dashboard-latency-remediation-2026-02-14.md
@@ -1,0 +1,129 @@
+# Dashboard Latency Remediation Report (2026-02-14)
+
+## Decision Summary
+
+- Full silent prefetch of all dashboard data after login is **rejected**.
+- Strategy implemented: lean critical path + consolidated detail endpoint + bounded caching + deterministic invalidation.
+
+Reasoning:
+
+1. Full silent prefetch scales poorly with many sites/routes.
+2. It increases stale-data risk and invalidation complexity.
+3. High-cardinality `Link` prefetch pressure was already a load source.
+
+## Milestone Ledger
+
+### M0 — Baseline/Attribution
+
+Pain: optimization claims drift without route-level attribution and contract lock.
+
+Implemented in this phase:
+
+- Baseline instrumentation from M14.7 remained the reference (`x-dashboard-trace-id` correlation).
+- Contract lock extended to include the new consolidated endpoint.
+
+Reviewer checks:
+
+- Website requests send `x-dashboard-trace-id`.
+- Backend wide events preserve trace IDs for correlation.
+
+### M1 — Remove Obvious Waste
+
+Pain: low-value background calls consumed budget on active sessions.
+
+Implemented:
+
+- `GET /api/dashboard/sites/[siteId]/status` now returns `{ site }` only.
+- Disabled `prefetch` on high-cardinality site links:
+  - overview list manage links
+  - per-site sidebar submenu links
+
+Reviewer checks:
+
+- Polling route no longer calls deployments.
+- Site-link prefetch is disabled where cardinality is high.
+
+### M2 — Consolidate Detail Data Path
+
+Pain: detail routes paid duplicate backend work and multiple RTTs.
+
+Implemented:
+
+- Added `GET /sites/{siteId}/dashboard` in webhooks:
+  - default: `{ site, deployments }`
+  - optional pages: `includePages=true&limit&offset`
+- Migrated dashboard route consumers:
+  - `/dashboard/sites/[id]`
+  - `/dashboard/sites/[id]/admin`
+  - `/dashboard/sites/[id]/pages`
+
+Reviewer checks:
+
+- Routes above load initial data from consolidated payload path.
+- Backend tests enforce new endpoint contract/validation.
+
+### M3 — Shell-First Direction
+
+Pain: users perceive delay before useful content.
+
+Status in this phase:
+
+- Kept middleware auth safety unchanged.
+- Focused this pass on data-path consolidation and request-count reduction first.
+- Shell-first rendering remains tracked for additional route-level streaming follow-up after new baseline capture.
+
+Reviewer checks:
+
+- No auth-boundary regressions introduced by this pass.
+
+### M4 — Deterministic Cache/Invalidation
+
+Pain: partial invalidation causes stale subviews and hidden rerender churn.
+
+Implemented:
+
+- Added short-TTL site dashboard cache (`30s`) in `internal/dashboard/data.ts`.
+- Added indexed cache-key tracking per site to invalidate all known variants (pagination offsets included).
+- Updated dashboard actions to invalidate site-dashboard cache alongside list cache when required.
+
+Reviewer checks:
+
+- Non-structural mutations invalidate detail cache without broad list churn.
+- Structural mutations still invalidate sites list + detail cache.
+
+### M5 — Contract/Docs Cutover
+
+Pain: drift between backend and website contracts creates hidden regressions.
+
+Implemented:
+
+- Synced OpenAPI snapshot from backend into website docs-generated artifacts.
+- Updated dashboard docs (`dashboard-flow-and-use-cases`, `backend/DASHBOARD_SPECS`) with:
+  - consolidated endpoint usage
+  - prefetch policy
+  - cache/invalidation policy
+
+Reviewer checks:
+
+- `test:contracts` passes with synced snapshots.
+- Docs and route behavior align for new endpoint/status contract.
+
+## Cache Invalidation Matrix (Implemented Policy)
+
+| Mutation class                                                           | Invalidate sites list | Invalidate site dashboard |
+| ------------------------------------------------------------------------ | --------------------- | ------------------------- |
+| Structural site mutations (create/update status/locales/domains/serving) | Yes                   | Yes                       |
+| Operational mutations (crawl/translate/run controls)                     | No                    | Yes                       |
+| Content mutations (glossary/override/slug)                               | No                    | Yes                       |
+
+Notes:
+
+- Sites list cache TTL remains long-lived.
+- Site dashboard cache TTL is short (`30s`) and index-backed for deterministic invalidation.
+
+## Validation Commands Run
+
+- Backend: `corepack pnpm test workers/webhooks-worker/src/index.test.ts`
+- Backend: `corepack pnpm openapi:generate`
+- Website: `WEBLINGO_REPO_PATH=../weblingo pnpm docs:sync`
+- Website: `pnpm test -- "app/api/dashboard/sites/[siteId]/status/route.test.ts" internal/dashboard/webhooks.timeout.test.ts internal/dashboard/data.test.ts app/dashboard/_components/sites-list.test.tsx app/dashboard/_components/sites-nav.test.tsx internal/dashboard/webhooks.openapi-contract.test.ts`

--- a/internal/dashboard/auth.ts
+++ b/internal/dashboard/auth.ts
@@ -20,6 +20,7 @@ import { readSubjectAccountId } from "./workspace";
 export type WebhooksAuthContext = {
   token: string;
   expiresAt: string;
+  subjectAccountId: string;
   refresh: () => Promise<string>;
 };
 
@@ -164,10 +165,12 @@ function buildWebhooksAuthContext(
   const auth: WebhooksAuthContext = {
     token: payload.token,
     expiresAt: payload.expiresAt,
+    subjectAccountId: payload.subjectAccountId,
     refresh: async () => {
       const refreshed = await exchangeWebhooksToken(supabaseAccessToken, payload.subjectAccountId);
       auth.token = refreshed.token;
       auth.expiresAt = refreshed.expiresAt;
+      auth.subjectAccountId = refreshed.subjectAccountId;
       return refreshed.token;
     },
   };

--- a/internal/dashboard/data.test.ts
+++ b/internal/dashboard/data.test.ts
@@ -121,7 +121,10 @@ describe("dashboard data caches", () => {
   });
 
   it("invalidates all indexed site dashboard cache variants", async () => {
-    redisMock.smembers.mockResolvedValue(["custom:dashboard:key:1", "custom:dashboard:key:2"]);
+    redisMock.smembers.mockResolvedValue([
+      "dashboard:site-dashboard:test:1",
+      "dashboard:site-dashboard:test:2",
+    ]);
     redisMock.del.mockResolvedValue(4);
 
     const { invalidateSiteDashboardCache } = await import("./data");
@@ -133,7 +136,10 @@ describe("dashboard data caches", () => {
     expect(redisMock.del).toHaveBeenCalledOnce();
     const deletedKeys = redisMock.del.mock.calls[0] as string[];
     expect(deletedKeys).toEqual(
-      expect.arrayContaining(["custom:dashboard:key:1", "custom:dashboard:key:2"]),
+      expect.arrayContaining([
+        "dashboard:site-dashboard:test:1",
+        "dashboard:site-dashboard:test:2",
+      ]),
     );
     expect(
       deletedKeys.filter((key) => key.startsWith("dashboard:site-dashboard:")).length,

--- a/internal/dashboard/data.test.ts
+++ b/internal/dashboard/data.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { WebhooksAuthContext } from "./auth";
+import type { SiteDashboardResponse } from "./webhooks";
+
+const redisMock = {
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+  sadd: vi.fn(),
+  smembers: vi.fn(),
+  expire: vi.fn(),
+};
+
+vi.mock("@/internal/core/redis", () => ({
+  redis: redisMock,
+}));
+
+vi.mock("./webhooks", () => ({
+  fetchSiteDashboard: vi.fn(),
+  listSites: vi.fn(),
+  listSupportedLanguages: vi.fn(),
+}));
+
+function makeAuth(subjectAccountId = "acct-1"): WebhooksAuthContext {
+  return {
+    token: "token",
+    expiresAt: "2026-01-01T00:00:00.000Z",
+    subjectAccountId,
+    refresh: async () => "token",
+  };
+}
+
+function makeDashboardPayload(): SiteDashboardResponse {
+  return {
+    site: {
+      id: "site-1",
+      accountId: "acct-1",
+      sourceUrl: "https://example.com",
+      status: "active",
+      servingMode: "strict",
+      maxLocales: null,
+      siteProfile: null,
+      locales: [],
+      domains: [],
+      latestCrawlRun: null,
+    },
+    deployments: [],
+    pages: [],
+    pagination: {
+      limit: 25,
+      offset: 0,
+      total: 0,
+      hasMore: false,
+    },
+  };
+}
+
+beforeEach(() => {
+  (process.env as Record<string, string | undefined>).NODE_ENV = "test";
+  delete process.env.VERCEL_ENV;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("dashboard data caches", () => {
+  it("fetches and indexes site dashboard payload on cache miss", async () => {
+    redisMock.get.mockResolvedValue(null);
+    redisMock.set.mockResolvedValue("OK");
+    redisMock.sadd.mockResolvedValue(1);
+    redisMock.expire.mockResolvedValue(1);
+
+    const payload = makeDashboardPayload();
+    const { fetchSiteDashboard } = await import("./webhooks");
+    const mockedFetchSiteDashboard = vi.mocked(fetchSiteDashboard);
+    mockedFetchSiteDashboard.mockResolvedValue(payload);
+
+    const { getSiteDashboardCached } = await import("./data");
+    const auth = makeAuth();
+    const result = await getSiteDashboardCached(auth, "site-1", {
+      includePages: true,
+      limit: 10,
+      offset: 20,
+    });
+
+    expect(result.site.id).toBe("site-1");
+    expect(mockedFetchSiteDashboard).toHaveBeenCalledWith(auth, "site-1", {
+      includePages: true,
+      limit: 10,
+      offset: 20,
+    });
+    expect(redisMock.set).toHaveBeenCalledWith(expect.any(String), payload, { ex: 30 });
+
+    const cacheKey = redisMock.set.mock.calls[0][0];
+    const indexKey = redisMock.sadd.mock.calls[0][0];
+    expect(typeof cacheKey).toBe("string");
+    expect(typeof indexKey).toBe("string");
+    expect(cacheKey.startsWith("dashboard:site-dashboard:")).toBe(true);
+    expect(indexKey.startsWith("dashboard:site-dashboard:index:")).toBe(true);
+    expect(redisMock.sadd).toHaveBeenCalledWith(indexKey, cacheKey);
+    expect(redisMock.expire).toHaveBeenCalledWith(indexKey, 300);
+  });
+
+  it("returns cached site dashboard payload without API fetch", async () => {
+    const payload = makeDashboardPayload();
+    redisMock.get.mockResolvedValue(payload);
+
+    const { fetchSiteDashboard } = await import("./webhooks");
+    const mockedFetchSiteDashboard = vi.mocked(fetchSiteDashboard);
+
+    const { getSiteDashboardCached } = await import("./data");
+    const result = await getSiteDashboardCached(makeAuth(), "site-1");
+
+    expect(result).toEqual(payload);
+    expect(mockedFetchSiteDashboard).not.toHaveBeenCalled();
+    expect(redisMock.set).not.toHaveBeenCalled();
+    expect(redisMock.sadd).not.toHaveBeenCalled();
+  });
+
+  it("invalidates all indexed site dashboard cache variants", async () => {
+    redisMock.smembers.mockResolvedValue(["custom:dashboard:key:1", "custom:dashboard:key:2"]);
+    redisMock.del.mockResolvedValue(4);
+
+    const { invalidateSiteDashboardCache } = await import("./data");
+    await invalidateSiteDashboardCache(makeAuth("acct-1"), "site-1");
+
+    expect(redisMock.smembers).toHaveBeenCalledWith(
+      expect.stringContaining("dashboard:site-dashboard:index:"),
+    );
+    expect(redisMock.del).toHaveBeenCalledOnce();
+    const deletedKeys = redisMock.del.mock.calls[0] as string[];
+    expect(deletedKeys).toEqual(
+      expect.arrayContaining(["custom:dashboard:key:1", "custom:dashboard:key:2"]),
+    );
+    expect(
+      deletedKeys.filter((key) => key.startsWith("dashboard:site-dashboard:")).length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(deletedKeys.some((key) => key.startsWith("dashboard:site-dashboard:index:"))).toBe(true);
+  });
+});

--- a/internal/dashboard/data.ts
+++ b/internal/dashboard/data.ts
@@ -6,18 +6,25 @@ import { redis } from "@/internal/core/redis";
 
 import type { WebhooksAuthContext } from "./auth";
 import {
+  fetchSiteDashboard,
   listSites,
   listSupportedLanguages,
+  type SiteDashboardResponse,
   type SiteSummary,
   type SupportedLanguage,
 } from "./webhooks";
 
 const SITES_CACHE_NAMESPACE = "dashboard:sites";
+const SITE_DASHBOARD_CACHE_NAMESPACE = "dashboard:site-dashboard";
+const SITE_DASHBOARD_CACHE_INDEX_NAMESPACE = "dashboard:site-dashboard:index";
 const LANGUAGES_CACHE_KEY = "dashboard:supported-languages";
 const SITES_CACHE_TTL_SECONDS = 600;
+const SITE_DASHBOARD_CACHE_TTL_SECONDS = 30;
+const SITE_DASHBOARD_CACHE_INDEX_TTL_SECONDS = 300;
 const LANGUAGES_CACHE_TTL_SECONDS = 21600;
 
 const sitesInflight = new Map<string, Promise<SiteSummary[]>>();
+const siteDashboardInflight = new Map<string, Promise<SiteDashboardResponse>>();
 const languagesInflight = new Map<string, Promise<SupportedLanguage[]>>();
 
 function getCacheEnvPrefix(): string {
@@ -34,6 +41,50 @@ function getSitesCacheKey(subjectAccountId: string): string {
 
 function getLanguagesCacheKey(): string {
   return `${LANGUAGES_CACHE_KEY}:${getCacheEnvPrefix()}`;
+}
+
+type SiteDashboardCacheOptions = {
+  includePages?: boolean;
+  limit?: number;
+  offset?: number;
+};
+
+type NormalizedSiteDashboardOptions = {
+  includePages: boolean;
+  limit: number;
+  offset: number;
+};
+
+function normalizeSiteDashboardOptions(
+  options?: SiteDashboardCacheOptions,
+): NormalizedSiteDashboardOptions {
+  const includePages = options?.includePages === true;
+  if (!includePages) {
+    return { includePages: false, limit: 25, offset: 0 };
+  }
+  return {
+    includePages,
+    limit: typeof options.limit === "number" ? options.limit : 25,
+    offset: typeof options.offset === "number" ? options.offset : 0,
+  };
+}
+
+function getSiteDashboardCacheKey(
+  subjectAccountId: string,
+  siteId: string,
+  options?: SiteDashboardCacheOptions,
+): string {
+  const normalized = normalizeSiteDashboardOptions(options);
+  const suffix = normalized.includePages
+    ? `pages:${normalized.limit}:${normalized.offset}`
+    : "pages:none";
+  const digest = hashToken(`${subjectAccountId}:${siteId}:${suffix}`);
+  return `${SITE_DASHBOARD_CACHE_NAMESPACE}:${getCacheEnvPrefix()}:${digest}`;
+}
+
+function getSiteDashboardCacheIndexKey(subjectAccountId: string, siteId: string): string {
+  const digest = hashToken(`${subjectAccountId}:${siteId}`);
+  return `${SITE_DASHBOARD_CACHE_INDEX_NAMESPACE}:${getCacheEnvPrefix()}:${digest}`;
 }
 
 export const listSitesCached = cache(async (auth: WebhooksAuthContext) => {
@@ -112,11 +163,86 @@ export const listSupportedLanguagesCached = cache(async () => {
   }
 });
 
+export const getSiteDashboardCached = cache(
+  async (
+    auth: WebhooksAuthContext,
+    siteId: string,
+    options?: SiteDashboardCacheOptions,
+  ): Promise<SiteDashboardResponse> => {
+    const normalized = normalizeSiteDashboardOptions(options);
+    const cacheKey = getSiteDashboardCacheKey(auth.subjectAccountId, siteId, normalized);
+    const indexKey = getSiteDashboardCacheIndexKey(auth.subjectAccountId, siteId);
+
+    try {
+      const cached = await redis.get<SiteDashboardResponse>(cacheKey);
+      if (cached) {
+        console.info("[dashboard] site dashboard cache hit");
+        return cached;
+      }
+    } catch (error) {
+      console.warn("[dashboard] site dashboard cache read failed:", error);
+    }
+
+    console.info("[dashboard] site dashboard cache miss");
+
+    const inflight = siteDashboardInflight.get(cacheKey);
+    if (inflight) {
+      return inflight;
+    }
+
+    const promise = (async () => {
+      const payload = await fetchSiteDashboard(auth, siteId, normalized);
+      try {
+        await redis.set(cacheKey, payload, { ex: SITE_DASHBOARD_CACHE_TTL_SECONDS });
+        await redis.sadd(indexKey, cacheKey);
+        await redis.expire(indexKey, SITE_DASHBOARD_CACHE_INDEX_TTL_SECONDS);
+      } catch (error) {
+        console.warn("[dashboard] site dashboard cache write/index failed:", error);
+      }
+      return payload;
+    })();
+
+    siteDashboardInflight.set(cacheKey, promise);
+    try {
+      return await promise;
+    } finally {
+      siteDashboardInflight.delete(cacheKey);
+    }
+  },
+);
+
 export async function invalidateSitesCache(auth: WebhooksAuthContext): Promise<void> {
   const cacheKey = getSitesCacheKey(auth.subjectAccountId);
   try {
     await redis.del(cacheKey);
   } catch (error) {
     console.warn("[dashboard] sites cache invalidate failed:", error);
+  }
+}
+
+export async function invalidateSiteDashboardCache(
+  auth: WebhooksAuthContext,
+  siteId: string,
+): Promise<void> {
+  const indexKey = getSiteDashboardCacheIndexKey(auth.subjectAccountId, siteId);
+  const keys = new Set<string>([
+    getSiteDashboardCacheKey(auth.subjectAccountId, siteId),
+    getSiteDashboardCacheKey(auth.subjectAccountId, siteId, {
+      includePages: true,
+      limit: 25,
+      offset: 0,
+    }),
+    indexKey,
+  ]);
+  try {
+    const indexedKeys = await redis.smembers<string[]>(indexKey);
+    for (const key of indexedKeys) {
+      if (typeof key === "string" && key) {
+        keys.add(key);
+      }
+    }
+    await redis.del(...Array.from(keys));
+  } catch (error) {
+    console.warn("[dashboard] site dashboard cache invalidate failed:", error);
   }
 }

--- a/internal/dashboard/webhooks.openapi-contract.test.ts
+++ b/internal/dashboard/webhooks.openapi-contract.test.ts
@@ -445,7 +445,8 @@ describe("webhooks OpenAPI contract (dashboard client)", () => {
       expect(openApiSchema).toBeTruthy();
       const paths = uniquePaths(collectZodPaths(schema));
       for (const path of paths) {
-        expect(openApiHasPath(spec, definitionsIndex, openApiSchema, path)).toBe(true);
+        const hasPath = openApiHasPath(spec, definitionsIndex, openApiSchema, path);
+        expect(hasPath, `[contracts] ${name} missing OpenAPI path: ${path.join(".")}`).toBe(true);
       }
     }
   });

--- a/internal/dashboard/webhooks.openapi-contract.test.ts
+++ b/internal/dashboard/webhooks.openapi-contract.test.ts
@@ -359,6 +359,7 @@ describe("webhooks OpenAPI contract (dashboard client)", () => {
       { path: "/sites", method: "post" },
       { path: "/sites/{siteId}", method: "get" },
       { path: "/sites/{siteId}", method: "patch" },
+      { path: "/sites/{siteId}/dashboard", method: "get" },
       { path: "/sites/{siteId}/crawl", method: "post" },
       { path: "/sites/{siteId}/translate", method: "post" },
       { path: "/sites/{siteId}/locales/{targetLang}/serve", method: "post" },
@@ -431,6 +432,7 @@ describe("webhooks OpenAPI contract (dashboard client)", () => {
         schema: __webhooksZodContracts.listDeploymentsResponseSchema,
       },
       { name: "ListSitePagesResponse", schema: __webhooksZodContracts.listSitePagesResponseSchema },
+      { name: "SiteDashboardResponse", schema: __webhooksZodContracts.siteDashboardResponseSchema },
       { name: "GlossaryResponse", schema: __webhooksZodContracts.upsertGlossaryResponseSchema },
       {
         name: "CreateOverrideResponse",

--- a/internal/dashboard/webhooks.timeout.test.ts
+++ b/internal/dashboard/webhooks.timeout.test.ts
@@ -61,6 +61,7 @@ describe("webhooks request wrapper", () => {
   });
 
   it("applies endpoint timeout profiles for list/detail/auth requests", async () => {
+    const tokenExpiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const fetchSpy = vi
       .fn()
@@ -121,7 +122,7 @@ describe("webhooks request wrapper", () => {
         return new Response(
           JSON.stringify({
             token: "wb-token",
-            expiresAt: "2026-02-13T00:00:00.000Z",
+            expiresAt: tokenExpiresAt,
             entitlements: { planType: "pro", planStatus: "active" },
             actorAccountId: "acct-1",
             subjectAccountId: "acct-1",

--- a/internal/dashboard/webhooks.timeout.test.ts
+++ b/internal/dashboard/webhooks.timeout.test.ts
@@ -59,4 +59,90 @@ describe("webhooks request wrapper", () => {
     expect(site.id).toBe("site-1");
     expect(fetchSpy).toHaveBeenCalledOnce();
   });
+
+  it("applies endpoint timeout profiles for list/detail/auth requests", async () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const fetchSpy = vi
+      .fn()
+      .mockImplementationOnce(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        expect(headers.get("Authorization")).toBe("Bearer token");
+        expect(typeof headers.get("x-dashboard-trace-id")).toBe("string");
+        return new Response(
+          JSON.stringify({
+            sites: [
+              {
+                id: "site-1",
+                accountId: "acct-1",
+                sourceUrl: "https://example.com",
+                status: "active",
+                servingMode: "strict",
+                maxLocales: null,
+                siteProfile: null,
+                sourceLang: "en",
+                targetLangs: ["fr"],
+                localeCount: 1,
+                serveEnabledLocaleCount: 1,
+                domainCount: 1,
+                verifiedDomainCount: 1,
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      })
+      .mockImplementationOnce(async () => {
+        return new Response(
+          JSON.stringify({
+            id: "site-1",
+            accountId: "acct-1",
+            sourceUrl: "https://example.com",
+            status: "active",
+            servingMode: "strict",
+            maxLocales: null,
+            siteProfile: null,
+            locales: [
+              {
+                sourceLang: "en",
+                targetLang: "fr",
+                alias: "fr",
+                serveEnabled: true,
+              },
+            ],
+            domains: [],
+            latestCrawlRun: null,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      })
+      .mockImplementationOnce(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        expect(headers.get("Authorization")).toBe("Bearer sb-token");
+        return new Response(
+          JSON.stringify({
+            token: "wb-token",
+            expiresAt: "2026-02-13T00:00:00.000Z",
+            entitlements: { planType: "pro", planStatus: "active" },
+            actorAccountId: "acct-1",
+            subjectAccountId: "acct-1",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      });
+    (globalThis as { fetch: typeof fetch }).fetch = fetchSpy as typeof fetch;
+
+    vi.resetModules();
+    const { exchangeWebhooksToken, fetchSite, listSites } = await import("./webhooks");
+
+    await listSites("token");
+    await fetchSite("token", "site-1");
+    await exchangeWebhooksToken("sb-token");
+
+    const timeoutValues = timeoutSpy.mock.calls
+      .map((call) => call[1])
+      .filter((value): value is number => typeof value === "number");
+    expect(timeoutValues).toContain(7_500);
+    expect(timeoutValues).toContain(10_000);
+    expect(timeoutValues).toContain(6_000);
+  });
 });

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -286,6 +286,15 @@ const listSitePagesResponseSchema = z
   })
   .strict();
 
+const siteDashboardResponseSchema = z
+  .object({
+    site: siteSchema,
+    deployments: z.array(deploymentSchema),
+    pages: z.array(sitePageSummarySchema).optional(),
+    pagination: listSitePagesResponseSchema.shape.pagination.optional(),
+  })
+  .strict();
+
 const featureFlagsSchema = z
   .object({
     editEnabled: z.boolean(),
@@ -442,6 +451,7 @@ export type TranslationRun = z.infer<typeof translationRunSchema>;
 export type SitePageSummary = z.infer<typeof sitePageSummarySchema>;
 export type SitePagesPagination = z.infer<typeof listSitePagesResponseSchema.shape.pagination>;
 export type SitePagesResponse = z.infer<typeof listSitePagesResponseSchema>;
+export type SiteDashboardResponse = z.infer<typeof siteDashboardResponseSchema>;
 export type GlossaryEntry = z.infer<typeof glossaryEntrySchema>;
 export type AccountMe = z.infer<typeof accountMeSchema>;
 export type SupportedLanguage = z.infer<typeof supportedLanguageSchema>;
@@ -471,6 +481,7 @@ export const __webhooksZodContracts = {
   domainResponseSchema,
   listDeploymentsResponseSchema,
   listSitePagesResponseSchema,
+  siteDashboardResponseSchema,
   glossaryResponseSchema,
   upsertGlossaryResponseSchema,
   createOverrideResponseSchema,
@@ -807,6 +818,32 @@ export async function fetchSite(auth: AuthInput, siteId: string): Promise<Site> 
     path: `/sites/${siteId}`,
     auth,
     schema: siteSchema,
+    timeoutProfile: "detail",
+  });
+}
+
+export async function fetchSiteDashboard(
+  auth: AuthInput,
+  siteId: string,
+  options?: { includePages?: boolean; limit?: number; offset?: number },
+): Promise<SiteDashboardResponse> {
+  const qs = new URLSearchParams();
+  if (typeof options?.includePages === "boolean") {
+    qs.set("includePages", String(options.includePages));
+  }
+  if (typeof options?.limit === "number") {
+    qs.set("limit", String(options.limit));
+  }
+  if (typeof options?.offset === "number") {
+    qs.set("offset", String(options.offset));
+  }
+  const path = qs.size
+    ? `/sites/${siteId}/dashboard?${qs.toString()}`
+    : `/sites/${siteId}/dashboard`;
+  return request({
+    path,
+    auth,
+    schema: siteDashboardResponseSchema,
     timeoutProfile: "detail",
   });
 }


### PR DESCRIPTION
## Summary

- Implements M14.7 dashboard latency remediation in the website app against the new summary-based `/api/sites` contract.
- Migrates dashboard list consumers (`overview`, `sites`, `sidebar`, `ops`) from full site payloads to `SiteSummary` fields.
- Changes overview rendering to shell-first streaming (`Suspense` boundaries) so first paint is no longer blocked on sites list completion.
- Introduces endpoint timeout profiles and stable `x-dashboard-trace-id` propagation in the webhooks client.
- Updates mutation UX defaults: `ActionForm` no longer refreshes routes by default; explicit refresh remains only where needed.
- Keeps cache correctness with subject-account-scoped sites cache keys and existing targeted invalidation paths.
- Adds/updates tests for refresh matrix, timeout profiles/trace headers, API status route auth context, and OpenAPI contract sync snapshots.

## Testing

- [x] `pnpm --filter @weblingo/segmenter test` → `N/A` (not applicable in this repository)
- [x] `pnpm run check`
- [x] Other: `pnpm test:contracts`
- [x] Other: `WEBLINGO_REPO_PATH=../weblingo pnpm docs:sync:check`
- [x] Other: `pnpm vitest --run components/dashboard/action-form.test.tsx internal/dashboard/webhooks.timeout.test.ts app/api/dashboard/sites/[siteId]/status/route.test.ts`
