### PR TITLE
feat(dashboard): add deployment history and completeness observability

### DIFF
--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -1637,6 +1637,43 @@
         ],
         "type": "object"
       },
+      "DeploymentCompleteness": {
+        "additionalProperties": false,
+        "properties": {
+          "discoveredPages": {
+            "type": "number"
+          },
+          "pendingPages": {
+            "type": "number"
+          },
+          "percentage": {
+            "type": "number"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DeploymentCompletenessStatus"
+          },
+          "translatedPages": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "discoveredPages",
+          "translatedPages",
+          "pendingPages",
+          "percentage",
+          "status"
+        ],
+        "type": "object"
+      },
+      "DeploymentCompletenessStatus": {
+        "enum": [
+          "not_started",
+          "partial",
+          "complete",
+          "unknown"
+        ],
+        "type": "string"
+      },
       "DeploymentHistoryByLocale": {
         "additionalProperties": false,
         "properties": {

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -1637,6 +1637,65 @@
         ],
         "type": "object"
       },
+      "DeploymentHistoryByLocale": {
+        "additionalProperties": false,
+        "properties": {
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/DeploymentHistoryEntry"
+            },
+            "type": "array"
+          },
+          "targetLang": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "targetLang",
+          "entries"
+        ],
+        "type": "object"
+      },
+      "DeploymentHistoryEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "activatedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "artifactManifest": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "deploymentId": {
+            "type": "string"
+          },
+          "routePrefix": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "deploymentId",
+          "status"
+        ],
+        "type": "object"
+      },
       "DeploymentServingStatus": {
         "enum": [
           "inactive",


### PR DESCRIPTION
## Summary

- Why: Expose normalized backend observability data in dashboard UX and smoke coverage.
- What:
  - Add deployment history table/completeness/pages summary dashboard views with API wiring.
  - Extend dashboard smoke tests and generated backend capability snapshots used by website docs.

## Testing

- [x] `N/A (PR opened from an existing branch; no additional local test run was executed during PR orchestration)`
- [x] `N/A`
- [x] `N/A`
- [x] `N/A (cross-repo docs sync check not rerun during PR orchestration)`

## Docs sync and capability matrix

- [x] `N/A`
- [x] `N/A`
