### PR TITLE
feat: harden website ESLint rollout and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Unit tests
         run: corepack pnpm test
 
-      - name: Check (lint/format/types)
-        run: corepack pnpm check
+      - name: CI validation (lint/format/types/contracts)
+        run: corepack pnpm check:ci
 
       - name: Build
         run: corepack pnpm build
@@ -139,11 +139,8 @@ jobs:
       - name: Install deps
         run: corepack pnpm install --frozen-lockfile
 
-      - name: Docs sync freshness check
-        run: WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" corepack pnpm docs:sync:check
-
-      - name: Contract and docs coverage tests
-        run: corepack pnpm test:contracts
+      - name: Cross-repo validation
+        run: WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" corepack pnpm check:ci
 
   docs-sync-fallback-guidance:
     needs: docs-sync-token-check
@@ -154,4 +151,4 @@ jobs:
         run: |
           echo "CROSS_REPO_CHECKOUT_TOKEN is not set."
           echo "Run fallback checks locally before merge:"
-          echo "WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check && corepack pnpm test:contracts"
+          echo "WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm check:ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,11 @@ jobs:
       - name: Install deps
         run: corepack pnpm install --frozen-lockfile
 
-      - name: Cross-repo validation
-        run: WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" corepack pnpm check:ci
+      - name: Docs sync freshness check
+        run: WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" corepack pnpm docs:sync:check
+
+      - name: Contract and docs coverage tests
+        run: corepack pnpm test:contracts
 
   docs-sync-fallback-guidance:
     needs: docs-sync-token-check

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ Website API docs use backend-synced snapshots under `content/docs/_generated`.
 CI behavior:
 
 - When `CROSS_REPO_CHECKOUT_TOKEN` is available, `.github/workflows/ci.yml` checks out backend HEAD and runs:
-  - `WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" corepack pnpm check:ci`
+  - `WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" corepack pnpm docs:sync:check`
+  - `corepack pnpm test:contracts`
 - When token access is unavailable, run this fallback locally before opening/updating a PR:
   - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm check:ci`
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Internationalization is handled via the `/[locale]` segment with English, French
 - Minimal validation for docs/capability alignment:
   - `corepack pnpm test:contracts`
   - `corepack pnpm check`
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm check:ci`
+
+## Lint Rollout
+
+Type-aware ESLint now uses `projectService: true` for TypeScript files.
+
+- First-wave strict rules apply to `app/api/**/*.ts`, `internal/**/*.ts`, and `lib/**/*.ts`.
+- First-wave rules: `consistent-type-imports`, `no-floating-promises`, `no-misused-promises`, `no-unnecessary-condition`, and phased `strict-boolean-expressions`.
+- Broad TSX `strict-boolean-expressions` remains deferred for `components/**`, `modules/**`, route TSX files, and `internal/**/*.tsx` until ReactNode truthiness patterns are normalized.
+- `corepack pnpm check:ci` adds `test:contracts` and runs `docs:sync:check` when `WEBLINGO_REPO_PATH` is set.
 
 ## Environment Variables
 
@@ -126,10 +136,9 @@ Website API docs use backend-synced snapshots under `content/docs/_generated`.
 CI behavior:
 
 - When `CROSS_REPO_CHECKOUT_TOKEN` is available, `.github/workflows/ci.yml` checks out backend HEAD and runs:
-  - `WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" corepack pnpm docs:sync:check`
-  - `corepack pnpm test:contracts`
+  - `WEBLINGO_REPO_PATH="$GITHUB_WORKSPACE/backend" corepack pnpm check:ci`
 - When token access is unavailable, run this fallback locally before opening/updating a PR:
