### PR TITLE
docs: align website env contracts and add env-doc drift checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,14 +21,9 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_replace_me
 SUPABASE_SECRET_KEY=sb_secret_replace_me
 SUPABASE_AUTH_TIMEOUT_MS=15000
 
-# Optional analytics / logging
-LOG_LEVEL=info
-
-# Webhooks API auth/signing (webhooks-worker)
 # Public endpoint consumed by the dashboard UI. Protect with auth, CORS, and rate limits.
 NEXT_PUBLIC_WEBHOOKS_API_BASE=http://127.0.0.1:8788/api
 NEXT_PUBLIC_WEBHOOKS_API_TIMEOUT_MS=15000
-WEBHOOK_SECRET=dev_webhook_secret
 
 # Try-now previews (server-only token)
 TRY_NOW_TOKEN=dev_preview_token
@@ -54,6 +49,3 @@ WEBSITE_PREVIEW_UPSTREAM_STREAM_CONNECT_TIMEOUT_MS=15000
 # Upstash (preferred Vercel naming)
 UPSTASH_REDIS__KV_REST_API_URL=upstash_rest_url
 UPSTASH_REDIS__KV_REST_API_TOKEN=upstash_rest_token
-UPSTASH_REDIS__KV_REST_API_READ_ONLY_TOKEN=upstash_ro_token
-UPSTASH_REDIS__KV_URL=upstash_url
-UPSTASH_REDIS__REDIS_URL=redis_url

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,12 +5,12 @@
 
 ## Testing
 
-- [ ] `pnpm test`
-- [ ] `pnpm check`
-- [ ] `pnpm test:contracts`
-- [ ] `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync:check` (required when CI cross-repo token is unavailable)
+- [ ] `corepack pnpm test`
+- [ ] `corepack pnpm check`
+- [ ] `corepack pnpm test:contracts`
+- [ ] `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check` (required when CI cross-repo token is unavailable)
 
 ## Docs sync and capability matrix
 
 - [ ] Updated `docs/backend/DASHBOARD_SPECS.md` if user-facing backend capability coverage changed.
-- [ ] Ran `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync` and committed `content/docs/_generated/*` when backend HEAD advanced.
+- [ ] Ran `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync` and committed `content/docs/_generated/*` when backend HEAD advanced.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HOME_PAGE_VARIANT: expansion
-      KV_REST_API_TOKEN: dummy
-      KV_REST_API_URL: https://example.com
       UPSTASH_REDIS__KV_REST_API_TOKEN: dummy
       UPSTASH_REDIS__KV_REST_API_URL: https://example.com
       NEXT_PUBLIC_APP_URL: https://example.com
@@ -48,25 +46,25 @@ jobs:
           cache: "pnpm"
 
       - name: Install deps
-        run: pnpm install --frozen-lockfile
+        run: corepack pnpm install --frozen-lockfile
 
       - name: Audit dependencies (high+)
-        run: pnpm audit --audit-level=high --ignore-registry-errors
+        run: corepack pnpm audit --audit-level=high --ignore-registry-errors
 
       - name: License check (prod)
         run: |
           LICENSES_JSON="$(mktemp)"
-          pnpm licenses list --prod --json > "$LICENSES_JSON"
+          corepack pnpm licenses list --prod --json > "$LICENSES_JSON"
           node scripts/check-licenses.mjs "$LICENSES_JSON"
 
       - name: Unit tests
-        run: pnpm test
+        run: corepack pnpm test
 
       - name: Check (lint/format/types)
-        run: pnpm check
+        run: corepack pnpm check
 
       - name: Build
-        run: pnpm build
+        run: corepack pnpm build
 
   docs-sync-token-check:
     runs-on: ubuntu-latest
@@ -90,8 +88,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HOME_PAGE_VARIANT: expansion
-      KV_REST_API_TOKEN: dummy
-      KV_REST_API_URL: https://example.com
       UPSTASH_REDIS__KV_REST_API_TOKEN: dummy
       UPSTASH_REDIS__KV_REST_API_URL: https://example.com
       NEXT_PUBLIC_APP_URL: https://example.com
