### PR TITLE
fix(dashboard): align bootstrap account schema with backend contract

### DIFF
--- a/content/docs/_generated/backend-feature-catalog.snapshot.json
+++ b/content/docs/_generated/backend-feature-catalog.snapshot.json
@@ -49,7 +49,7 @@
         "accounts.me"
       ],
       "stability": "GA",
-      "summary": "Get current account entitlements and quotas",
+      "summary": "Returns resolved limits and counters for dashboard usage. `dailyCrawlUsage` is the single-day snapshot for `date`; `usageCounters` provides period totals (`periodStart`/`periodEnd`) and also mirrors the current-day crawl counters for convenience. `quotaLimits` are the effective enforcement limits, while `quotas` exposes raw account-configured quota fields.",
       "userFacing": true
     },
     {

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -47,8 +47,14 @@
           "planType": {
             "$ref": "#/components/schemas/AccountPlanType"
           },
+          "quotaLimits": {
+            "$ref": "#/components/schemas/AccountQuotaLimits"
+          },
           "quotas": {
             "$ref": "#/components/schemas/AccountQuotas"
+          },
+          "usageCounters": {
+            "$ref": "#/components/schemas/AccountUsageCounters"
           }
         },
         "required": [
@@ -57,6 +63,8 @@
           "planStatus",
           "featureFlags",
           "dailyCrawlUsage",
+          "usageCounters",
+          "quotaLimits",
           "quotas"
         ],
         "type": "object"
@@ -67,22 +75,39 @@
       "AccountPlanType": {
         "$ref": "#/components/schemas/PlanType"
       },
