### PR TITLE
docs: improve cross-repo capability docs discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,3 +114,17 @@ Server only:
 
 - Follow `.github/pull_request_template.md` when opening/updating PRs; keep Summary/Testing aligned with commands actually run.
 - If `gh pr edit` fails with `GraphQL: Projects (classic) ... projectCards`, patch via REST instead: `BODY="$(cat /tmp/pr_body.md)" && gh api repos/<owner>/<repo>/pulls/<number> -X PATCH --raw-field title='...' --raw-field body="$BODY"`, then verify with `gh pr view <number> --json title,body`.
+
+## Cross-Repo Capability Ownership & Discoverability
+
+For backend↔website capability alignment work (M6.5 and follow-ups), use these as first lookups:
+
+- Canonical website capability matrix/spec: `docs/backend/DASHBOARD_SPECS.md`
+- Synced backend artifacts consumed by docs: `content/docs/_generated/*`
+- Backend bridge pointer (in backend repo): `weblingo/docs/backend/DASHBOARD_SPECS.md`
+- Alignment plan/report (in backend repo): `weblingo/docs/reports/backend-dashboard-doc-sync-plan-2026-02-16.md`
+
+Operational commands:
+
+- Refresh backend docs snapshots: `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync`
+- Verify freshness + contracts: `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync:check && pnpm test:contracts`

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Ownership:
 
 - Website maintainers own `content/docs/_generated/*`, docs pages, and dashboard capability matrix updates.
 - Backend maintainers own canonical OpenAPI/feature catalog/playbooks and must notify website maintainers on user-facing contract changes.
+- Canonical website capability matrix/spec: `docs/backend/DASHBOARD_SPECS.md`.
+- Backend bridge pointer to this matrix: `weblingo/docs/backend/DASHBOARD_SPECS.md`.
 
 ## Stripe Setup
 


### PR DESCRIPTION
## Summary

- Improve cross-repo discoverability for capability/docs ownership in website contributor docs.
- Add explicit backend↔website lookup pointers and command guidance in `AGENTS.md`.
- Extend `README.md` backend docs-sync ownership section with direct links to:
  - canonical website matrix: `docs/backend/DASHBOARD_SPECS.md`
  - backend bridge pointer: `weblingo/docs/backend/DASHBOARD_SPECS.md`

## Testing

- [x] `N/A (docs-only changes; no runtime or test behavior change)`
- [x] Other: `N/A`