@@ -135,13 +131,13 @@ jobs:
           cache: "pnpm"
 
       - name: Install deps
-        run: pnpm install --frozen-lockfile
+        run: corepack pnpm install --frozen-lockfile
 
       - name: Docs sync freshness check
-        run: WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" pnpm docs:sync:check
+        run: WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" corepack pnpm docs:sync:check
 
       - name: Contract and docs coverage tests
-        run: pnpm test:contracts
+        run: corepack pnpm test:contracts
 
   docs-sync-fallback-guidance:
     needs: docs-sync-token-check
@@ -152,4 +148,4 @@ jobs:
         run: |
           echo "CROSS_REPO_CHECKOUT_TOKEN is not set."
           echo "Run fallback checks locally before merge:"
-          echo "WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync:check && pnpm test:contracts"
+          echo "WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check && corepack pnpm test:contracts"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,23 @@ This document guides contributors working inside the WebLingo marketing + dashbo
 - `docs/` — Updated guidance and runbooks.
 - `tests/` — Vitest + Playwright coverage.
 
+## Start Here (Codex Quick Lookup)
+
+- Env source of truth: `internal/core/env.ts` (client) and `internal/core/env-server.ts` (server).
+- Dashboard capability matrix/spec: `docs/backend/DASHBOARD_SPECS.md`.
+- Backend bridge pointer and execution report:
+  - `weblingo/docs/backend/DASHBOARD_SPECS.md`
+  - `weblingo/docs/reports/backend-dashboard-doc-sync-plan-2026-02-16.md`
+- Cross-repo docs sync commands:
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync`
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check && corepack pnpm test:contracts`
+- Minimal validation set:
+  - `corepack pnpm test:contracts`
+  - `corepack pnpm check`
+
 ## Environment Variables
 
-Define these in `.env.local` (source of truth: `internal/core/env.ts`).
+Define these in `.env.local` (source of truth: `internal/core/env.ts` + `internal/core/env-server.ts`).
 
 Client (`NEXT_PUBLIC_*`):
 
@@ -33,6 +47,7 @@ Client (`NEXT_PUBLIC_*`):
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
 - `NEXT_PUBLIC_WEBHOOKS_API_BASE` (Webhooks worker base including `/api`, e.g. `https://api.weblingo.app/api`)
+- `NEXT_PUBLIC_WEBHOOKS_API_TIMEOUT_MS`
 
 Server only:
 
@@ -64,6 +79,7 @@ Server only:
 - `WEBSITE_PREVIEW_UPSTREAM_STREAM_CONNECT_TIMEOUT_MS`
 - Redis (required):
 - `UPSTASH_REDIS__KV_REST_API_URL` + `UPSTASH_REDIS__KV_REST_API_TOKEN`
+- No legacy alias fallback names are supported in docs/CI; only canonical schema-backed Redis env names are valid.
 
 ## Development Principles
 
@@ -123,8 +139,9 @@ For backend↔website capability alignment work (M6.5 and follow-ups), use these
 - Synced backend artifacts consumed by docs: `content/docs/_generated/*`
 - Backend bridge pointer (in backend repo): `weblingo/docs/backend/DASHBOARD_SPECS.md`
 - Alignment plan/report (in backend repo): `weblingo/docs/reports/backend-dashboard-doc-sync-plan-2026-02-16.md`
+- Ownership model: roles stay split between website and backend maintainers, but one maintainer currently fulfills both roles.
 
 Operational commands:
 
-- Refresh backend docs snapshots: `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync`
-- Verify freshness + contracts: `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync:check && pnpm test:contracts`
+- Refresh backend docs snapshots: `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync`
+- Verify freshness + contracts: `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check && corepack pnpm test:contracts`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Key modules today:
 
 Internationalization is handled via the `/[locale]` segment with English, French, and Japanese dictionaries stored under `internal/i18n/messages/*`.
 