-      "AccountQuotas": {
+      "AccountQuotaLimits": {
         "additionalProperties": false,
         "properties": {
+          "dailyPageCrawls": {
+            "description": "Effective daily page-crawl cap from resolved feature flags.",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "dailySiteCrawls": {
+            "description": "Effective daily site-crawl cap from resolved feature flags.",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "maxSites": {
+            "description": "Effective max-sites limit used for enforcement/UI (resolved from account + plan defaults).",
             "type": [
               "number",
               "null"
             ]
           },
-          "proQuota": {
+          "previewRequests": {
+            "description": "Effective preview-request cap (null when unlimited/not configured).",
             "type": [
               "number",
               "null"
             ]
           },
-          "starterQuota": {
+          "translationChars": {
+            "description": "Effective translation character cap for the active plan.",
             "type": [
               "number",
               "null"
@@ -91,8 +116,93 @@
         },
         "required": [
           "maxSites",
+          "translationChars",
+          "dailySiteCrawls",
+          "dailyPageCrawls",
+          "previewRequests"
+        ],
+        "type": "object"
+      },
+      "AccountQuotas": {
+        "additionalProperties": false,
+        "properties": {
+          "freeQuota": {
+            "description": "Account-configured free-plan translation cap (`accounts.free_quota`).",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "maxSites": {
+            "description": "Account-configured max sites entitlement (`accounts.max_sites`).",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "proQuota": {
+            "description": "Account-configured pro/agency translation cap (`accounts.pro_quota`).",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "starterQuota": {
+            "description": "Account-configured starter-plan translation cap (`accounts.starter_quota`).",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "maxSites",
+          "freeQuota",
           "starterQuota",
           "proQuota"
+        ],
+        "type": "object"
+      },
+      "AccountUsageCounters": {
+        "additionalProperties": false,
+        "properties": {
+          "charsTranslated": {
+            "description": "Total translated characters during `[periodStart, periodEnd]`.",
+            "type": "number"
+          },
+          "dailyPageCrawls": {
+            "description": "Mirrors current-day `dailyCrawlUsage.pageCrawls` for dashboard convenience.",
+            "type": "number"
+          },
+          "dailySiteCrawls": {
+            "description": "Mirrors current-day `dailyCrawlUsage.siteCrawls` for dashboard convenience.",
+            "type": "number"
+          },
+          "pagesPublished": {
+            "description": "Total pages published during `[periodStart, periodEnd]`.",
+            "type": "number"
+          },
+          "periodEnd": {
+            "description": "Inclusive end date for the usage counter period (`YYYY-MM-DD`).",
+            "type": "string"
+          },
+          "periodStart": {
+            "description": "Inclusive start date for the usage counter period (`YYYY-MM-DD`).",
+            "type": "string"
+          },
+          "rebuildsTriggered": {
+            "description": "Total rebuild actions during `[periodStart, periodEnd]`.",
+            "type": "number"
+          }
+        },
+        "required": [
+          "periodStart",
+          "periodEnd",
+          "pagesPublished",
+          "charsTranslated",
+          "rebuildsTriggered",
+          "dailySiteCrawls",
+          "dailyPageCrawls"
         ],
         "type": "object"
       },
@@ -1366,12 +1476,15 @@
         "additionalProperties": false,
         "properties": {
           "date": {
+            "description": "UTC date (`YYYY-MM-DD`) for single-day crawl counters.",
             "type": "string"
           },
           "pageCrawls": {
+            "description": "Page-level crawl count for `date` only.",
             "type": "number"
           },
           "siteCrawls": {
+            "description": "Site-level crawl count for `date` only.",
             "type": "number"
           }
         },
@@ -1543,102 +1656,6 @@
             "translatedPages": 7
           }
         ],
-        "properties": {
-          "discoveredPages": {
-            "type": "number"
-          },
-          "pendingPages": {
-            "type": "number"
-          },
-          "percentage": {
-            "type": "number"
-          },
-          "status": {
-            "$ref": "#/components/schemas/DeploymentCompletenessStatus"
-          },
-          "translatedPages": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "discoveredPages",
-          "translatedPages",
-          "pendingPages",
-          "percentage",
-          "status"
-        ],
-        "type": "object"
-      },
-      "DeploymentCompletenessStatus": {
-        "enum": [
-          "not_started",
-          "partial",
-          "complete",
-          "unknown"
-        ],
-        "type": "string"
-      },
-      "DeploymentHistoryByLocale": {
-        "additionalProperties": false,
-        "properties": {
-          "entries": {
-            "items": {
-              "$ref": "#/components/schemas/DeploymentHistoryEntry"
-            },
-            "type": "array"
-          },
-          "targetLang": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "targetLang",
-          "entries"
-        ],
-        "type": "object"
-      },
-      "DeploymentHistoryEntry": {
-        "additionalProperties": false,
-        "properties": {
-          "activatedAt": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "artifactManifest": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "createdAt": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "deploymentId": {
-            "type": "string"
-          },
-          "routePrefix": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "status": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "deploymentId",
-          "status"
-        ],
-        "type": "object"
-      },
-      "DeploymentCompleteness": {
-        "additionalProperties": false,
         "properties": {
           "discoveredPages": {
             "type": "number"
@@ -4164,6 +4181,7 @@
     },
     "/accounts/me": {
       "get": {
+        "description": "Returns resolved limits and counters for dashboard usage. `dailyCrawlUsage` is the single-day snapshot for `date`; `usageCounters` provides period totals (`periodStart`/`periodEnd`) and also mirrors the current-day crawl counters for convenience. `quotaLimits` are the effective enforcement limits, while `quotas` exposes raw account-configured quota fields.",
         "operationId": "accounts.me",
         "responses": {
           "200": {
@@ -4207,10 +4225,27 @@
                   },
                   "planStatus": "active",
                   "planType": "free",
+                  "quotaLimits": {
+                    "dailyPageCrawls": 1,
+                    "dailySiteCrawls": 1,
+                    "maxSites": 1,
+                    "previewRequests": 1,
+                    "translationChars": 1
+                  },
                   "quotas": {
+                    "freeQuota": 1,
                     "maxSites": 1,
                     "proQuota": 1,
                     "starterQuota": 1
+                  },
+                  "usageCounters": {
+                    "charsTranslated": 1,
+                    "dailyPageCrawls": 1,
+                    "dailySiteCrawls": 1,
+                    "pagesPublished": 1,
+                    "periodEnd": "string",
+                    "periodStart": "string",
+                    "rebuildsTriggered": 1
                   }
                 },
                 "schema": {
@@ -4593,10 +4628,27 @@
                     },
                     "planStatus": "active",
                     "planType": "free",
+                    "quotaLimits": {
+                      "dailyPageCrawls": 1,
+                      "dailySiteCrawls": 1,
+                      "maxSites": 1,
+                      "previewRequests": 1,
+                      "translationChars": 1
+                    },
                     "quotas": {
+                      "freeQuota": 1,
                       "maxSites": 1,
                       "proQuota": 1,
                       "starterQuota": 1
+                    },
+                    "usageCounters": {
+                      "charsTranslated": 1,
+                      "dailyPageCrawls": 1,
+                      "dailySiteCrawls": 1,
+                      "pagesPublished": 1,
+                      "periodEnd": "string",
+                      "periodStart": "string",
+                      "rebuildsTriggered": 1
                     }
                   },
                   "actorAccountId": "string",

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-02-17T21:03:34+09:00",
+  "generatedAt": "2026-02-18T13:49:56+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
-      "bytes": 62898,
-      "sha256": "7ecfaf5c86418cd0ebb2e2ad68eb30e5ca25fdaa0b3746792440a700fae876f8"
+      "bytes": 63213,
+      "sha256": "2685ee1f4a7063e717e5774702d145e4fe51bc7bf72bd8b414ff77b2ccc4b68a"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 224277,
-      "sha256": "b1d6bcaee51a10cfb579944ef82e9d4633c71b4949dc55b5e83197687985ca5b"
+      "bytes": 229975,
+      "sha256": "2573e6af18636984da893561bf837d64c8385e5245c866d7dcdb5485a3b93d7d"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
       "bytes": 5940,
@@ -24,15 +24,15 @@
       "sha256": "8aa954c46e1b33ed58d9de0b79baff098342ff637cbada7857555e2681e1d241"
     },
     "docs/reference/feature-catalog.generated.json": {
-      "bytes": 57986,
-      "sha256": "1f96385e682082543fd047188349cceeec7972138c960de7f522169e472ee6d5"
+      "bytes": 58301,
+      "sha256": "66a183e2acb91f853d096f3db84d72788de8adcacb8c429f8cc335baaf21fb89"
     },
     "docs/reference/openapi.json": {
-      "bytes": 171659,
-      "sha256": "2cdbeb11d39d90c86c5100af8190cd08c1e1f32fe321bf91614ad71baa5e23ad"
+      "bytes": 177141,
+      "sha256": "b1fbdd09ef0416a0e6c400e2811045a949aff1f9b1ca65b4657171446b10cc63"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-02-17T21:03:34+09:00",
+  "sourceRepoCommitTimestamp": "2026-02-18T13:49:56+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "b52de0f1d2ad9978e364fe0fee61e6ad334cfbcf"
+  "sourceRepoSha": "b6bbe4f7e9e77ef9774b99fcd9cfb0c8714c4502"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-02-18T13:49:56+09:00",
+  "generatedAt": "2026-02-18T14:57:18+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 63213,
@@ -32,7 +32,7 @@
       "sha256": "b1fbdd09ef0416a0e6c400e2811045a949aff1f9b1ca65b4657171446b10cc63"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-02-18T13:49:56+09:00",
+  "sourceRepoCommitTimestamp": "2026-02-18T14:57:18+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "b6bbe4f7e9e77ef9774b99fcd9cfb0c8714c4502"
+  "sourceRepoSha": "d883d1c6043af0164f8da93008f40a0771c513c4"
 }

--- a/internal/dashboard/auth.ts
+++ b/internal/dashboard/auth.ts
@@ -87,6 +87,7 @@ const FALLBACK_FEATURE_FLAGS: AccountMe["featureFlags"] = {
 
 const FALLBACK_QUOTAS: AccountMe["quotas"] = {
   maxSites: null,
+  freeQuota: null,
   starterQuota: null,
   proQuota: null,
 };
@@ -112,15 +113,32 @@ type BootstrapOptions = {
 const bootstrapInflight = new Map<string, Promise<BootstrapCacheEntry>>();
 
 function buildFallbackAccount(accountId: string, entitlements: TokenEntitlements): AccountMe {
+  const today = new Date().toISOString().slice(0, 10);
   return {
     accountId,
     planType: entitlements.planType,
     planStatus: entitlements.planStatus,
     featureFlags: FALLBACK_FEATURE_FLAGS,
     dailyCrawlUsage: {
-      date: new Date().toISOString().slice(0, 10),
+      date: today,
       siteCrawls: 0,
       pageCrawls: 0,
+    },
+    usageCounters: {
+      periodStart: today,
+      periodEnd: today,
+      pagesPublished: 0,
+      charsTranslated: 0,
+      rebuildsTriggered: 0,
+      dailySiteCrawls: 0,
+      dailyPageCrawls: 0,
+    },
+    quotaLimits: {
+      maxSites: null,
+      translationChars: null,
+      dailySiteCrawls: null,
+      dailyPageCrawls: null,
+      previewRequests: null,
     },
     quotas: FALLBACK_QUOTAS,
   };
@@ -181,6 +199,7 @@ function buildWebhooksAuthContext(
 }
 
 function buildDashboardE2eMockAuth(): DashboardAuth {
+  const today = new Date().toISOString().slice(0, 10);
   const account: AccountMe = {
     accountId: DASHBOARD_E2E_ACCOUNT_ID,
     planType: "starter",
@@ -213,12 +232,29 @@ function buildDashboardE2eMockAuth(): DashboardAuth {
       featurePreview: [],
     },
     dailyCrawlUsage: {
-      date: new Date().toISOString().slice(0, 10),
+      date: today,
       siteCrawls: 1,
       pageCrawls: 3,
     },
+    usageCounters: {
+      periodStart: today,
+      periodEnd: today,
+      pagesPublished: 2,
+      charsTranslated: 500,
+      rebuildsTriggered: 1,
+      dailySiteCrawls: 1,
+      dailyPageCrawls: 3,
+    },
+    quotaLimits: {
+      maxSites: 10,
+      translationChars: 10_000,
+      dailySiteCrawls: 20,
+      dailyPageCrawls: 200,
+      previewRequests: null,
+    },
     quotas: {
       maxSites: 10,
+      freeQuota: 1,
       starterQuota: 10,
       proQuota: 50,
     },

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -596,9 +596,32 @@ const dailyCrawlUsageSchema = z
   })
   .strict();
 
+const usageCountersSchema = z
+  .object({
+    periodStart: z.string(),
+    periodEnd: z.string(),
+    pagesPublished: z.number().int().nonnegative(),
+    charsTranslated: z.number().int().nonnegative(),
+    rebuildsTriggered: z.number().int().nonnegative(),
+    dailySiteCrawls: z.number().int().nonnegative(),
+    dailyPageCrawls: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const quotaLimitsSchema = z
+  .object({
+    maxSites: z.number().int().nonnegative().nullable(),
+    translationChars: z.number().int().nonnegative().nullable(),
+    dailySiteCrawls: z.number().int().nonnegative().nullable(),
+    dailyPageCrawls: z.number().int().nonnegative().nullable(),
+    previewRequests: z.number().int().nonnegative().nullable(),
+  })
+  .strict();
+
 const quotasSchema = z
   .object({
     maxSites: z.number().int().nonnegative().nullable(),
+    freeQuota: z.number().int().nonnegative().nullable(),
     starterQuota: z.number().int().nonnegative().nullable(),
     proQuota: z.number().int().nonnegative().nullable(),
   })
@@ -611,6 +634,8 @@ const accountMeSchema = z
     planStatus: planStatusSchema,
     featureFlags: featureFlagsSchema,
     dailyCrawlUsage: dailyCrawlUsageSchema,
+    usageCounters: usageCountersSchema,
+    quotaLimits: quotaLimitsSchema,
     quotas: quotasSchema,
   })
   .strict();

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "pnpm": {
     "overrides": {
+      "fast-xml-parser": "5.3.6",
       "glob@10.4.5": "10.5.0",
       "js-yaml@4.1.0": "4.1.1",
       "preact@10.27.2": "10.27.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  fast-xml-parser: 5.3.6
   glob@10.4.5: 10.5.0
   js-yaml@4.1.0: 4.1.1
   preact@10.27.2: 10.27.3
@@ -2108,8 +2109,8 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-parser@4.5.3:
-    resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
+  fast-xml-parser@5.3.6:
+    resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
     hasBin: true
 
   fastq@1.19.1:
@@ -3418,8 +3419,8 @@ packages:
       '@types/node':
         optional: true
 
-  strnum@1.1.2:
-    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -5946,9 +5947,9 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-parser@4.5.3:
+  fast-xml-parser@5.3.6:
     dependencies:
-      strnum: 1.1.2
+      strnum: 2.1.2
 
   fastq@1.19.1:
     dependencies:
@@ -6971,7 +6972,7 @@ snapshots:
   openapi-sampler@1.6.2:
     dependencies:
       '@types/json-schema': 7.0.15
-      fast-xml-parser: 4.5.3
+      fast-xml-parser: 5.3.6
       json-pointer: 0.6.2
 
   optionator@0.9.4:
@@ -7633,7 +7634,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.2.3
 
-  strnum@1.1.2: {}
+  strnum@2.1.2: {}
 
   style-to-js@1.1.21:
     dependencies:


### PR DESCRIPTION
## Summary

- Why: Dashboard bootstrap started failing with `schema_mismatch` because backend `AccountMeResponse` added `usageCounters`, `quotaLimits`, and `quotas.freeQuota` while website Zod contracts remained strict on the older shape.
- What:
  - Updated dashboard webhooks schemas to accept the current backend bootstrap/account payload (`usageCounters`, `quotaLimits`, `freeQuota`).
  - Updated fallback + E2E mock account payload builders and synced backend-generated docs snapshots used by website contract tests.

## Testing

- [x] `N/A (full test suite not run for this targeted contract fix)`
- [x] `N/A (full check script not run; targeted validation used instead)`
- [x] `corepack pnpm test:contracts`
- [x] `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm docs:sync`

## Docs sync and capability matrix

- [x] `N/A (no user-facing dashboard capability coverage matrix change required)`
- [x] Ran `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm docs:sync` and committed `content/docs/_generated/*` updates from backend HEAD.