-  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check && corepack pnpm test:contracts`
+  - `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm check:ci`
 
 Ownership:
 

--- a/app/api/previews/[id]/route.ts
+++ b/app/api/previews/[id]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 
 import { envServer } from "@internal/core/env-server";
 import { buildErrorLogFields } from "@internal/core/error-log";

--- a/app/api/previews/[id]/stream/route.ts
+++ b/app/api/previews/[id]/stream/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from "next/server";
+import type { NextRequest } from "next/server";
 
 import { envServer } from "@internal/core/env-server";
 import { buildErrorLogFields } from "@internal/core/error-log";

--- a/app/api/previews/route.ts
+++ b/app/api/previews/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 
 import { envServer } from "@internal/core/env-server";
 import { buildErrorLogFields } from "@internal/core/error-log";

--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { createCheckoutSession } from "@internal/billing";

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import Stripe from "stripe";
+import { NextResponse, type NextRequest } from "next/server";
+import type Stripe from "stripe";
 
 import { createServiceRoleClient, fetchUserByEmail } from "@/lib/supabase/admin";
 import { verifyStripeSignature } from "@internal/billing";
@@ -290,7 +290,7 @@ function extractCustomerEmail(session: Stripe.Checkout.Session) {
   }
 
   if (
-    session.customer &&
+    session.customer != null &&
     typeof session.customer === "object" &&
     !isDeletedCustomer(session.customer)
   ) {

--- a/app/api/waitlist/route.ts
+++ b/app/api/waitlist/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { createServiceRoleClient } from "@/lib/supabase/admin";
@@ -137,5 +137,5 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unable to save signup right now" }, { status: 500 });
   }
 
-  return NextResponse.json({ ok: true, signupId: data?.id, createdAt: data?.created_at });
+  return NextResponse.json({ ok: true, signupId: data.id, createdAt: data.created_at });
 }

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -2364,10 +2364,90 @@
               "$ref": "#/components/schemas/GlossaryEntry"
             },
             "type": "array"
+          },
+          "retranslateStatus": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GlossaryRetranslateStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
           "entries"
+        ],
+        "type": "object"
+      },
+      "GlossaryRetranslateLocaleStatus": {
+        "additionalProperties": false,
+        "properties": {
+          "enqueued": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "impactedPageCount": {
+            "type": "number"
+          },
+          "impactedSegmentCount": {
+            "type": "number"
+          },
+          "reason": {
+            "enum": [
+              "no_glossary_change",
+              "no_impacted_segments",
+              "no_latest_page_versions",
+              "active_run"
+            ],
+            "type": "string"
+          },
+          "runId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "enum": [
+              "started",
+              "noop",
+              "skipped"
+            ],
+            "type": "string"
+          },
+          "targetLang": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "targetLang",
+          "status",
+          "impactedSegmentCount",
+          "impactedPageCount"
+        ],
+        "type": "object"
+      },
+      "GlossaryRetranslateStatus": {
+        "additionalProperties": false,
+        "properties": {
+          "locales": {
+            "items": {
+              "$ref": "#/components/schemas/GlossaryRetranslateLocaleStatus"
+            },
+            "type": "array"
+          },
+          "mode": {
+            "const": "targeted",
+            "type": "string"
+          }
+        },
+        "required": [
+          "mode",
+          "locales"
         ],
         "type": "object"
       },

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-03-13T18:18:21+09:00",
+  "generatedAt": "2026-03-13T21:01:01+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 64584,
       "sha256": "6fb08e2e4e90508d7b5cf94f175ff1a9c488cf2809e56d48df49267e576532cb"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 241608,
-      "sha256": "465fb7d0d3693a06ad585cd46d837cd17ddfce2b02d3968e70f223bd2e6307cf"
+      "bytes": 243509,
+      "sha256": "0c2d98855c88d392d22c87d4d2e5d5b2d227c91f86e73255c2a1e16b90eb126d"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
       "bytes": 6021,
@@ -28,11 +28,11 @@
       "sha256": "ddc6c7f4edf18fd13aef6294a6697c872b3f923a2af84e2d1641b50fb2e9ed9e"
     },
     "docs/reference/openapi.json": {
-      "bytes": 187626,
-      "sha256": "37e981b28b5227374a21a7f1ea8366098e105df2f307d2d5f065469377f12a37"
+      "bytes": 189043,
+      "sha256": "760b2113398b0990c8534831cd3c6ef283e7ffe598c0b842dafe1e2adf43d38f"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-03-13T18:18:21+09:00",
+  "sourceRepoCommitTimestamp": "2026-03-13T21:01:01+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "297c1f0fa048205cb685fb72c4a1f8e2050163b7"
+  "sourceRepoSha": "9b03d496f95a88b030a2f47edb28fc881076f117"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-13T21:01:01+09:00",
+  "generatedAt": "2026-03-13T21:23:50+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 64584,
@@ -32,7 +32,7 @@
       "sha256": "760b2113398b0990c8534831cd3c6ef283e7ffe598c0b842dafe1e2adf43d38f"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-03-13T21:01:01+09:00",
+  "sourceRepoCommitTimestamp": "2026-03-13T21:23:50+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "9b03d496f95a88b030a2f47edb28fc881076f117"
+  "sourceRepoSha": "cd15365db1bdfc8de79e218e2487e3971f3e1059"
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,28 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import tseslint from "typescript-eslint";
+
+const testFiles = [
+  "**/*.test.{ts,tsx,js,jsx}",
+  "**/*.spec.{ts,tsx,js,jsx}",
+  "tests/**/*.{ts,tsx,js,jsx}",
+];
+
+const firstWaveStrictFiles = ["app/api/**/*.ts", "internal/**/*.ts", "lib/**/*.ts"];
+
+const strictBooleanExpressionsRule = [
+  "error",
+  {
+    allowString: true,
+    allowNumber: true,
+    allowNullableObject: true,
+    allowNullableBoolean: false,
+    allowNullableString: true,
+    allowNullableNumber: true,
+    allowAny: false,
+  },
+];
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -13,6 +35,19 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     "types/database.ts",
   ]),
+  {
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tseslint.plugin,
+    },
+  },
   {
     files: [
       "app/api/**/*.{ts,tsx,js,jsx}",
@@ -34,6 +69,47 @@ const eslintConfig = defineConfig([
     files: ["internal/core/fetch-timeout.ts"],
     rules: {
       "no-restricted-syntax": "off",
+    },
+  },
+  {
+    files: firstWaveStrictFiles,
+    ignores: testFiles,
+    rules: {
+      "@typescript-eslint/consistent-type-imports": "error",
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": [
+        "error",
+        {
+          checksVoidReturn: {
+            arguments: false,
+            attributes: false,
+          },
+        },
+      ],
+      "@typescript-eslint/no-unnecessary-condition": "error",
+      "@typescript-eslint/strict-boolean-expressions": strictBooleanExpressionsRule,
+    },
+  },
+  {
+    files: [
+      "app/**/*.{tsx,jsx}",
+      "components/**/*.{tsx,jsx}",
+      "modules/**/*.{tsx,jsx}",
+      "internal/**/*.tsx",
+    ],
+    rules: {
+      "@typescript-eslint/strict-boolean-expressions": "off",
+    },
+  },
+  {
+    files: testFiles,
+    rules: {
+      "@typescript-eslint/consistent-type-imports": "off",
+      "@typescript-eslint/no-floating-promises": "off",
+      "@typescript-eslint/no-misused-promises": "off",
+      "@typescript-eslint/no-unnecessary-condition": "off",
+      "@typescript-eslint/strict-boolean-expressions": "off",
+      "@typescript-eslint/switch-exhaustiveness-check": "off",
     },
   },
 ]);

--- a/internal/core/body.ts
+++ b/internal/core/body.ts
@@ -41,14 +41,12 @@ export async function readJsonBodyLimited(
   let text = "";
 
   try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) {
         break;
       }
-      if (!value) {
-        continue;
-      }
+      const value = chunk.value;
 
       total += value.byteLength;
       if (total > options.maxBytes) {

--- a/internal/core/fetch-timeout.ts
+++ b/internal/core/fetch-timeout.ts
@@ -18,9 +18,7 @@ export async function fetchWithTimeout(
   }
 
   const controller = new AbortController();
-  let timedOut = false;
   const timer = setTimeout(() => {
-    timedOut = true;
     controller.abort();
   }, timeoutMs);
 
@@ -36,7 +34,7 @@ export async function fetchWithTimeout(
   try {
     return await fetch(input, { ...init, signal: controller.signal });
   } catch (error) {
-    if (timedOut) {
+    if (controller.signal.aborted && callerSignal?.aborted !== true) {
       throw new FetchTimeoutError();
     }
     throw error;

--- a/internal/core/fetch-timeout.ts
+++ b/internal/core/fetch-timeout.ts
@@ -18,7 +18,9 @@ export async function fetchWithTimeout(
   }
 
   const controller = new AbortController();
+  const timeoutState = { timedOut: false };
   const timer = setTimeout(() => {
+    timeoutState.timedOut = true;
     controller.abort();
   }, timeoutMs);
 
@@ -34,7 +36,7 @@ export async function fetchWithTimeout(
   try {
     return await fetch(input, { ...init, signal: controller.signal });
   } catch (error) {
-    if (controller.signal.aborted && callerSignal?.aborted !== true) {
+    if (timeoutState.timedOut) {
       throw new FetchTimeoutError();
     }
     throw error;

--- a/internal/dashboard/auth.ts
+++ b/internal/dashboard/auth.ts
@@ -149,7 +149,13 @@ function normalizeSubjectAccountId(subjectAccountId?: string | null): string {
 }
 
 function getCacheEnvPrefix(): string {
-  return process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown";
+  if (typeof process.env.VERCEL_ENV === "string") {
+    return process.env.VERCEL_ENV;
+  }
+  if (typeof process.env.NODE_ENV === "string") {
+    return process.env.NODE_ENV;
+  }
+  return "unknown";
 }
 
 function getBootstrapCacheKey(

--- a/internal/dashboard/data.ts
+++ b/internal/dashboard/data.ts
@@ -34,7 +34,13 @@ function shouldBypassDashboardCache(): boolean {
 }
 
 function getCacheEnvPrefix(): string {
-  return process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "unknown";
+  if (typeof process.env.VERCEL_ENV === "string") {
+    return process.env.VERCEL_ENV;
+  }
+  if (typeof process.env.NODE_ENV === "string") {
+    return process.env.NODE_ENV;
+  }
+  return "unknown";
 }
 
 function hashToken(token: string): string {

--- a/internal/dashboard/entitlements.ts
+++ b/internal/dashboard/entitlements.ts
@@ -105,7 +105,7 @@ export function check(
 
   if ("feature" in requirement) {
     const key = FEATURE_FLAG_BY_FEATURE[requirement.feature];
-    return account.featureFlags[key]
+    return account.featureFlags[key] === true
       ? ({ ok: true } as const)
       : ({ ok: false, reason: { kind: "feature", feature: requirement.feature } } as const);
   }

--- a/internal/dashboard/site-settings.ts
+++ b/internal/dashboard/site-settings.ts
@@ -257,7 +257,7 @@ export function buildSiteSettingsUpdatePayload(
     payload.siteProfile = siteProfile;
   }
 
-  if (!Object.keys(payload).length) {
+  if (Object.keys(payload).length === 0) {
     return { ok: false, error: "No editable changes submitted." };
   }
 
@@ -267,7 +267,7 @@ export function buildSiteSettingsUpdatePayload(
 export function parseJsonObject(input: string): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(input);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
       return null;
     }
     if (Object.keys(parsed).length === 0) {
@@ -297,7 +297,7 @@ function parseSpaRefreshFallback(
   value: FormDataEntryValue | null,
   context: string,
 ): SpaRefreshFallback {
-  if (!value) {
+  if (value === null) {
     return "globalOnly";
   }
   const normalized = value.toString().trim();
@@ -308,7 +308,7 @@ function parseSpaRefreshFallback(
 }
 
 function parseSpaRefreshBoolean(value: FormDataEntryValue | null): boolean {
-  if (!value) {
+  if (value === null) {
     return false;
   }
   const normalized = value.toString().trim();
@@ -321,7 +321,7 @@ export function parseLocaleAliases(
   raw: string,
   targetLangs: string[],
 ): Record<string, string | null> | string | null {
-  if (!raw) {
+  if (raw.length === 0) {
     return null;
   }
   let parsed: unknown;
@@ -330,7 +330,7 @@ export function parseLocaleAliases(
   } catch {
     return "Locale aliases must be valid JSON.";
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
     return "Locale aliases must be an object.";
   }
   const targetSet = new Set(targetLangs);

--- a/internal/dashboard/use-poll.ts
+++ b/internal/dashboard/use-poll.ts
@@ -71,6 +71,9 @@ export function usePoll<T>(options: UsePollOptions<T>): PollState<T> {
         setError(nextError);
         console.error("[dashboard] usePoll fetch failed:", err);
       }
+      if (isInactive()) {
+        return;
+      }
       timeoutId = setTimeout(() => {
         void tick();
       }, intervalMs);

--- a/internal/dashboard/use-poll.ts
+++ b/internal/dashboard/use-poll.ts
@@ -45,12 +45,16 @@ export function usePoll<T>(options: UsePollOptions<T>): PollState<T> {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     let inFlightToken = 0;
     setIsPolling(true);
+    const isInactive = () => active === false;
 
     const tick = async () => {
+      if (isInactive()) {
+        return;
+      }
       const token = (inFlightToken += 1);
       try {
         const nextValue = await fetcherRef.current();
-        if (!active || token !== inFlightToken) {
+        if (isInactive() || token !== inFlightToken) {
           return;
         }
         setValue(nextValue);
@@ -60,17 +64,16 @@ export function usePoll<T>(options: UsePollOptions<T>): PollState<T> {
           return;
         }
       } catch (err) {
-        if (!active || token !== inFlightToken) {
+        if (isInactive() || token !== inFlightToken) {
           return;
         }
         const nextError = err instanceof Error ? err : new Error("Unable to refresh status.");
         setError(nextError);
         console.error("[dashboard] usePoll fetch failed:", err);
       }
-      if (!active) {
-        return;
-      }
-      timeoutId = setTimeout(tick, intervalMs);
+      timeoutId = setTimeout(() => {
+        void tick();
+      }, intervalMs);
     };
 
     void tick();

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -450,6 +450,7 @@ const glossaryRetranslateStatusSchema = z
 const glossaryResponseSchema = z
   .object({
     entries: z.array(glossaryEntrySchema),
+    crawlStatus: crawlStatusSchema.nullable().optional(),
     retranslateStatus: glossaryRetranslateStatusSchema.nullable().optional(),
   })
   .strict();

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -430,8 +430,12 @@ const glossaryRetranslateLocaleStatusSchema = z
   .object({
     targetLang: z.string(),
     status: z.enum(["started", "noop", "skipped"]),
+    enqueued: z.number().int().nonnegative().nullable().optional(),
     impactedSegmentCount: z.number().int().nonnegative(),
     impactedPageCount: z.number().int().nonnegative(),
+    reason: z
+      .enum(["no_glossary_change", "no_impacted_segments", "no_latest_page_versions", "active_run"])
+      .optional(),
     runId: z.string().nullable().optional(),
   })
   .strict();

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -39,6 +39,14 @@ const errorResponseSchema = z.object({
   details: z.unknown().optional(),
 });
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function getBodyRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
 const planTypeSchema = z.enum(["free", "starter", "pro", "agency"]);
 const planStatusSchema = z.enum(["active", "past_due", "cancelled"]);
 
@@ -1129,26 +1137,21 @@ function resolveDashboardE2eMockPayload(input: {
 
   const siteMatch = pathname.match(/^\/sites\/([^/]+)$/);
   if (siteMatch && method === "GET") {
-    return createDashboardE2eMockSite(siteMatch[1] ?? DASHBOARD_E2E_MOCK_SITE_ID);
+    return createDashboardE2eMockSite(siteMatch[1]);
   }
   if (siteMatch && method === "PATCH") {
-    return createDashboardE2eMockSite(siteMatch[1] ?? DASHBOARD_E2E_MOCK_SITE_ID);
+    return createDashboardE2eMockSite(siteMatch[1]);
   }
 
   const siteDashboardMatch = pathname.match(/^\/sites\/([^/]+)\/dashboard$/);
   if (siteDashboardMatch && method === "GET") {
-    return createDashboardE2eMockDashboardPayload(
-      siteDashboardMatch[1] ?? DASHBOARD_E2E_MOCK_SITE_ID,
-      url.searchParams,
-    );
+    return createDashboardE2eMockDashboardPayload(siteDashboardMatch[1], url.searchParams);
   }
 
   const deploymentsMatch = pathname.match(/^\/sites\/([^/]+)\/deployments$/);
   if (deploymentsMatch && method === "GET") {
     return {
-      deployments: createDashboardE2eMockDeployments(
-        deploymentsMatch[1] ?? DASHBOARD_E2E_MOCK_SITE_ID,
-      ),
+      deployments: createDashboardE2eMockDeployments(deploymentsMatch[1]),
     };
   }
 
@@ -1167,7 +1170,7 @@ function resolveDashboardE2eMockPayload(input: {
     const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.floor(limitRaw) : 100;
     const offset = Number.isFinite(offsetRaw) && offsetRaw >= 0 ? Math.floor(offsetRaw) : 0;
     return {
-      siteId: consistencyCpmMatch[1] ?? DASHBOARD_E2E_MOCK_SITE_ID,
+      siteId: consistencyCpmMatch[1],
       sourceLang: "en",
       targetLang,
       limit,
@@ -1192,15 +1195,14 @@ function resolveDashboardE2eMockPayload(input: {
   }
 
   if (consistencyCpmMatch && method === "PUT") {
-    const payload =
-      input.body && typeof input.body === "object" ? (input.body as Record<string, unknown>) : {};
+    const payload = getBodyRecord(input.body);
     const entries = Array.isArray(payload.entries)
-      ? payload.entries.filter((value): value is Record<string, unknown> => Boolean(value))
+      ? payload.entries.filter((value): value is Record<string, unknown> => isRecord(value))
       : [];
     const first = entries[0] ?? {};
     const targetLang = typeof payload.targetLang === "string" ? payload.targetLang : "fr";
     return {
-      siteId: consistencyCpmMatch[1] ?? DASHBOARD_E2E_MOCK_SITE_ID,
+      siteId: consistencyCpmMatch[1],
       sourceLang: typeof payload.sourceLang === "string" ? payload.sourceLang : "en",
       targetLang,
       upserted: [
@@ -1227,7 +1229,7 @@ function resolveDashboardE2eMockPayload(input: {
   const consistencyBlocksListMatch = pathname.match(/^\/sites\/([^/]+)\/consistency\/blocks$/);
   if (consistencyBlocksListMatch && method === "GET") {
     return {
-      siteId: consistencyBlocksListMatch[1] ?? DASHBOARD_E2E_MOCK_SITE_ID,
+      siteId: consistencyBlocksListMatch[1],
       statusFilter: [] as const,
       blocks: [
         {
@@ -1253,8 +1255,7 @@ function resolveDashboardE2eMockPayload(input: {
     /^\/sites\/([^/]+)\/consistency\/blocks\/([^/]+)$/,
   );
   if (consistencyBlockUpdateMatch && method === "PUT") {
-    const payload =
-      input.body && typeof input.body === "object" ? (input.body as Record<string, unknown>) : {};
+    const payload = getBodyRecord(input.body);
     const members = Array.isArray(payload.members)
       ? payload.members
           .filter((value): value is string => typeof value === "string")
@@ -1268,9 +1269,9 @@ function resolveDashboardE2eMockPayload(input: {
           { id: "member-2", contentId: "cid_demo_pricing", position: 1 },
         ];
     return {
-      siteId: consistencyBlockUpdateMatch[1] ?? DASHBOARD_E2E_MOCK_SITE_ID,
+      siteId: consistencyBlockUpdateMatch[1],
       block: {
-        id: decodeURIComponent(consistencyBlockUpdateMatch[2] ?? "block-nav"),
+        id: decodeURIComponent(consistencyBlockUpdateMatch[2]),
         blockType: "nav",
         blockSignature: "nav-signature",
         familySignature: "nav-family",
@@ -1297,7 +1298,7 @@ function resolveDashboardE2eMockPayload(input: {
     const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.floor(limitRaw) : 100;
     const offset = Number.isFinite(offsetRaw) && offsetRaw >= 0 ? Math.floor(offsetRaw) : 0;
     return {
-      siteId: overrideHygieneMatch[1] ?? DASHBOARD_E2E_MOCK_SITE_ID,
+      siteId: overrideHygieneMatch[1],
       sourceLang: "en",
       targetLang,
       limit,
@@ -1328,8 +1329,7 @@ function resolveDashboardE2eMockPayload(input: {
 
   const crawlTranslateMatch = pathname.match(/^\/sites\/([^/]+)\/crawl-translate$/);
   if (crawlTranslateMatch && method === "POST") {
-    const payload =
-      input.body && typeof input.body === "object" ? (input.body as Record<string, unknown>) : {};
+    const payload = getBodyRecord(input.body);
     const targetLangs = Array.isArray(payload.targetLangs)
       ? payload.targetLangs.filter((value): value is string => typeof value === "string")
       : ["fr"];
@@ -1344,14 +1344,13 @@ function resolveDashboardE2eMockPayload(input: {
 
   const translateMatch = pathname.match(/^\/sites\/([^/]+)\/translate$/);
   if (translateMatch && method === "POST") {
-    const payload =
-      input.body && typeof input.body === "object" ? (input.body as Record<string, unknown>) : {};
+    const payload = getBodyRecord(input.body);
     const targetLang = typeof payload.targetLang === "string" ? payload.targetLang : "fr";
     const now = new Date().toISOString();
     return {
       run: {
         id: `run-${targetLang}-smoke`,
-        siteId: translateMatch[1] ?? DASHBOARD_E2E_MOCK_SITE_ID,
+        siteId: translateMatch[1],
         targetLang,
         status: "in_progress",
         pagesTotal: 2,
@@ -1375,10 +1374,9 @@ function resolveDashboardE2eMockPayload(input: {
 
   const serveToggleMatch = pathname.match(/^\/sites\/([^/]+)\/locales\/([^/]+)\/serve$/);
   if (serveToggleMatch && method === "POST") {
-    const payload =
-      input.body && typeof input.body === "object" ? (input.body as Record<string, unknown>) : {};
+    const payload = getBodyRecord(input.body);
     const enabled = payload.enabled === true;
-    const targetLang = decodeURIComponent(serveToggleMatch[2] ?? "fr");
+    const targetLang = decodeURIComponent(serveToggleMatch[2]);
     return {
       targetLang,
       serveEnabled: enabled,
@@ -1391,7 +1389,7 @@ function resolveDashboardE2eMockPayload(input: {
     /^\/sites\/([^/]+)\/domains\/([^/]+)\/(verify|provision|refresh)$/,
   );
   if (domainMatch && method === "POST") {
-    const domain = decodeURIComponent(domainMatch[2] ?? "pending.example.test");
+    const domain = decodeURIComponent(domainMatch[2]);
     const action = domainMatch[3];
     const now = new Date().toISOString();
     const status =
@@ -1451,6 +1449,7 @@ async function request<T>({
   let loggedTiming = false;
   const traceId = inputTraceId ?? buildDashboardTraceId();
   const timeoutMs = REQUEST_TIMEOUT_MS[timeoutProfile];
+  const hasBody = body !== undefined;
   const logTiming = (status: number, ok: boolean, note?: string) => {
     if (loggedTiming) {
       return;
@@ -1505,11 +1504,11 @@ async function request<T>({
       method,
       headers: {
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        ...(body ? { "Content-Type": "application/json" } : {}),
+        ...(hasBody ? { "Content-Type": "application/json" } : {}),
         "x-dashboard-trace-id": traceId,
         ...headers,
       },
-      body: body ? JSON.stringify(body) : undefined,
+      body: hasBody ? JSON.stringify(body) : undefined,
       cache: "no-store",
       signal: controller.signal,
     });
@@ -1553,12 +1552,12 @@ async function request<T>({
       }
     }
     logTiming(response.status, false);
-    const parsedError = parsed ? errorResponseSchema.safeParse(parsed) : null;
+    const parsedError = parsed === undefined ? null : errorResponseSchema.safeParse(parsed);
     const message =
-      parsedError?.success && parsedError.data.error
+      parsedError?.success === true
         ? parsedError.data.error
         : `Request failed with status ${response.status}`;
-    const details = parsedError?.success ? parsedError.data.details : (parsed ?? undefined);
+    const details = parsedError?.success === true ? parsedError.data.details : parsed;
     throw new WebhooksApiError(message, response.status, details);
   }
 
@@ -1586,7 +1585,7 @@ async function request<T>({
   return result.data;
 }
 
-function safeParseJson(input: string) {
+function safeParseJson(input: string): unknown | undefined {
   try {
     return JSON.parse(input);
   } catch {
@@ -1595,7 +1594,7 @@ function safeParseJson(input: string) {
 }
 
 function normalizeAuth(auth?: AuthInput): WebhooksAuth | null {
-  if (!auth) {
+  if (auth == null) {
     return null;
   }
   if (typeof auth === "string") {
@@ -1637,11 +1636,16 @@ export async function fetchDashboardBootstrap(
   supabaseAccessToken: string,
   payload?: { subjectAccountId?: string | null; includeAgencyCustomers?: boolean },
 ): Promise<DashboardBootstrapResponse> {
+  const subjectAccountId =
+    typeof payload?.subjectAccountId === "string" && payload.subjectAccountId.length > 0
+      ? payload.subjectAccountId
+      : undefined;
+  const includeAgencyCustomers = payload?.includeAgencyCustomers === true;
   const body =
-    payload && (payload.subjectAccountId || payload.includeAgencyCustomers)
+    subjectAccountId !== undefined || includeAgencyCustomers
       ? {
-          subjectAccountId: payload.subjectAccountId ?? undefined,
-          includeAgencyCustomers: payload.includeAgencyCustomers ?? undefined,
+          subjectAccountId,
+          includeAgencyCustomers: includeAgencyCustomers ? true : undefined,
         }
       : undefined;
   return request({
@@ -1807,7 +1811,7 @@ export async function triggerCrawl(
     path: `/sites/${siteId}/crawl${searchParams.toString() ? `?${searchParams}` : ""}`,
     method: "POST",
     auth,
-    body: options?.force ? { force: true } : undefined,
+    body: options?.force === true ? { force: true } : undefined,
     schema: crawlStatusSchema,
   });
 }

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -426,7 +426,29 @@ const glossaryEntrySchema = z.object({
   scope: z.enum(["segment", "in_segment"]).optional(),
 });
 
-const glossaryResponseSchema = z.object({ entries: z.array(glossaryEntrySchema) });
+const glossaryRetranslateLocaleStatusSchema = z
+  .object({
+    targetLang: z.string(),
+    status: z.enum(["started", "noop", "skipped"]),
+    impactedSegmentCount: z.number().int().nonnegative(),
+    impactedPageCount: z.number().int().nonnegative(),
+    runId: z.string().nullable().optional(),
+  })
+  .strict();
+
+const glossaryRetranslateStatusSchema = z
+  .object({
+    mode: z.literal("targeted"),
+    locales: z.array(glossaryRetranslateLocaleStatusSchema),
+  })
+  .strict();
+
+const glossaryResponseSchema = z
+  .object({
+    entries: z.array(glossaryEntrySchema),
+    retranslateStatus: glossaryRetranslateStatusSchema.nullable().optional(),
+  })
+  .strict();
 
 const consistencyStatusSchema = z.enum(["proposed", "approved", "frozen"]);
 const consistencyBlockModeSchema = z.enum(["strict", "prefer"]);
@@ -731,6 +753,7 @@ const upsertGlossaryResponseSchema = z
   .object({
     entries: z.array(glossaryEntrySchema),
     crawlStatus: crawlStatusSchema.nullable().optional(),
+    retranslateStatus: glossaryRetranslateStatusSchema.nullable().optional(),
   })
   .strict();
 

--- a/internal/dashboard/workspace.ts
+++ b/internal/dashboard/workspace.ts
@@ -4,7 +4,7 @@ export const SUBJECT_ACCOUNT_COOKIE = "weblingo_dashboard_subject";
 
 export async function readSubjectAccountId(): Promise<string | null> {
   const cookieStore = await cookies();
-  const value = cookieStore.get(SUBJECT_ACCOUNT_COOKIE)?.value?.trim();
+  const value = cookieStore.get(SUBJECT_ACCOUNT_COOKIE)?.value.trim();
   if (!value || value === "undefined" || value === "null") {
     return null;
   }

--- a/internal/i18n/client.ts
+++ b/internal/i18n/client.ts
@@ -2,8 +2,8 @@ export type ClientMessages = Record<string, string>;
 
 export function createClientTranslator(messages: ClientMessages) {
   return (key: string, fallback?: string, vars?: Record<string, string>) => {
-    const template = messages[key] ?? fallback ?? key;
-    if (!vars) return template;
+    const template = key in messages ? messages[key] : (fallback ?? key);
+    if (vars == null) return template;
     return Object.entries(vars).reduce(
       (acc, [varKey, value]) => acc.replace(new RegExp(`{${varKey}}`, "g"), value),
       template,

--- a/internal/i18n/server.ts
+++ b/internal/i18n/server.ts
@@ -79,8 +79,8 @@ export type Translator = (key: string, fallback?: string, vars?: Record<string, 
 
 export function createTranslator(messages: Messages): Translator {
   return (key, fallback, vars) => {
-    const template = messages[key] ?? fallback ?? key;
-    if (!vars) return template;
+    const template = key in messages ? messages[key] : (fallback ?? key);
+    if (vars == null) return template;
     return Object.entries(vars).reduce(
       (acc, [varKey, value]) => acc.replace(new RegExp(`{${varKey}}`, "g"), value),
       template,

--- a/internal/previews/preview-sse.ts
+++ b/internal/previews/preview-sse.ts
@@ -67,7 +67,7 @@ export function hasExplicitFailure(payload: Record<string, unknown>): boolean {
   if (isPreviewErrorCode(payload.errorCode) || payload.errorStage != null) {
     return true;
   }
-  if (payload.details && typeof payload.details === "object") {
+  if (payload.details != null && typeof payload.details === "object") {
     const details = payload.details as Record<string, unknown>;
     if (isPreviewErrorCode(details.errorCode) || details.errorStage != null) {
       return true;

--- a/internal/previews/status-center-store.ts
+++ b/internal/previews/status-center-store.ts
@@ -169,14 +169,14 @@ export function parsePreviewStatusCenterRequestKey(
 ): ParsedPreviewStatusCenterRequestKey | null {
   if (requestKey.startsWith(PREVIEW_STATUS_CENTER_REQUEST_KEY_PREFIX)) {
     const encoded = requestKey.slice(PREVIEW_STATUS_CENTER_REQUEST_KEY_PREFIX.length);
-    const [sourceUrl, sourceLang, targetLang, email, ...rest] = encoded.split("|");
+    const [sourceUrl, sourceLang, targetLang, email = "", ...rest] = encoded.split("|");
     if (!sourceUrl || !sourceLang || !targetLang || rest.length > 0) {
       return null;
     }
     const decodedSourceUrl = decodeRequestKeyPart(sourceUrl);
     const decodedSourceLang = decodeRequestKeyPart(sourceLang);
     const decodedTargetLang = decodeRequestKeyPart(targetLang);
-    const decodedEmail = decodeRequestKeyPart(email ?? "");
+    const decodedEmail = decodeRequestKeyPart(email);
     if (!decodedSourceUrl || !decodedSourceLang || !decodedTargetLang) {
       return null;
     }

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -62,5 +62,5 @@ export async function fetchUserByEmail(email: string): Promise<User | null> {
   }
 
   const payload = (await response.json()) as { users?: User[] };
-  return payload?.users?.[0] ?? null;
+  return payload.users?.[0] ?? null;
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "docs:sync": "pnpm docs:sync:tsc && node .tmp/docs-sync/docs-sync-weblingo.js",
     "docs:sync:check": "pnpm docs:sync:tsc && node .tmp/docs-sync/docs-sync-check.js",
     "check": "pnpm run lint && pnpm run format && pnpm run type",
+    "check:ci": "pnpm run lint && pnpm run format && pnpm run type && pnpm run test:contracts && node scripts/check-ci.mjs",
     "supabase:types": "supabase gen types typescript --schema public --project-id \"$SUPABASE_PROJECT_ID\" > types/database.ts"
   },
   "dependencies": {
@@ -68,6 +69,7 @@
     "prettier": "^3.7.4",
     "tailwindcss": "^3.4.13",
     "typescript": "^5.6.2",
+    "typescript-eslint": "^8.46.3",
     "vitest": "^4.0.18"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       typescript:
         specifier: ^5.6.2
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.46.3
+        version: 8.46.3(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(happy-dom@20.3.0)(jiti@1.21.7)(jsdom@27.4.0)(yaml@2.8.2)

--- a/scripts/check-ci.mjs
+++ b/scripts/check-ci.mjs
@@ -1,0 +1,24 @@
+import { spawnSync } from "node:child_process";
+
+const corepackCommand = process.platform === "win32" ? "corepack.cmd" : "corepack";
+
+function run(command, args, env = process.env) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    env,
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+if (!process.env.WEBLINGO_REPO_PATH) {
+  console.info("[check:ci] WEBLINGO_REPO_PATH is not set; skipping docs:sync:check.");
+  process.exit(0);
+}
+
+run(corepackCommand, ["pnpm", "docs:sync:check"], {
+  ...process.env,
+  WEBLINGO_REPO_PATH: process.env.WEBLINGO_REPO_PATH,
+});


### PR DESCRIPTION
## Summary

- Why:
  Complete the website tranche of the staged frontend ESLint/tooling rollout so the website enforces type-aware linting on the highest-risk server/data paths and keeps CI aligned with backend docs/contracts.
- What:
  Add `typescript-eslint` project-service linting plus a scoped first strict-rule wave for `app/api/**/*.ts`, `internal/**/*.ts`, and `lib/**/*.ts`; fix the resulting async/null/body-handling issues across preview, dashboard, Stripe, waitlist, i18n, and Supabase helpers; add `check:ci` and wire CI/fallback guidance to it; sync the website glossary contract/docs snapshots with backend retranslation fields; then merge `main` and refresh synced backend artifacts against current backend HEAD.

## Testing

- [x] `corepack pnpm test`
- [x] `corepack pnpm check`
- [x] `corepack pnpm test:contracts`
- [x] `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check` (required when CI cross-repo token is unavailable)

## Docs sync and capability matrix

- [ ] Updated `docs/backend/DASHBOARD_SPECS.md` if user-facing backend capability coverage changed.
- [x] Ran `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync` and committed `content/docs/_generated/*` when backend HEAD advanced.