+## Codex Quick Lookup
+
+- Env source of truth: `internal/core/env.ts` (client) and `internal/core/env-server.ts` (server).
+- Dashboard capability matrix/spec: `docs/backend/DASHBOARD_SPECS.md`.
+- Backend docs snapshot sync:
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync`
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check`
+- Minimal validation for docs/capability alignment:
+  - `corepack pnpm test:contracts`
+  - `corepack pnpm check`
+
 ## Environment Variables
 
 Create `.env.local` (or configure host env) with:
@@ -61,7 +72,6 @@ WEBSITE_PREVIEW_UPSTREAM_STREAM_CONNECT_TIMEOUT_MS=15000
 # Redis (required; preferred Vercel/Upstash naming)
 UPSTASH_REDIS__KV_REST_API_URL=https://<db>.upstash.io
 UPSTASH_REDIS__KV_REST_API_TOKEN=upstash_token
-# optional: UPSTASH_REDIS__KV_REST_API_READ_ONLY_TOKEN=...
 
 # Stripe
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
@@ -87,38 +97,39 @@ NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
 
 ## Running Locally
 
-1. Install dependencies: `pnpm install`
+1. Install dependencies: `corepack pnpm install`
 2. Fill `.env.local` with the values above (set `NEXT_PUBLIC_WEBHOOKS_API_BASE` for the dashboard and `TRY_NOW_TOKEN` for previews).
    Redis credentials are required for public-form and preview rate limiting (`UPSTASH_REDIS__KV_REST_API_URL` + `UPSTASH_REDIS__KV_REST_API_TOKEN`).
-3. Start dev server: `pnpm run dev` (opens `http://localhost:3000`).
+3. Start dev server: `corepack pnpm run dev` (opens `http://localhost:3000`).
 4. Dashboard access: visit `/dashboard`, sign in via Supabase auth, then create/manage sites (calls `NEXT_PUBLIC_WEBHOOKS_API_BASE`).
-5. Validation: optional `pnpm run lint`, `pnpm run typecheck`, `pnpm run format` before committing.
+5. Validation: optional `corepack pnpm run lint`, `corepack pnpm run typecheck`, `corepack pnpm run format` before committing.
 
 ## Backend Docs Sync
 
 Website API docs use backend-synced snapshots under `content/docs/_generated`.
 
 - Refresh snapshots:
-  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync`
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync`
 - Verify snapshots are fresh (fails fast when missing/stale):
-  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync:check`
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check`
 - Contract/doc coverage tests:
-  - `pnpm test:contracts`
+  - `corepack pnpm test:contracts`
 
 `WEBLINGO_REPO_PATH` is required for sync commands. There is no fallback path.
 
 CI behavior:
 
 - When `CROSS_REPO_CHECKOUT_TOKEN` is available, `.github/workflows/ci.yml` checks out backend HEAD and runs:
-  - `WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" pnpm docs:sync:check`
-  - `pnpm test:contracts`
+  - `WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" corepack pnpm docs:sync:check`
+  - `corepack pnpm test:contracts`
 - When token access is unavailable, run this fallback locally before opening/updating a PR:
-  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync:check && pnpm test:contracts`
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check && corepack pnpm test:contracts`
 
 Ownership:
 
 - Website maintainers own `content/docs/_generated/*`, docs pages, and dashboard capability matrix updates.
 - Backend maintainers own canonical OpenAPI/feature catalog/playbooks and must notify website maintainers on user-facing contract changes.
+- Current maintainer model: one repository maintainer currently fulfills both roles.
 - Canonical website capability matrix/spec: `docs/backend/DASHBOARD_SPECS.md`.
 - Backend bridge pointer to this matrix: `weblingo/docs/backend/DASHBOARD_SPECS.md`.
 
@@ -131,7 +142,7 @@ Ownership:
 
 ## Deployment
 
-- **Build**: `pnpm run build` (Next.js static + server output).
+- **Build**: `corepack pnpm run build` (Next.js static + server output).
 - **Hosting**: Deploy to Vercel/Netlify/Fly/etc. with Node 20.9+ and set all env vars above. Ensure the hosting URL matches `NEXT_PUBLIC_APP_URL`.
 - **Rate limiting store**: Provision Upstash Redis (or compatible REST KV) and configure `UPSTASH_REDIS__KV_REST_API_URL`/`UPSTASH_REDIS__KV_REST_API_TOKEN`. This is required for waitlist/contact/preview abuse controls.
 - **Supabase**: Configure the site URL and redirect URLs in Supabase Auth settings. Provide `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`/`SUPABASE_SECRET_KEY` to the host.

--- a/docs/backend/DASHBOARD_SPECS.md
+++ b/docs/backend/DASHBOARD_SPECS.md
@@ -396,11 +396,12 @@ Legend:
 
 - **Primary owner**: Website dashboard/docs maintainers.
 - **Input owner**: Backend API/docs maintainers when user-facing capabilities change.
+- **Current maintainer model**: one repository maintainer currently fulfills both roles.
 - **Merge-time checks (required)**:
-  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync:check`
-  - `pnpm test:contracts`
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check`
+  - `corepack pnpm test:contracts`
 - **Refresh snapshots when backend HEAD advances**:
-  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync`
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync`
 - **Drift policy**: keep checks merge-time only; add periodic drift audits only if stale snapshots repeatedly bypass PR checks.
 
 ## Maintenance checklist (OpenAPI parity)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "type": "node scripts/ensure-next-types.cjs && tsc --noEmit",
     "typecheck": "pnpm run type",
     "test": "vitest run",
-    "test:contracts": "vitest run internal/dashboard/webhooks.openapi-contract.test.ts tests/docs/docs-feature-coverage.test.ts",
+    "test:contracts": "vitest run internal/dashboard/webhooks.openapi-contract.test.ts tests/docs/docs-feature-coverage.test.ts tests/docs/docs-env-contract.test.ts",
     "test:e2e": "playwright test",
     "docs:sync:tsc": "tsc --pretty false --noEmit false --skipLibCheck true --types node --module commonjs --moduleResolution node --target ES2022 --outDir .tmp/docs-sync scripts/docs-sync-shared.ts scripts/docs-sync-weblingo.ts scripts/docs-sync-check.ts",
     "docs:sync": "pnpm docs:sync:tsc && node .tmp/docs-sync/docs-sync-weblingo.js",

--- a/scripts/docs-sync-check.ts
+++ b/scripts/docs-sync-check.ts
@@ -22,7 +22,7 @@ function main(): void {
   }
 
   if (stalePaths.length > 0) {
-    const refreshCommand = `WEBLINGO_REPO_PATH=${quoteCommandPath(sourceRepoPath)} pnpm docs:sync`;
+    const refreshCommand = `WEBLINGO_REPO_PATH=${quoteCommandPath(sourceRepoPath)} corepack pnpm docs:sync`;
     throw new Error(
       `[docs:sync:check] Stale or missing synced docs artifacts:\n${stalePaths
         .sort((left, right) => left.localeCompare(right))

--- a/scripts/docs-sync-shared.ts
+++ b/scripts/docs-sync-shared.ts
@@ -74,7 +74,7 @@ export function resolveWeblingoRepoPathOrThrow(cwd = process.cwd()): string {
   const configured = process.env.WEBLINGO_REPO_PATH?.trim();
   if (!configured) {
     throw new Error(
-      "[docs-sync] WEBLINGO_REPO_PATH is required. Example: WEBLINGO_REPO_PATH=/absolute/path/to/weblingo pnpm docs:sync",
+      "[docs-sync] WEBLINGO_REPO_PATH is required. Example: WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync",
     );
   }
 

--- a/tests/docs/docs-env-contract.test.ts
+++ b/tests/docs/docs-env-contract.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readUtf8(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const REQUIRED_DOC_KEYS = [
+  "NEXT_PUBLIC_APP_URL",
+  "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
+  "NEXT_PUBLIC_POSTHOG_KEY",
+  "NEXT_PUBLIC_POSTHOG_HOST",
+  "NEXT_PUBLIC_SUPABASE_URL",
+  "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+  "NEXT_PUBLIC_WEBHOOKS_API_BASE",
+  "NEXT_PUBLIC_WEBHOOKS_API_TIMEOUT_MS",
+  "HOME_PAGE_VARIANT",
+  "PUBLIC_PORTAL_MODE",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+  "STRIPE_PRICING_TABLE_ID",
+  "STRIPE_PRICING_TABLE_ID_EN",
+  "STRIPE_PRICING_TABLE_ID_FR",
+  "STRIPE_PRICING_TABLE_ID_JA",
+  "SUPABASE_SECRET_KEY",
+  "SUPABASE_AUTH_TIMEOUT_MS",
+  "TRY_NOW_TOKEN",
+  "WEBSITE_WAITLIST_RATE_LIMIT_WINDOW_MS",
+  "WEBSITE_WAITLIST_MAX_PER_WINDOW",
+  "WEBSITE_WAITLIST_MAX_BODY_BYTES",
+  "WEBSITE_CONTACT_RATE_LIMIT_WINDOW_MS",
+  "WEBSITE_CONTACT_MAX_PER_WINDOW",
+  "WEBSITE_PREVIEW_RATE_LIMIT_WINDOW_MS",
+  "WEBSITE_PREVIEW_CREATE_MAX_PER_WINDOW",
+  "WEBSITE_PREVIEW_CREATE_MAX_PER_SOURCE_HOST_PER_WINDOW",
+  "WEBSITE_PREVIEW_STATUS_MAX_PER_WINDOW",
+  "WEBSITE_PREVIEW_STREAM_MAX_PER_WINDOW",
+  "WEBSITE_PREVIEW_MAX_BODY_BYTES",
+  "WEBSITE_PREVIEW_UPSTREAM_CREATE_TIMEOUT_MS",
+  "WEBSITE_PREVIEW_UPSTREAM_STATUS_TIMEOUT_MS",
+  "WEBSITE_PREVIEW_UPSTREAM_STREAM_CONNECT_TIMEOUT_MS",
+  "UPSTASH_REDIS__KV_REST_API_URL",
+  "UPSTASH_REDIS__KV_REST_API_TOKEN",
+] as const;
+
+const REQUIRED_CI_KEYS = [
+  "HOME_PAGE_VARIANT",
+  "PUBLIC_PORTAL_MODE",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+  "SUPABASE_SECRET_KEY",
+  "SUPABASE_AUTH_TIMEOUT_MS",
+  "NEXT_PUBLIC_APP_URL",
+  "NEXT_PUBLIC_POSTHOG_HOST",
+  "NEXT_PUBLIC_POSTHOG_KEY",
+  "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
+  "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+  "NEXT_PUBLIC_SUPABASE_URL",
+  "NEXT_PUBLIC_WEBHOOKS_API_BASE",
+  "NEXT_PUBLIC_WEBHOOKS_API_TIMEOUT_MS",
+  "WEBSITE_CONTACT_MAX_PER_WINDOW",
+  "WEBSITE_CONTACT_RATE_LIMIT_WINDOW_MS",
+  "WEBSITE_WAITLIST_MAX_BODY_BYTES",
+  "WEBSITE_WAITLIST_MAX_PER_WINDOW",
+  "WEBSITE_WAITLIST_RATE_LIMIT_WINDOW_MS",
+  "UPSTASH_REDIS__KV_REST_API_TOKEN",
+  "UPSTASH_REDIS__KV_REST_API_URL",
+] as const;
+
+const PREVIEW_KEYS = [
+  "WEBSITE_PREVIEW_RATE_LIMIT_WINDOW_MS",
+  "WEBSITE_PREVIEW_CREATE_MAX_PER_WINDOW",
+  "WEBSITE_PREVIEW_CREATE_MAX_PER_SOURCE_HOST_PER_WINDOW",
+  "WEBSITE_PREVIEW_STATUS_MAX_PER_WINDOW",
+  "WEBSITE_PREVIEW_STREAM_MAX_PER_WINDOW",
+  "WEBSITE_PREVIEW_MAX_BODY_BYTES",
+  "WEBSITE_PREVIEW_UPSTREAM_CREATE_TIMEOUT_MS",
+  "WEBSITE_PREVIEW_UPSTREAM_STATUS_TIMEOUT_MS",
+  "WEBSITE_PREVIEW_UPSTREAM_STREAM_CONNECT_TIMEOUT_MS",
+] as const;
+
+const BANNED_ALIAS_KEYS = [
+  "KV_REST_API_URL",
+  "KV_REST_API_TOKEN",
+  "UPSTASH_REDIS__KV_URL",
+  "UPSTASH_REDIS__REDIS_URL",
+  "UPSTASH_REDIS__KV_REST_API_READ_ONLY_TOKEN",
+] as const;
+
+describe("docs env contract", () => {
+  const readme = readUtf8("README.md");
+  const agents = readUtf8("AGENTS.md");
+  const envExample = readUtf8(".env.example");
+  const ciWorkflow = readUtf8(".github/workflows/ci.yml");
+  const docsCorpus = `${readme}\n${agents}\n${envExample}`;
+
+  it("documents canonical env keys used by runtime schemas", () => {
+    for (const key of REQUIRED_DOC_KEYS) {
+      expect(docsCorpus).toContain(key);
+    }
+  });
+
+  it("keeps TRY_NOW_TOKEN preview requirements explicit in docs", () => {
+    expect(docsCorpus).toContain("required when TRY_NOW_TOKEN is set");
+    for (const key of PREVIEW_KEYS) {
+      expect(docsCorpus).toContain(key);
+    }
+  });
+
+  it("keeps CI env placeholders aligned with canonical keys", () => {
+    for (const key of REQUIRED_CI_KEYS) {
+      expect(ciWorkflow).toContain(`${key}:`);
+    }
+  });
+
+  it("rejects non-canonical env aliases in docs/examples/ci", () => {
+    const allText = `${docsCorpus}\n${ciWorkflow}`;
+    for (const key of BANNED_ALIAS_KEYS) {
+      const regex = new RegExp(`(?<![A-Z0-9_])${escapeRegExp(key)}(?![A-Z0-9_])`);
+      expect(regex.test(allText)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Why:
  - Keep website env documentation and CI placeholders strictly aligned with runtime env schemas.
  - Remove legacy env alias drift and standardize contributor command UX on `corepack pnpm`.
  - Add lightweight contract coverage so env-doc drift is caught in `test:contracts`.
- What:
  - Canonicalized env docs/examples/CI keys in `README.md`, `AGENTS.md`, `.env.example`, and `.github/workflows/ci.yml`.
  - Removed legacy alias placeholders from docs/CI and kept conditional `TRY_NOW_TOKEN` preview requirements explicit.
  - Unified docs sync/contract command examples and PR template commands to `corepack pnpm`.
  - Added `tests/docs/docs-env-contract.test.ts` and wired it into `test:contracts`.
  - Updated `docs/backend/DASHBOARD_SPECS.md` ownership note for the single-maintainer model.

## Testing

- [ ] `corepack pnpm test`
- [x] `corepack pnpm check`
- [x] `corepack pnpm test:contracts`
- [ ] `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check` (required when CI cross-repo token is unavailable)

## Docs sync and capability matrix

- [x] Updated `docs/backend/DASHBOARD_SPECS.md` if user-facing backend capability coverage changed.
- [ ] Ran `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync` and committed `content/docs/_generated/*` when backend HEAD advanced.
