### PR TITLE
feat: add admin showcase dashboard

### DIFF
--- a/app/dashboard/actions.capabilities.test.ts
+++ b/app/dashboard/actions.capabilities.test.ts
@@ -22,6 +22,7 @@ const provisionDomain = vi.fn();
 const refreshDomain = vi.fn();
 const updateGlossary = vi.fn();
 const createOverride = vi.fn();
+const createManagedDemo = vi.fn();
 const updateSlug = vi.fn();
 const setLocaleServing = vi.fn();
 const deactivateSite = vi.fn();
@@ -40,6 +41,7 @@ class MockWebhooksApiError extends Error {
 
 vi.mock("@internal/dashboard/webhooks", () => ({
   createOverride,
+  createManagedDemo,
   createSite,
   deactivateSite,
   cancelTranslationRun,
@@ -70,16 +72,25 @@ vi.mock("@internal/dashboard/data", () => ({
 }));
 
 const requireDashboardAuth = vi.fn();
+const invalidateDashboardBootstrapCache = vi.fn();
+const hasActorInternalOps = vi.fn();
 vi.mock("@internal/dashboard/auth", () => ({
+  hasActorInternalOps,
+  invalidateDashboardBootstrapCache,
   requireDashboardAuth,
 }));
 
+const buildSiteSettingsUpdatePayload = vi.fn();
+const deriveSiteSettingsAccess = vi.fn();
+const parseJsonObject = vi.fn();
+const parseLocaleAliases = vi.fn();
+const validateSourceUrl = vi.fn();
 vi.mock("@internal/dashboard/site-settings", () => ({
-  buildSiteSettingsUpdatePayload: vi.fn(),
-  deriveSiteSettingsAccess: vi.fn(),
-  parseJsonObject: vi.fn(),
-  parseLocaleAliases: vi.fn(),
-  validateSourceUrl: vi.fn(),
+  buildSiteSettingsUpdatePayload,
+  deriveSiteSettingsAccess,
+  parseJsonObject,
+  parseLocaleAliases,
+  validateSourceUrl,
 }));
 
 describe("dashboard capability actions", () => {
@@ -88,6 +99,9 @@ describe("dashboard capability actions", () => {
     withWebhooksAuth.mockImplementation(async (callback: (auth: { token: string }) => unknown) =>
       callback({ token: "webhooks-token" }),
     );
+    hasActorInternalOps.mockReturnValue(true);
+    validateSourceUrl.mockReturnValue(null);
+    parseLocaleAliases.mockImplementation((raw: string) => (raw ? JSON.parse(raw) : undefined));
   });
 
   it("queues crawl+translate with parsed csv payload and force flag", async () => {
@@ -254,5 +268,72 @@ describe("dashboard capability actions", () => {
         currentLang: "fr",
       },
     );
+  });
+
+  it("creates a managed demo with locale aliases and invalidates actor bootstrap auth", async () => {
+    requireDashboardAuth.mockResolvedValue({
+      session: { access_token: "session-token" },
+      actorWebhooksAuth: { token: "actor-token", subjectAccountId: "acct-admin" },
+      webhooksAuth: { token: "subject-token", subjectAccountId: "acct-customer" },
+      actorAccount: { accountId: "acct-admin", planType: "agency", featureFlags: {} },
+      account: { accountId: "acct-customer", planType: "pro", featureFlags: {} },
+    });
+    createManagedDemo.mockResolvedValue({
+      accountId: "acct-demo",
+      site: { id: "site-demo" },
+      showcase: { url: "https://t2.weblingo.app/autotrim.com/fr", websitePath: "autotrim.com" },
+    });
+
+    const { createManagedDemoAction } = await import("./actions");
+    const formData = new FormData();
+    formData.set("sourceUrl", "https://www.autotrim.com");
+    formData.set("sourceLang", "en");
+    formData.append("targetLangs", "fr");
+    formData.append("targetLangs", "de");
+    formData.set("subdomainPattern", "https://{lang}.autotrim.com");
+    formData.set("defaultLang", "fr");
+    formData.set("localeAliases", JSON.stringify({ fr: "fr-fr" }));
+
+    const result = await createManagedDemoAction(undefined, formData);
+
+    expect(result).toMatchObject({
+      ok: true,
+      meta: {
+        accountId: "acct-demo",
+        siteId: "site-demo",
+      },
+    });
+    expect(createManagedDemo).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "actor-token" }),
+      expect.objectContaining({
+        site: expect.objectContaining({
+          localeAliases: { fr: "fr-fr" },
+          targetLangs: ["fr", "de"],
+        }),
+      }),
+    );
+    expect(invalidateDashboardBootstrapCache).toHaveBeenCalledWith("session-token");
+  });
+
+  it("rejects managed demo creation when locale aliases are invalid", async () => {
+    parseLocaleAliases.mockReturnValue("Locale aliases are invalid.");
+
+    const { createManagedDemoAction } = await import("./actions");
+    const formData = new FormData();
+    formData.set("sourceUrl", "https://www.autotrim.com");
+    formData.set("sourceLang", "en");
+    formData.append("targetLangs", "fr");
+    formData.set("subdomainPattern", "https://{lang}.autotrim.com");
+    formData.set("defaultLang", "fr");
+    formData.set("localeAliases", '{"fr":"bad alias"}');
+
+    const result = await createManagedDemoAction(undefined, formData);
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Locale aliases are invalid.",
+      meta: undefined,
+    });
+    expect(createManagedDemo).not.toHaveBeenCalled();
   });
 });

--- a/app/dashboard/actions.ts
+++ b/app/dashboard/actions.ts
@@ -37,6 +37,7 @@ import {
 import { invalidateSiteDashboardCache, invalidateSitesCache } from "@internal/dashboard/data";
 import {
   hasActorInternalOps,
+  invalidateDashboardBootstrapCache,
   requireDashboardAuth,
   type DashboardAuth,
   type WebhooksAuthContext,
@@ -206,20 +207,6 @@ async function invalidateDashboardCaches(
   if (options.invalidateSitesList) {
     await invalidateSitesCache(auth);
   }
-}
-
-async function requireInternalAdminActorAuth(): Promise<WebhooksAuthContext> {
-  const auth = await requireDashboardAuth();
-  if (!hasActorInternalOps(auth)) {
-    throw new Error("Internal admin access is required.");
-  }
-  return (
-    auth.actorWebhooksAuth ??
-    auth.webhooksAuth ??
-    (() => {
-      throw new Error("Unable to authenticate internal admin actions.");
-    })()
-  );
 }
 
 async function requireInternalAdminWorkspaceAuth(): Promise<WebhooksAuthContext> {
@@ -417,6 +404,7 @@ export async function createManagedDemoAction(
     .map((lang) => lang.toString().trim())
     .filter(Boolean);
   const subdomainPattern = formData.get("subdomainPattern")?.toString().trim() ?? "";
+  const localeAliasesRaw = formData.get("localeAliases")?.toString().trim() ?? "";
   const websitePath = formData.get("websitePath")?.toString().trim() ?? "";
   const defaultLangRaw = formData.get("defaultLang")?.toString().trim() ?? "";
 
@@ -437,15 +425,32 @@ export async function createManagedDemoAction(
   if (!defaultLang || !uniqueTargets.includes(defaultLang)) {
     return failed("Default showcase language must be one of the selected target languages.");
   }
+  const localeAliases = parseLocaleAliases(localeAliasesRaw, uniqueTargets);
+  if (typeof localeAliases === "string") {
+    return failed(localeAliases);
+  }
 
   try {
-    const auth = await requireInternalAdminActorAuth();
+    const dashboardAuth = await requireDashboardAuth();
+    if (!hasActorInternalOps(dashboardAuth)) {
+      throw new Error("Internal admin access is required.");
+    }
+    if (!dashboardAuth.session?.access_token) {
+      throw new Error("Unable to read the current dashboard session.");
+    }
+    const auth =
+      dashboardAuth.actorWebhooksAuth ??
+      dashboardAuth.webhooksAuth ??
+      (() => {
+        throw new Error("Unable to authenticate internal admin actions.");
+      })();
     const result = await createManagedDemo(auth, {
       site: {
         sourceUrl,
         sourceLang,
         targetLangs: uniqueTargets,
         subdomainPattern,
+        ...(localeAliases ? { localeAliases } : {}),
         servingMode: "strict",
         maxLocales: null,
       },
@@ -454,6 +459,7 @@ export async function createManagedDemoAction(
         defaultLang,
       },
     });
+    await invalidateDashboardBootstrapCache(dashboardAuth.session.access_token);
     revalidatePath("/dashboard");
     revalidatePath("/dashboard/agency");
     revalidatePath("/dashboard/agency/customers");

--- a/app/dashboard/actions.ts
+++ b/app/dashboard/actions.ts
@@ -4,12 +4,16 @@ import { revalidatePath } from "next/cache";
 
 import {
   createOverride,
+  createManagedDemo,
+  createSiteShowcase,
   createSite,
   deactivateSite,
   cancelTranslationRun,
   upsertConsistencyCpm,
   updateConsistencyBlock,
+  updateSiteShowcase,
   fetchSwitcherSnippets,
+  getSiteShowcase,
   listTranslationSummaries,
   provisionDomain,
   refreshDomain,
@@ -32,6 +36,7 @@ import {
 } from "@internal/dashboard/webhooks";
 import { invalidateSiteDashboardCache, invalidateSitesCache } from "@internal/dashboard/data";
 import {
+  hasActorInternalOps,
   requireDashboardAuth,
   type DashboardAuth,
   type WebhooksAuthContext,
@@ -201,6 +206,31 @@ async function invalidateDashboardCaches(
   if (options.invalidateSitesList) {
     await invalidateSitesCache(auth);
   }
+}
+
+async function requireInternalAdminActorAuth(): Promise<WebhooksAuthContext> {
+  const auth = await requireDashboardAuth();
+  if (!hasActorInternalOps(auth)) {
+    throw new Error("Internal admin access is required.");
+  }
+  return (
+    auth.actorWebhooksAuth ??
+    auth.webhooksAuth ??
+    (() => {
+      throw new Error("Unable to authenticate internal admin actions.");
+    })()
+  );
+}
+
+async function requireInternalAdminWorkspaceAuth(): Promise<WebhooksAuthContext> {
+  const auth = await requireDashboardAuth();
+  if (!hasActorInternalOps(auth)) {
+    throw new Error("Internal admin access is required.");
+  }
+  if (!auth.webhooksAuth) {
+    throw new Error("Unable to authenticate the current workspace.");
+  }
+  return auth.webhooksAuth;
 }
 
 function normalizeGlossaryEntries(entries: unknown): GlossaryEntry[] | string {
@@ -373,6 +403,157 @@ export async function createSiteAction(
       return failed(toFriendlyDashboardActionError(error, "Unable to create site right now."));
     }
     return failed("Unable to create site right now.");
+  }
+}
+
+export async function createManagedDemoAction(
+  _prevState: ActionResponse | undefined,
+  formData: FormData,
+): Promise<ActionResponse> {
+  const sourceUrl = formData.get("sourceUrl")?.toString().trim() ?? "";
+  const sourceLang = formData.get("sourceLang")?.toString().trim() ?? "";
+  const targetLangs = formData
+    .getAll("targetLangs")
+    .map((lang) => lang.toString().trim())
+    .filter(Boolean);
+  const subdomainPattern = formData.get("subdomainPattern")?.toString().trim() ?? "";
+  const websitePath = formData.get("websitePath")?.toString().trim() ?? "";
+  const defaultLangRaw = formData.get("defaultLang")?.toString().trim() ?? "";
+
+  const uniqueTargets = Array.from(new Set(targetLangs));
+
+  if (!sourceUrl || !sourceLang || uniqueTargets.length === 0 || !subdomainPattern) {
+    return failed("Please fill every required field and pick at least one target language.");
+  }
+
+  const sourceUrlError = validateSourceUrl(sourceUrl);
+  if (sourceUrlError) {
+    return failed(sourceUrlError);
+  }
+  if (!subdomainPattern.includes("{lang}")) {
+    return failed("Generated subdomain pattern is invalid. Check the source URL.");
+  }
+  const defaultLang = defaultLangRaw || uniqueTargets[0] || "";
+  if (!defaultLang || !uniqueTargets.includes(defaultLang)) {
+    return failed("Default showcase language must be one of the selected target languages.");
+  }
+
+  try {
+    const auth = await requireInternalAdminActorAuth();
+    const result = await createManagedDemo(auth, {
+      site: {
+        sourceUrl,
+        sourceLang,
+        targetLangs: uniqueTargets,
+        subdomainPattern,
+        servingMode: "strict",
+        maxLocales: null,
+      },
+      showcase: {
+        ...(websitePath ? { websitePath } : {}),
+        defaultLang,
+      },
+    });
+    revalidatePath("/dashboard");
+    revalidatePath("/dashboard/agency");
+    revalidatePath("/dashboard/agency/customers");
+    revalidatePath("/dashboard/ops/showcases");
+    return succeeded("Managed demo created.", {
+      accountId: result.accountId,
+      siteId: result.site.id,
+      showcaseUrl: result.showcase.url,
+      websitePath: result.showcase.websitePath,
+    });
+  } catch (error) {
+    if (isNextRedirectError(error)) {
+      throw error;
+    }
+    console.error("[dashboard] createManagedDemoAction failed:", error);
+    return failed(
+      toFriendlyDashboardActionError(error, "Unable to create the managed demo right now."),
+    );
+  }
+}
+
+export async function createSiteShowcaseAction(
+  _prevState: ActionResponse | undefined,
+  formData: FormData,
+): Promise<ActionResponse> {
+  const siteId = formData.get("siteId")?.toString().trim() ?? "";
+  const websitePath = formData.get("websitePath")?.toString().trim() ?? "";
+  const defaultLangRaw = formData.get("defaultLang")?.toString().trim();
+  const defaultLang = defaultLangRaw ? defaultLangRaw : null;
+
+  if (!siteId || !websitePath) {
+    return failed("Site ID and website path are required.");
+  }
+
+  try {
+    const auth = await requireInternalAdminWorkspaceAuth();
+    const result = await createSiteShowcase(auth, siteId, { websitePath, defaultLang });
+    await invalidateDashboardCaches(auth, siteId, { invalidateSitesList: true });
+    revalidatePath(`/dashboard/sites/${siteId}`);
+    revalidatePath(`/dashboard/sites/${siteId}/admin`);
+    revalidatePath("/dashboard/ops/showcases");
+    return succeeded("Showcase created.", {
+      showcaseUrl: result.showcase.url,
+      websitePath: result.showcase.websitePath,
+    });
+  } catch (error) {
+    if (isNextRedirectError(error)) {
+      throw error;
+    }
+    console.error("[dashboard] createSiteShowcaseAction failed:", error);
+    return failed(toFriendlyDashboardActionError(error, "Unable to create showcase."));
+  }
+}
+
+export async function updateSiteShowcaseAction(
+  _prevState: ActionResponse | undefined,
+  formData: FormData,
+): Promise<ActionResponse> {
+  const siteId = formData.get("siteId")?.toString().trim() ?? "";
+  const defaultLangValue = formData.get("defaultLang")?.toString().trim();
+  const statusValue = formData.get("status")?.toString().trim();
+
+  if (!siteId) {
+    return failed("Site ID is required.");
+  }
+  const payload: { defaultLang?: string | null; status?: "active" | "disabled" } = {};
+  if (defaultLangValue !== undefined) {
+    payload.defaultLang = defaultLangValue ? defaultLangValue : null;
+  }
+  if (statusValue) {
+    if (statusValue !== "active" && statusValue !== "disabled") {
+      return failed("Showcase status must be active or disabled.");
+    }
+    payload.status = statusValue;
+  }
+  if (!("defaultLang" in payload) && !payload.status) {
+    return failed("Choose a showcase update to apply.");
+  }
+
+  try {
+    const auth = await requireInternalAdminWorkspaceAuth();
+    const existing = await getSiteShowcase(auth, siteId);
+    const result = await updateSiteShowcase(auth, siteId, {
+      defaultLang: "defaultLang" in payload ? payload.defaultLang : existing.showcase.defaultLang,
+      status: payload.status ?? existing.showcase.status,
+    });
+    await invalidateDashboardCaches(auth, siteId, { invalidateSitesList: true });
+    revalidatePath(`/dashboard/sites/${siteId}`);
+    revalidatePath(`/dashboard/sites/${siteId}/admin`);
+    revalidatePath("/dashboard/ops/showcases");
+    return succeeded("Showcase updated.", {
+      showcaseUrl: result.showcase.url,
+      websitePath: result.showcase.websitePath,
+    });
+  } catch (error) {
+    if (isNextRedirectError(error)) {
+      throw error;
+    }
+    console.error("[dashboard] updateSiteShowcaseAction failed:", error);
+    return failed(toFriendlyDashboardActionError(error, "Unable to update showcase."));
   }
 }
 

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import Link from "next/link";
-import { Briefcase, Globe, LayoutDashboard, Users, Wrench } from "lucide-react";
+import { Briefcase, Globe, LayoutDashboard, MonitorPlay, Users, Wrench } from "lucide-react";
 
 import { DashboardNav } from "./_components/dashboard-nav";
 import { SitesNav, type SiteNavEntry } from "./_components/sites-nav";
@@ -22,7 +22,11 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { logout } from "@/app/auth/logout/actions";
-import { requireDashboardAuth, type DashboardAuth } from "@internal/dashboard/auth";
+import {
+  hasActorInternalOps,
+  requireDashboardAuth,
+  type DashboardAuth,
+} from "@internal/dashboard/auth";
 import { listSitesCached } from "@internal/dashboard/data";
 import { i18nConfig } from "@internal/i18n";
 import type { SiteSummary } from "@internal/dashboard/webhooks";
@@ -40,6 +44,7 @@ export default async function DashboardLayout({ children }: DashboardLayoutProps
   const auth = await requireDashboardAuth();
   const email = auth.user?.email ?? "—";
   const isAgency = auth.actorAccount?.planType === "agency";
+  const canAccessInternalOps = hasActorInternalOps(auth);
   const pricingPath = `/${i18nConfig.defaultLocale}/pricing`;
   const navItems = [
     {
@@ -70,6 +75,15 @@ export default async function DashboardLayout({ children }: DashboardLayoutProps
       label: "Developer tools",
       icon: <Wrench className="h-4 w-4" />,
     },
+    ...(canAccessInternalOps
+      ? [
+          {
+            href: "/dashboard/ops/showcases",
+            label: "Showcases",
+            icon: <MonitorPlay className="h-4 w-4" />,
+          },
+        ]
+      : []),
   ];
   const workspaceOptions = buildWorkspaceOptions(auth);
   const subjectLabel =

--- a/app/dashboard/ops/page.tsx
+++ b/app/dashboard/ops/page.tsx
@@ -1,8 +1,10 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { requireDashboardAuth } from "@internal/dashboard/auth";
+import { hasActorInternalOps, requireDashboardAuth } from "@internal/dashboard/auth";
 import { listSitesCached } from "@internal/dashboard/data";
 
 export const metadata = {
@@ -12,7 +14,7 @@ export const metadata = {
 
 export default async function OpsPage() {
   const auth = await requireDashboardAuth();
-  const canAccessOps = auth.has({ feature: "internal_ops" });
+  const canAccessOps = hasActorInternalOps(auth);
   if (!canAccessOps) {
     notFound();
   }
@@ -41,6 +43,26 @@ export default async function OpsPage() {
           <InfoBlock label="Total sites" value={`${sites.length}`} />
           <InfoBlock label="Active sites" value={`${activeSites}`} />
           <InfoBlock label="Inactive sites" value={`${sites.length - activeSites}`} />
+        </CardContent>
+      </Card>
+
+      <Card className="border-border/60 bg-muted/20">
+        <CardHeader>
+          <CardTitle>Managed demos</CardTitle>
+          <CardDescription>
+            Use the dedicated showcase workspace to provision pre-sales demo sites and open their
+            managed customer workspaces.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-muted-foreground">
+            Showcase URLs stay public on{" "}
+            <span className="font-medium text-foreground">t2.weblingo.app</span>
+            while customer domains remain gated by verification.
+          </p>
+          <Button asChild variant="secondary">
+            <Link href="/dashboard/ops/showcases">Open managed demos</Link>
+          </Button>
         </CardContent>
       </Card>
 

--- a/app/dashboard/ops/showcases/managed-demo-create-form.tsx
+++ b/app/dashboard/ops/showcases/managed-demo-create-form.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useActionState, useEffect, useMemo, useState } from "react";
+import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
+
+import { createManagedDemoAction, type ActionResponse } from "../../actions";
+import { TargetLanguagePicker } from "../../sites/target-language-picker";
+import { parseSourceUrl, stripWwwPrefix } from "../../sites/site-form-utils";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Field } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useActionToast } from "@internal/dashboard/use-action-toast";
+import type { SupportedLanguage } from "@internal/dashboard/webhooks";
+
+const LanguageTagCombobox = dynamic(
+  () => import("@/components/language-tag-combobox").then((mod) => mod.LanguageTagCombobox),
+  { ssr: false },
+);
+
+const initialState: ActionResponse = { ok: false, message: "" };
+
+type ManagedDemoCreateFormProps = {
+  supportedLanguages: SupportedLanguage[];
+  displayLocale: string;
+};
+
+export function ManagedDemoCreateForm({
+  supportedLanguages,
+  displayLocale,
+}: ManagedDemoCreateFormProps) {
+  const [state, formAction, pending] = useActionState(createManagedDemoAction, initialState);
+  const router = useRouter();
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [sourceLang, setSourceLang] = useState("");
+  const [targets, setTargets] = useState<string[]>([]);
+  const [aliasesByLang, setAliasesByLang] = useState<Record<string, string>>({});
+  const [websitePath, setWebsitePath] = useState("");
+  const [defaultLang, setDefaultLang] = useState("");
+
+  const parsedSourceUrl = useMemo(() => parseSourceUrl(sourceUrl), [sourceUrl]);
+  const sourceHost = parsedSourceUrl ? stripWwwPrefix(parsedSourceUrl.hostname) : "";
+  const derivedWebsitePath = sourceHost.toLowerCase();
+  const effectiveWebsitePath = websitePath.trim() || derivedWebsitePath;
+  const targetLangs = useMemo(() => Array.from(new Set(targets)), [targets]);
+  const effectiveDefaultLang =
+    defaultLang && targetLangs.includes(defaultLang) ? defaultLang : (targetLangs[0] ?? "");
+  const subdomainPattern = useMemo(() => {
+    if (!parsedSourceUrl) {
+      return "";
+    }
+    return `${parsedSourceUrl.protocol}//{lang}.${stripWwwPrefix(parsedSourceUrl.hostname)}`;
+  }, [parsedSourceUrl]);
+  const showcasePreview =
+    effectiveWebsitePath && effectiveDefaultLang
+      ? `https://t2.weblingo.app/${effectiveWebsitePath}/${effectiveDefaultLang}`
+      : null;
+  const customerPatternPreview = subdomainPattern
+    ? subdomainPattern.replace("{lang}", effectiveDefaultLang || "fr")
+    : null;
+
+  const submitDisabled =
+    pending || !parsedSourceUrl || !sourceLang || !targetLangs.length || !subdomainPattern;
+
+  const submitWithToast = useActionToast({
+    formAction,
+    state,
+    pending,
+    loading: "Creating managed demo...",
+    success: "Managed demo created.",
+    error: "Unable to create managed demo.",
+  });
+
+  useEffect(() => {
+    if (!state.ok) {
+      return;
+    }
+    router.refresh();
+  }, [router, state.ok]);
+
+  return (
+    <Card className="border-border/60 bg-background">
+      <CardHeader className="space-y-2">
+        <CardTitle>Create managed demo</CardTitle>
+        <CardDescription>
+          Bootstrap a managed demo account, its first site, and a public showcase URL on
+          <span className="font-medium text-foreground"> t2.weblingo.app</span>.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <form action={submitWithToast} className="space-y-5">
+          <input name="subdomainPattern" type="hidden" value={subdomainPattern} />
+          <input name="defaultLang" type="hidden" value={effectiveDefaultLang} />
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            <Field label="Source URL" htmlFor="managed-demo-source-url">
+              <Input
+                id="managed-demo-source-url"
+                name="sourceUrl"
+                type="url"
+                placeholder="https://www.example.com"
+                value={sourceUrl}
+                onChange={(event) => setSourceUrl(event.target.value)}
+                required
+              />
+            </Field>
+            <Field label="Source language" htmlFor="managed-demo-source-lang">
+              <LanguageTagCombobox
+                id="managed-demo-source-lang"
+                name="sourceLang"
+                value={sourceLang}
+                onValueChange={setSourceLang}
+                supportedLanguages={supportedLanguages}
+                displayLocale={displayLocale}
+                placeholder="Select a language"
+                required
+              />
+            </Field>
+          </div>
+
+          <Field
+            label="Target languages"
+            description="Pick the first locales you want ready for demos. The first one becomes the default showcase language unless you change it."
+          >
+            <TargetLanguagePicker
+              targets={targets}
+              aliases={aliasesByLang}
+              onTargetsChange={setTargets}
+              onAliasesChange={setAliasesByLang}
+              supportedLanguages={supportedLanguages}
+              displayLocale={displayLocale}
+              maxLocales={null}
+            />
+          </Field>
+
+          <div className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+            <Field
+              label="Showcase path"
+              htmlFor="managed-demo-website-path"
+              description="Optional override. Leave blank to derive it from the source host."
+            >
+              <Input
+                id="managed-demo-website-path"
+                name="websitePath"
+                placeholder={derivedWebsitePath || "autotrim.com"}
+                value={websitePath}
+                onChange={(event) => setWebsitePath(event.target.value.toLowerCase())}
+              />
+            </Field>
+            <Field
+              label="Default showcase language"
+              htmlFor="managed-demo-default-lang"
+              description="Visitors hitting the root showcase path will land on this language."
+            >
+              <select
+                id="managed-demo-default-lang"
+                name="defaultLangSelect"
+                className="h-10 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+                value={effectiveDefaultLang}
+                onChange={(event) => setDefaultLang(event.target.value)}
+                disabled={!targetLangs.length}
+              >
+                {targetLangs.length === 0 ? (
+                  <option value="">Pick target languages first</option>
+                ) : null}
+                {targetLangs.map((lang) => (
+                  <option key={lang} value={lang}>
+                    {lang}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </div>
+
+          <div className="grid gap-3 rounded-xl border border-border/60 bg-muted/20 p-4 lg:grid-cols-2">
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Showcase URL
+              </p>
+              <p className="font-mono text-sm text-foreground">
+                {showcasePreview ??
+                  "Enter a source URL and target language to preview the demo URL."}
+              </p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Customer-domain pattern
+              </p>
+              <p className="font-mono text-sm text-foreground">
+                {customerPatternPreview ?? "Derived after you enter the source URL."}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3 border-t border-border/60 pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs text-muted-foreground">
+              Showcase URLs stay public but ship with noindex and robots blocking. Customer domains
+              still require DNS verification.
+            </p>
+            <Button type="submit" disabled={submitDisabled}>
+              {pending ? "Creating..." : "Create managed demo"}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/dashboard/ops/showcases/managed-demo-create-form.tsx
+++ b/app/dashboard/ops/showcases/managed-demo-create-form.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 
 import { createManagedDemoAction, type ActionResponse } from "../../actions";
 import { TargetLanguagePicker } from "../../sites/target-language-picker";
-import { parseSourceUrl, stripWwwPrefix } from "../../sites/site-form-utils";
+import { buildLocaleAliases, parseSourceUrl, stripWwwPrefix } from "../../sites/site-form-utils";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Field } from "@/components/ui/field";
@@ -45,6 +45,11 @@ export function ManagedDemoCreateForm({
   const derivedWebsitePath = sourceHost.toLowerCase();
   const effectiveWebsitePath = websitePath.trim() || derivedWebsitePath;
   const targetLangs = useMemo(() => Array.from(new Set(targets)), [targets]);
+  const localeAliases = useMemo(
+    () => buildLocaleAliases(targetLangs, aliasesByLang),
+    [aliasesByLang, targetLangs],
+  );
+  const localeAliasesJson = useMemo(() => JSON.stringify(localeAliases), [localeAliases]);
   const effectiveDefaultLang =
     defaultLang && targetLangs.includes(defaultLang) ? defaultLang : (targetLangs[0] ?? "");
   const subdomainPattern = useMemo(() => {
@@ -93,6 +98,7 @@ export function ManagedDemoCreateForm({
         <form action={submitWithToast} className="space-y-5">
           <input name="subdomainPattern" type="hidden" value={subdomainPattern} />
           <input name="defaultLang" type="hidden" value={effectiveDefaultLang} />
+          <input name="localeAliases" type="hidden" value={localeAliasesJson} />
 
           <div className="grid gap-4 lg:grid-cols-2">
             <Field label="Source URL" htmlFor="managed-demo-source-url">

--- a/app/dashboard/ops/showcases/page.tsx
+++ b/app/dashboard/ops/showcases/page.tsx
@@ -28,13 +28,23 @@ export default async function OpsShowcasesPage() {
     notFound();
   }
 
-  const [managedDemoResponse, supportedLanguages] = await Promise.all([
+  const [managedDemoResult, supportedLanguagesResult] = await Promise.allSettled([
     listManagedDemos(actorAuth),
     listSupportedLanguagesCached(),
   ]);
-  const items = managedDemoResponse.items;
+  const items = managedDemoResult.status === "fulfilled" ? managedDemoResult.value.items : [];
+  const supportedLanguages =
+    supportedLanguagesResult.status === "fulfilled" ? supportedLanguagesResult.value : [];
+  const managedDemoError =
+    managedDemoResult.status === "rejected"
+      ? managedDemoResult.reason instanceof Error
+        ? managedDemoResult.reason.message
+        : "Unable to load managed demos right now."
+      : null;
   const activeShowcases = items.filter((item) => item.showcase.status === "active").length;
-  const servingShowcases = items.filter((item) => item.showcaseServingStatus === "serving").length;
+  const servingShowcases = items.filter(
+    (item) => item.showcaseServingStatus === "serving" || item.showcaseServingStatus === "degraded",
+  ).length;
 
   return (
     <div className="space-y-6">
@@ -75,6 +85,12 @@ export default async function OpsShowcasesPage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          {managedDemoError ? (
+            <div className="rounded-lg border border-dashed border-amber-300/70 bg-amber-50/80 p-4 text-sm text-amber-950 dark:border-amber-700/70 dark:bg-amber-950/30 dark:text-amber-100">
+              Demo inventory is temporarily unavailable. You can still create a managed demo above.
+              <div className="mt-2 text-xs opacity-80">{managedDemoError}</div>
+            </div>
+          ) : null}
           {items.length === 0 ? (
             <div className="rounded-lg border border-dashed border-border/70 bg-muted/20 p-6 text-sm text-muted-foreground">
               No managed demos yet. Create one above to provision the account, site, and showcase

--- a/app/dashboard/ops/showcases/page.tsx
+++ b/app/dashboard/ops/showcases/page.tsx
@@ -1,0 +1,182 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowUpRight, ExternalLink } from "lucide-react";
+
+import { ManagedDemoCreateForm } from "./managed-demo-create-form";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { hasActorInternalOps, requireDashboardAuth } from "@internal/dashboard/auth";
+import { listSupportedLanguagesCached } from "@internal/dashboard/data";
+import { i18nConfig } from "@internal/i18n";
+import { listManagedDemos, type ManagedDemoSiteSummary } from "@internal/dashboard/webhooks";
+import { setWorkspaceAction } from "../../_lib/workspace-actions";
+
+export const metadata = {
+  title: "Managed demos",
+  robots: { index: false, follow: false },
+};
+
+export default async function OpsShowcasesPage() {
+  const auth = await requireDashboardAuth();
+  if (!hasActorInternalOps(auth)) {
+    notFound();
+  }
+  const actorAuth = auth.actorWebhooksAuth ?? auth.webhooksAuth;
+  if (!actorAuth) {
+    notFound();
+  }
+
+  const [managedDemoResponse, supportedLanguages] = await Promise.all([
+    listManagedDemos(actorAuth),
+    listSupportedLanguagesCached(),
+  ]);
+  const items = managedDemoResponse.items;
+  const activeShowcases = items.filter((item) => item.showcase.status === "active").length;
+  const servingShowcases = items.filter((item) => item.showcaseServingStatus === "serving").length;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="text-2xl font-semibold">Managed demos</h2>
+          <Badge variant="outline">Internal admin</Badge>
+        </div>
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          Create and operate pre-sales showcase sites. This view always uses your admin account,
+          even when you are currently acting inside a managed customer workspace.
+        </p>
+      </div>
+
+      <Card className="border-border/60 bg-muted/20">
+        <CardHeader>
+          <CardTitle>Showcase pulse</CardTitle>
+          <CardDescription>Quick view of the current managed-demo fleet.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-3">
+          <InfoBlock label="Managed demos" value={`${items.length}`} />
+          <InfoBlock label="Active showcase namespaces" value={`${activeShowcases}`} />
+          <InfoBlock label="Currently serving" value={`${servingShowcases}`} />
+        </CardContent>
+      </Card>
+
+      <ManagedDemoCreateForm
+        supportedLanguages={supportedLanguages}
+        displayLocale={i18nConfig.defaultLocale}
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Demo inventory</CardTitle>
+          <CardDescription>
+            Track public showcase URLs, customer-domain readiness, and jump into the managed
+            workspace for deeper site operations.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {items.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border/70 bg-muted/20 p-6 text-sm text-muted-foreground">
+              No managed demos yet. Create one above to provision the account, site, and showcase
+              namespace in one step.
+            </div>
+          ) : (
+            items.map((item) => <ManagedDemoRow key={item.siteId} item={item} />)
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ManagedDemoRow({ item }: { item: ManagedDemoSiteSummary }) {
+  return (
+    <div className="rounded-2xl border border-border/60 bg-background p-4 shadow-sm">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-base font-semibold text-foreground">{item.sourceUrl}</p>
+            <Badge variant={item.siteStatus === "active" ? "secondary" : "outline"}>
+              Site {item.siteStatus}
+            </Badge>
+            <Badge variant={item.showcase.status === "active" ? "secondary" : "outline"}>
+              Showcase {item.showcase.status}
+            </Badge>
+          </div>
+          <div className="grid gap-2 text-sm text-muted-foreground md:grid-cols-2 xl:grid-cols-3">
+            <InfoRow label="Customer serving" value={item.customerServingStatus} />
+            <InfoRow label="Showcase serving" value={item.showcaseServingStatus} />
+            <InfoRow label="Workspace" value={item.accountId} />
+            <InfoRow label="Site ID" value={item.siteId} />
+            <InfoRow label="Website path" value={item.showcase.websitePath} />
+            <InfoRow label="Default lang" value={item.showcase.defaultLang ?? "—"} />
+          </div>
+          {item.deployment ? (
+            <div className="rounded-xl border border-border/60 bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
+              Deployment focus:{" "}
+              <span className="font-medium text-foreground">
+                {item.deployment.targetLang.toUpperCase()}
+              </span>
+              {" · "}
+              status{" "}
+              <span className="font-medium text-foreground">{item.deployment.status ?? "—"}</span>
+              {" · "}
+              active pointer{" "}
+              <span className="font-mono text-xs text-foreground">
+                {item.deployment.activeDeploymentId ?? "—"}
+              </span>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-2 lg:min-w-64">
+          <Button asChild variant="secondary">
+            <Link
+              href={item.showcase.url ?? "#"}
+              target="_blank"
+              rel="noreferrer"
+              className={!item.showcase.url ? "pointer-events-none opacity-60" : undefined}
+            >
+              Open showcase
+              <ExternalLink className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+          <form action={setWorkspaceAction}>
+            <input name="subjectAccountId" type="hidden" value={item.accountId} />
+            <input
+              name="redirectTo"
+              type="hidden"
+              value={`/dashboard/sites/${item.siteId}/admin`}
+            />
+            <Button type="submit" variant="outline" className="w-full">
+              Open site admin
+              <ArrowUpRight className="ml-2 h-4 w-4" />
+            </Button>
+          </form>
+          <Button asChild variant="ghost" className="justify-start px-0">
+            <Link href={`/dashboard/agency/customers?query=${encodeURIComponent(item.accountId)}`}>
+              Inspect linked workspace
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function InfoBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-border/60 bg-background p-3">
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-1 text-sm font-semibold text-foreground">{value}</p>
+    </div>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <span className="font-semibold text-foreground">{label}:</span> {value}
+    </div>
+  );
+}

--- a/app/dashboard/sites/[id]/admin/page.tsx
+++ b/app/dashboard/sites/[id]/admin/page.tsx
@@ -76,6 +76,7 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
   let supportedLanguages: SupportedLanguage[] = [];
   let showcaseState: SiteShowcaseResponse | null = null;
   let showcaseError: string | null = null;
+  let showcaseMissingConfirmed = false;
   const canManageShowcase = hasActorInternalOps(auth);
 
   const [
@@ -129,6 +130,7 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
     showcaseResult.reason.status === 404
   ) {
     showcaseState = null;
+    showcaseMissingConfirmed = true;
   } else if (showcaseResult.status === "rejected") {
     showcaseError =
       showcaseResult.reason instanceof Error
@@ -402,6 +404,7 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
           sourceUrl={site.sourceUrl}
           targetLangs={targetLangs}
           showcaseState={showcaseState}
+          showcaseMissingConfirmed={showcaseMissingConfirmed}
           fetchError={showcaseError}
         />
       ) : null}

--- a/app/dashboard/sites/[id]/admin/page.tsx
+++ b/app/dashboard/sites/[id]/admin/page.tsx
@@ -4,6 +4,7 @@ import { headers } from "next/headers";
 import { Info } from "lucide-react";
 
 import { SiteAdminForm } from "./site-admin-form";
+import { SiteShowcaseCard } from "./site-showcase-card";
 
 import { ActionForm } from "@/components/dashboard/action-form";
 import { DeploymentCompletenessBadge } from "@/components/dashboard/deployment-completeness-badge";
@@ -22,7 +23,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { requireDashboardAuth } from "@internal/dashboard/auth";
+import { hasActorInternalOps, requireDashboardAuth } from "@internal/dashboard/auth";
 import {
   getSiteDashboardCached,
   listSitesCached,
@@ -31,9 +32,12 @@ import {
 import { deriveSiteSettingsAccess } from "@internal/dashboard/site-settings";
 import {
   fetchDeploymentHistory,
+  getSiteShowcase,
+  WebhooksApiError,
   type Deployment,
   type DeploymentHistoryByLocale,
   type Site,
+  type SiteShowcaseResponse,
   type SupportedLanguage,
 } from "@internal/dashboard/webhooks";
 import { i18nConfig, resolveLocaleTranslator } from "@internal/i18n";
@@ -70,15 +74,23 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
   let activeSiteCount: number | null = null;
   let error: string | null = null;
   let supportedLanguages: SupportedLanguage[] = [];
+  let showcaseState: SiteShowcaseResponse | null = null;
+  let showcaseError: string | null = null;
+  const canManageShowcase = hasActorInternalOps(auth);
 
-  // Parallelize all API fetches - optimistic that site exists (the common case)
-  const [siteDashboardResult, deploymentHistoryResult, sitesResult, supportedLanguagesResult] =
-    await Promise.allSettled([
-      getSiteDashboardCached(auth.webhooksAuth!, id),
-      fetchDeploymentHistory(auth.webhooksAuth!, id, { limit: 5 }),
-      listSitesCached(auth.webhooksAuth!),
-      settingsAccess.canEditLocales ? listSupportedLanguagesCached() : Promise.resolve([]),
-    ]);
+  const [
+    siteDashboardResult,
+    deploymentHistoryResult,
+    sitesResult,
+    supportedLanguagesResult,
+    showcaseResult,
+  ] = await Promise.allSettled([
+    getSiteDashboardCached(auth.webhooksAuth!, id),
+    fetchDeploymentHistory(auth.webhooksAuth!, id, { limit: 5 }),
+    listSitesCached(auth.webhooksAuth!),
+    settingsAccess.canEditLocales ? listSupportedLanguagesCached() : Promise.resolve([]),
+    canManageShowcase ? getSiteShowcase(auth.webhooksAuth!, id) : Promise.resolve(null),
+  ]);
 
   if (siteDashboardResult.status === "fulfilled") {
     site = siteDashboardResult.value.site;
@@ -108,6 +120,20 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
 
   if (supportedLanguagesResult.status === "fulfilled") {
     supportedLanguages = supportedLanguagesResult.value;
+  }
+
+  if (showcaseResult.status === "fulfilled") {
+    showcaseState = showcaseResult.value;
+  } else if (
+    showcaseResult.reason instanceof WebhooksApiError &&
+    showcaseResult.reason.status === 404
+  ) {
+    showcaseState = null;
+  } else if (showcaseResult.status === "rejected") {
+    showcaseError =
+      showcaseResult.reason instanceof Error
+        ? showcaseResult.reason.message
+        : "Unable to load showcase state right now.";
   }
 
   if (!site) {
@@ -188,6 +214,7 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
     needs_domain: t("dashboard.serving.status.needsDomain"),
     ready: t("dashboard.serving.status.ready"),
     serving: t("dashboard.serving.status.serving"),
+    degraded: t("dashboard.serving.status.degraded", "Degraded"),
   };
   const servingActionTranslate = t("dashboard.serving.action.translate");
   const servingActionVerify = t("dashboard.serving.action.verify");
@@ -369,6 +396,15 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
         initialBrandVoice={brandVoice}
         initialSiteProfileNotes={siteProfileNotes}
       />
+      {canManageShowcase ? (
+        <SiteShowcaseCard
+          siteId={site.id}
+          sourceUrl={site.sourceUrl}
+          targetLangs={targetLangs}
+          showcaseState={showcaseState}
+          fetchError={showcaseError}
+        />
+      ) : null}
 
       <Card className="border-border/60 bg-muted/20">
         <CardHeader>

--- a/app/dashboard/sites/[id]/admin/site-showcase-card.tsx
+++ b/app/dashboard/sites/[id]/admin/site-showcase-card.tsx
@@ -24,6 +24,7 @@ type SiteShowcaseCardProps = {
   sourceUrl: string;
   targetLangs: string[];
   showcaseState: SiteShowcaseResponse | null;
+  showcaseMissingConfirmed: boolean;
   fetchError?: string | null;
 };
 
@@ -41,6 +42,7 @@ export function SiteShowcaseCard({
   sourceUrl,
   targetLangs,
   showcaseState,
+  showcaseMissingConfirmed,
   fetchError,
 }: SiteShowcaseCardProps) {
   const router = useRouter();
@@ -114,7 +116,7 @@ export function SiteShowcaseCard({
                 Customer serving {showcaseState.customerServingStatus}
               </Badge>
               <Badge variant="outline">
-                Showcase serving {showcaseState.showcaseServingStatus ?? "inactive"}
+                Showcase serving {showcaseState.showcaseServingStatus}
               </Badge>
             </div>
 
@@ -197,7 +199,7 @@ export function SiteShowcaseCard({
               </div>
             </form>
           </>
-        ) : (
+        ) : showcaseMissingConfirmed ? (
           <form action={createWithToast} className="space-y-4">
             <input name="siteId" type="hidden" value={siteId} />
             <div className="grid gap-4 md:grid-cols-2">
@@ -256,6 +258,11 @@ export function SiteShowcaseCard({
               </Button>
             </div>
           </form>
+        ) : (
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            Showcase state could not be confirmed. Reload this page before creating or updating the
+            namespace.
+          </div>
         )}
       </CardContent>
     </Card>

--- a/app/dashboard/sites/[id]/admin/site-showcase-card.tsx
+++ b/app/dashboard/sites/[id]/admin/site-showcase-card.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useActionState, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  createSiteShowcaseAction,
+  updateSiteShowcaseAction,
+  type ActionResponse,
+} from "../../../actions";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Field } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { useActionToast } from "@internal/dashboard/use-action-toast";
+import type { SiteShowcaseResponse } from "@internal/dashboard/webhooks";
+
+const initialState: ActionResponse = { ok: false, message: "" };
+
+type SiteShowcaseCardProps = {
+  siteId: string;
+  sourceUrl: string;
+  targetLangs: string[];
+  showcaseState: SiteShowcaseResponse | null;
+  fetchError?: string | null;
+};
+
+function deriveWebsitePath(sourceUrl: string): string {
+  try {
+    const url = new URL(sourceUrl);
+    return url.hostname.replace(/^www\./, "").toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+export function SiteShowcaseCard({
+  siteId,
+  sourceUrl,
+  targetLangs,
+  showcaseState,
+  fetchError,
+}: SiteShowcaseCardProps) {
+  const router = useRouter();
+  const [createState, createAction, createPending] = useActionState(
+    createSiteShowcaseAction,
+    initialState,
+  );
+  const [updateState, updateAction, updatePending] = useActionState(
+    updateSiteShowcaseAction,
+    initialState,
+  );
+  const suggestedWebsitePath = useMemo(() => deriveWebsitePath(sourceUrl), [sourceUrl]);
+  const [websitePath, setWebsitePath] = useState(
+    showcaseState?.showcase.websitePath ?? suggestedWebsitePath,
+  );
+  const [defaultLang, setDefaultLang] = useState(
+    showcaseState?.showcase.defaultLang ?? targetLangs[0] ?? "",
+  );
+  const [status, setStatus] = useState<"active" | "disabled">(
+    showcaseState?.showcase.status ?? "active",
+  );
+
+  const createWithToast = useActionToast({
+    formAction: createAction,
+    state: createState,
+    pending: createPending,
+    loading: "Creating showcase...",
+    success: "Showcase created.",
+    error: "Unable to create showcase.",
+  });
+
+  const updateWithToast = useActionToast({
+    formAction: updateAction,
+    state: updateState,
+    pending: updatePending,
+    loading: "Updating showcase...",
+    success: "Showcase updated.",
+    error: "Unable to update showcase.",
+  });
+
+  useEffect(() => {
+    if (!createState.ok && !updateState.ok) {
+      return;
+    }
+    router.refresh();
+  }, [createState.ok, router, updateState.ok]);
+
+  return (
+    <Card className="border-border/60 bg-muted/20">
+      <CardHeader>
+        <CardTitle>Showcase</CardTitle>
+        <CardDescription>
+          Public demo access on <span className="font-medium text-foreground">t2.weblingo.app</span>
+          . Customer domains still stay blocked until DNS verification is complete.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {fetchError ? (
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            {fetchError}
+          </div>
+        ) : null}
+
+        {showcaseState ? (
+          <>
+            <div className="flex flex-wrap gap-2">
+              <Badge variant={showcaseState.showcase.status === "active" ? "secondary" : "outline"}>
+                Namespace {showcaseState.showcase.status}
+              </Badge>
+              <Badge variant="outline">
+                Customer serving {showcaseState.customerServingStatus}
+              </Badge>
+              <Badge variant="outline">
+                Showcase serving {showcaseState.showcaseServingStatus ?? "inactive"}
+              </Badge>
+            </div>
+
+            <div className="grid gap-3 rounded-xl border border-border/60 bg-background p-4 md:grid-cols-2">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Public URL
+                </p>
+                <p className="mt-1 font-mono text-sm text-foreground">
+                  {showcaseState.showcase.url ?? "No default language selected"}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Website path
+                </p>
+                <p className="mt-1 font-mono text-sm text-foreground">
+                  {showcaseState.showcase.websitePath}
+                </p>
+              </div>
+            </div>
+
+            <form action={updateWithToast} className="space-y-4">
+              <input name="siteId" type="hidden" value={siteId} />
+              <div className="grid gap-4 md:grid-cols-2">
+                <Field
+                  label="Default language"
+                  htmlFor={`showcase-default-lang-${siteId}`}
+                  description="Root showcase requests redirect here."
+                >
+                  <select
+                    id={`showcase-default-lang-${siteId}`}
+                    name="defaultLang"
+                    className="h-10 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+                    value={defaultLang}
+                    onChange={(event) => setDefaultLang(event.target.value)}
+                    disabled={updatePending}
+                  >
+                    {targetLangs.map((lang) => (
+                      <option key={lang} value={lang}>
+                        {lang}
+                      </option>
+                    ))}
+                  </select>
+                </Field>
+                <Field
+                  label="Namespace status"
+                  htmlFor={`showcase-status-${siteId}`}
+                  description="Disable the showcase without touching the customer-facing site state."
+                >
+                  <select
+                    id={`showcase-status-${siteId}`}
+                    name="status"
+                    className="h-10 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+                    value={status}
+                    onChange={(event) => setStatus(event.target.value as "active" | "disabled")}
+                    disabled={updatePending}
+                  >
+                    <option value="active">active</option>
+                    <option value="disabled">disabled</option>
+                  </select>
+                </Field>
+              </div>
+              <div className="flex flex-col gap-3 border-t border-border/60 pt-4 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-xs text-muted-foreground">
+                  Showcase URLs remain public. SEO is suppressed via noindex and robots blocking.
+                </p>
+                <div className="flex gap-2">
+                  {showcaseState.showcase.url ? (
+                    <Button asChild variant="outline">
+                      <a href={showcaseState.showcase.url} target="_blank" rel="noreferrer">
+                        Open showcase
+                      </a>
+                    </Button>
+                  ) : null}
+                  <Button type="submit" disabled={updatePending}>
+                    {updatePending ? "Saving..." : "Update showcase"}
+                  </Button>
+                </div>
+              </div>
+            </form>
+          </>
+        ) : (
+          <form action={createWithToast} className="space-y-4">
+            <input name="siteId" type="hidden" value={siteId} />
+            <div className="grid gap-4 md:grid-cols-2">
+              <Field
+                label="Website path"
+                htmlFor={`create-showcase-path-${siteId}`}
+                description="Public path segment under t2.weblingo.app."
+              >
+                <Input
+                  id={`create-showcase-path-${siteId}`}
+                  name="websitePath"
+                  value={websitePath}
+                  onChange={(event) => setWebsitePath(event.target.value.toLowerCase())}
+                  placeholder={suggestedWebsitePath || "autotrim.com"}
+                  required
+                />
+              </Field>
+              <Field
+                label="Default language"
+                htmlFor={`create-showcase-default-lang-${siteId}`}
+                description="Used when the showcase root is opened."
+              >
+                <select
+                  id={`create-showcase-default-lang-${siteId}`}
+                  name="defaultLang"
+                  className="h-10 rounded-md border border-border bg-background px-3 text-sm text-foreground"
+                  value={defaultLang}
+                  onChange={(event) => setDefaultLang(event.target.value)}
+                  disabled={createPending}
+                >
+                  {targetLangs.map((lang) => (
+                    <option key={lang} value={lang}>
+                      {lang}
+                    </option>
+                  ))}
+                </select>
+              </Field>
+            </div>
+            <div className="rounded-xl border border-border/60 bg-background p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Preview URL
+              </p>
+              <p className="mt-1 font-mono text-sm text-foreground">
+                {websitePath && defaultLang
+                  ? `https://t2.weblingo.app/${websitePath}/${defaultLang}`
+                  : "Choose a website path and default language to preview the showcase URL."}
+              </p>
+            </div>
+            <div className="flex flex-col gap-3 border-t border-border/60 pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-xs text-muted-foreground">
+                Use this when a managed demo site exists but does not yet have its showcase
+                namespace.
+              </p>
+              <Button type="submit" disabled={createPending || !websitePath || !defaultLang}>
+                {createPending ? "Creating..." : "Create showcase"}
+              </Button>
+            </div>
+          </form>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/dashboard/sites/[id]/pages/page.tsx
+++ b/app/dashboard/sites/[id]/pages/page.tsx
@@ -98,6 +98,7 @@ export default async function SitePagesPage({ params, searchParams }: SitePagesP
     needs_domain: t("dashboard.serving.status.needsDomain"),
     ready: t("dashboard.serving.status.ready"),
     serving: t("dashboard.serving.status.serving"),
+    degraded: t("dashboard.serving.status.degraded", "Degraded"),
   };
   const crawlStatusLabels = {
     in_progress: t("dashboard.crawl.status.inProgress"),

--- a/content/docs/_generated/backend-feature-catalog.snapshot.json
+++ b/content/docs/_generated/backend-feature-catalog.snapshot.json
@@ -56,6 +56,62 @@
       "endpoint": {
         "auth": "bearer",
         "method": "POST",
+        "operationId": "admin.managedDemos.create",
+        "path": "/admin/managed-demos"
+      },
+      "family": "api",
+      "flagKeys": [
+        "internalOpsEnabled"
+      ],
+      "group": "admin",
+      "id": "api.admin.managedDemos.create",
+      "name": "Create a managed demo account, site, and showcase",
+      "playbooks": [
+        {
+          "anchor": "playbook-admin-managed-demos",
+          "id": "playbook-admin-managed-demos",
+          "title": "Playbook: Admin Managed Demos"
+        }
+      ],
+      "routeIds": [
+        "admin.managedDemos.create"
+      ],
+      "stability": "Internal",
+      "summary": "Creates an internal managed demo account, links it to the authenticated internal admin actor, provisions the first site, and reserves its showcase namespace.",
+      "userFacing": false
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "admin.managedDemos.list",
+        "path": "/admin/managed-demos"
+      },
+      "family": "api",
+      "flagKeys": [
+        "internalOpsEnabled"
+      ],
+      "group": "admin",
+      "id": "api.admin.managedDemos.list",
+      "name": "List admin-managed demo sites",
+      "playbooks": [
+        {
+          "anchor": "playbook-admin-managed-demos",
+          "id": "playbook-admin-managed-demos",
+          "title": "Playbook: Admin Managed Demos"
+        }
+      ],
+      "routeIds": [
+        "admin.managedDemos.list"
+      ],
+      "stability": "Internal",
+      "summary": "Returns showcase-backed demo sites owned by managed demo accounts linked to the authenticated internal admin actor.",
+      "userFacing": false
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
         "operationId": "agency.customers.create",
         "path": "/agency/customers"
       },
@@ -1036,6 +1092,84 @@
       "stability": "Internal",
       "summary": "Get pipeline status for a page version",
       "userFacing": false
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
+        "operationId": "sites.showcase.create",
+        "path": "/sites/:siteId/showcase"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.showcase",
+      "id": "api.sites.showcase.create",
+      "name": "Create site showcase namespace",
+      "playbooks": [
+        {
+          "anchor": "playbook-admin-managed-demos",
+          "id": "playbook-admin-managed-demos",
+          "title": "Playbook: Admin Managed Demos"
+        }
+      ],
+      "routeIds": [
+        "sites.showcase.create"
+      ],
+      "stability": "GA",
+      "summary": "Reserves a showcase namespace on the managed showcase host for an existing site. Internal admin access required.",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "sites.showcase.get",
+        "path": "/sites/:siteId/showcase"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.showcase",
+      "id": "api.sites.showcase.get",
+      "name": "Get site showcase state",
+      "playbooks": [
+        {
+          "anchor": "playbook-admin-managed-demos",
+          "id": "playbook-admin-managed-demos",
+          "title": "Playbook: Admin Managed Demos"
+        }
+      ],
+      "routeIds": [
+        "sites.showcase.get"
+      ],
+      "stability": "GA",
+      "summary": "Returns the showcase namespace and separate customer-live vs showcase serving status for an admin-managed site.",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "PATCH",
+        "operationId": "sites.showcase.update",
+        "path": "/sites/:siteId/showcase"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.showcase",
+      "id": "api.sites.showcase.update",
+      "name": "Update site showcase state",
+      "playbooks": [
+        {
+          "anchor": "playbook-admin-managed-demos",
+          "id": "playbook-admin-managed-demos",
+          "title": "Playbook: Admin Managed Demos"
+        }
+      ],
+      "routeIds": [
+        "sites.showcase.update"
+      ],
+      "stability": "GA",
+      "summary": "Updates showcase default language or status for an existing site showcase. Internal admin access required.",
+      "userFacing": true
     },
     {
       "endpoint": {

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -1400,6 +1400,53 @@
         ],
         "type": "object"
       },
+      "CreateManagedDemoSiteRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "showcase": {
+            "additionalProperties": false,
+            "properties": {
+              "defaultLang": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "websitePath": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "site": {
+            "$ref": "#/components/schemas/CreateSiteRequest"
+          }
+        },
+        "required": [
+          "site"
+        ],
+        "type": "object"
+      },
+      "CreateManagedDemoSiteResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "accountId": {
+            "type": "string"
+          },
+          "showcase": {
+            "$ref": "#/components/schemas/ManagedDemoShowcase"
+          },
+          "site": {
+            "$ref": "#/components/schemas/SiteWithCrawlStatus"
+          }
+        },
+        "required": [
+          "accountId",
+          "site",
+          "showcase"
+        ],
+        "type": "object"
+      },
       "CreateOverrideRequest": {
         "additionalProperties": false,
         "properties": {
@@ -1603,6 +1650,24 @@
         ],
         "type": "object"
       },
+      "CreateSiteShowcaseRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "defaultLang": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "websitePath": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "websitePath"
+        ],
+        "type": "object"
+      },
       "DailyCrawlUsage": {
         "additionalProperties": false,
         "properties": {
@@ -1734,6 +1799,9 @@
           "completeness": {
             "$ref": "#/components/schemas/DeploymentCompleteness"
           },
+          "customerServingStatus": {
+            "$ref": "#/components/schemas/DeploymentServingStatus"
+          },
           "deploymentId": {
             "description": "Latest deployment row id from the durable deployments table.",
             "type": [
@@ -1777,6 +1845,22 @@
           },
           "servingStatus": {
             "$ref": "#/components/schemas/DeploymentServingStatus"
+          },
+          "showcaseServingStatus": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DeploymentServingStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "showcaseUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "stateDrift": {
             "$ref": "#/components/schemas/DeploymentStateDriftSignal"
@@ -2713,6 +2797,21 @@
         ],
         "type": "object"
       },
+      "ListManagedDemoSitesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ManagedDemoSiteSummary"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object"
+      },
       "ListSitePagesResponse": {
         "additionalProperties": false,
         "properties": {
@@ -2795,6 +2894,138 @@
         },
         "required": [
           "summaries"
+        ],
+        "type": "object"
+      },
+      "ManagedDemoDeploymentSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "activatedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "activeActivatedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "activeDeploymentId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "activeDeploymentRowId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "activeDeploymentStatus": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "deploymentId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "targetLang": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "targetLang",
+          "deploymentId",
+          "status",
+          "activeDeploymentId",
+          "activeDeploymentRowId",
+          "activeDeploymentStatus"
+        ],
+        "type": "object"
+      },
+      "ManagedDemoShowcase": {
+        "$ref": "#/components/schemas/SiteShowcase"
+      },
+      "ManagedDemoShowcaseStatus": {
+        "enum": [
+          "active",
+          "disabled"
+        ],
+        "type": "string"
+      },
+      "ManagedDemoSiteSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "accountId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "customerServingStatus": {
+            "$ref": "#/components/schemas/DeploymentServingStatus"
+          },
+          "deployment": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ManagedDemoDeploymentSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "showcase": {
+            "$ref": "#/components/schemas/ManagedDemoShowcase"
+          },
+          "showcaseServingStatus": {
+            "$ref": "#/components/schemas/DeploymentServingStatus"
+          },
+          "siteId": {
+            "type": "string"
+          },
+          "siteStatus": {
+            "enum": [
+              "active",
+              "inactive"
+            ],
+            "type": "string"
+          },
+          "sourceUrl": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "accountId",
+          "siteId",
+          "sourceUrl",
+          "siteStatus",
+          "customerServingStatus",
+          "showcaseServingStatus",
+          "showcase",
+          "deployment"
         ],
         "type": "object"
       },
@@ -3548,6 +3779,16 @@
           "accountId": {
             "type": "string"
           },
+          "customerServingStatus": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DeploymentServingStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "domains": {
             "items": {
               "$ref": "#/components/schemas/SiteDomain"
@@ -3591,6 +3832,26 @@
           },
           "servingMode": {
             "$ref": "#/components/schemas/ServingMode"
+          },
+          "showcase": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SiteShowcase"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "showcaseServingStatus": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DeploymentServingStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "siteProfile": {
             "anyOf": [
@@ -4004,6 +4265,72 @@
         ],
         "type": "object"
       },
+      "SiteShowcase": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "defaultLang": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/ManagedDemoShowcaseStatus"
+          },
+          "updatedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "websitePath": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "websitePath",
+          "defaultLang",
+          "status",
+          "url"
+        ],
+        "type": "object"
+      },
+      "SiteShowcaseResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "customerServingStatus": {
+            "$ref": "#/components/schemas/DeploymentServingStatus"
+          },
+          "showcase": {
+            "$ref": "#/components/schemas/SiteShowcase"
+          },
+          "showcaseServingStatus": {
+            "$ref": "#/components/schemas/DeploymentServingStatus"
+          },
+          "siteId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "siteId",
+          "customerServingStatus",
+          "showcaseServingStatus",
+          "showcase"
+        ],
+        "type": "object"
+      },
       "SiteSummary": {
         "additionalProperties": false,
         "description": "Summary shape returned by `GET /api/sites`. Excludes detail/sensitive fields such as `locales`, `domains`, `routeConfig`, `webhookUrl`, `webhookSecret`, and `latestCrawlRun`.",
@@ -4099,6 +4426,16 @@
           "crawlStatus": {
             "$ref": "#/components/schemas/CrawlStatus"
           },
+          "customerServingStatus": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DeploymentServingStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "domains": {
             "items": {
               "$ref": "#/components/schemas/SiteDomain"
@@ -4142,6 +4479,26 @@
           },
           "servingMode": {
             "$ref": "#/components/schemas/ServingMode"
+          },
+          "showcase": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SiteShowcase"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "showcaseServingStatus": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DeploymentServingStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "siteProfile": {
             "anyOf": [
@@ -4625,6 +4982,21 @@
         },
         "type": "object"
       },
+      "UpdateSiteShowcaseRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "defaultLang": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/ManagedDemoShowcaseStatus"
+          }
+        },
+        "type": "object"
+      },
       "UpsertGlossaryRequest": {
         "additionalProperties": false,
         "properties": {
@@ -4895,6 +5267,221 @@
         "summary": "Get current account entitlements and quotas",
         "tags": [
           "Accounts"
+        ]
+      }
+    },
+    "/admin/managed-demos": {
+      "get": {
+        "description": "Returns showcase-backed demo sites owned by managed demo accounts linked to the authenticated internal admin actor.",
+        "operationId": "admin.managedDemos.list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "items": [
+                    {
+                      "accountId": "string",
+                      "customerServingStatus": "inactive",
+                      "deployment": {
+                        "activeDeploymentId": "string",
+                        "activeDeploymentRowId": "string",
+                        "activeDeploymentStatus": "string",
+                        "deploymentId": "string",
+                        "status": "string",
+                        "targetLang": "string"
+                      },
+                      "showcase": {
+                        "defaultLang": "string",
+                        "status": "active",
+                        "url": "string",
+                        "websitePath": "string"
+                      },
+                      "showcaseServingStatus": "inactive",
+                      "siteId": "string",
+                      "siteStatus": "active",
+                      "sourceUrl": "string"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ListManagedDemoSitesResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List admin-managed demo sites",
+        "tags": [
+          "Admin"
+        ]
+      },
+      "post": {
+        "description": "Creates an internal managed demo account, links it to the authenticated internal admin actor, provisions the first site, and reserves its showcase namespace.",
+        "operationId": "admin.managedDemos.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "site": {
+                  "maxLocales": 5,
+                  "servingMode": "strict",
+                  "sourceLang": "en",
+                  "sourceUrl": "https://www.example.com",
+                  "subdomainPattern": "{lang}.example.com",
+                  "targetLangs": [
+                    "fr",
+                    "de"
+                  ]
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CreateManagedDemoSiteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "accountId": "string",
+                  "showcase": {
+                    "defaultLang": "string",
+                    "status": "active",
+                    "url": "string",
+                    "websitePath": "string"
+                  },
+                  "site": {
+                    "accountId": "string",
+                    "crawlStatus": {
+                      "enqueued": true
+                    },
+                    "domains": [
+                      {
+                        "domain": "string",
+                        "status": "pending",
+                        "verificationToken": "string"
+                      }
+                    ],
+                    "id": "string",
+                    "locales": [
+                      {
+                        "serveEnabled": true,
+                        "sourceLang": "string",
+                        "targetLang": "string"
+                      }
+                    ],
+                    "maxLocales": 1,
+                    "servingMode": "strict",
+                    "sourceUrl": "string",
+                    "status": "active"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CreateManagedDemoSiteResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create a managed demo account, site, and showcase",
+        "tags": [
+          "Admin"
         ]
       }
     },
@@ -5496,7 +6083,7 @@
                   "expiresAt": "2026-02-12T21:00:00.000Z",
                   "previewId": "9f27aa40-a2bc-4e8f-8f17-573b66195f1c",
                   "previewUrl": null,
-                  "status": "queued",
+                  "status": "pending",
                   "statusToken": "<status-token>",
                   "streamUrl": "/api/previews/9f27aa40-a2bc-4e8f-8f17-573b66195f1c/stream"
                 },
@@ -8748,6 +9335,296 @@
         "tags": [
           "Sites",
           "Pipeline"
+        ]
+      }
+    },
+    "/sites/{siteId}/showcase": {
+      "get": {
+        "description": "Returns the showcase namespace and separate customer-live vs showcase serving status for an admin-managed site.",
+        "operationId": "sites.showcase.get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "customerServingStatus": "inactive",
+                  "showcase": {
+                    "defaultLang": "string",
+                    "status": "active",
+                    "url": "string",
+                    "websitePath": "string"
+                  },
+                  "showcaseServingStatus": "inactive",
+                  "siteId": "string"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SiteShowcaseResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get site showcase state",
+        "tags": [
+          "Sites",
+          "Admin"
+        ]
+      },
+      "patch": {
+        "description": "Updates showcase default language or status for an existing site showcase. Internal admin access required.",
+        "operationId": "sites.showcase.update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "defaultLang": "string",
+                "status": "active"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSiteShowcaseRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "customerServingStatus": "inactive",
+                  "showcase": {
+                    "defaultLang": "string",
+                    "status": "active",
+                    "url": "string",
+                    "websitePath": "string"
+                  },
+                  "showcaseServingStatus": "inactive",
+                  "siteId": "string"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SiteShowcaseResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Update site showcase state",
+        "tags": [
+          "Sites",
+          "Admin"
+        ]
+      },
+      "post": {
+        "description": "Reserves a showcase namespace on the managed showcase host for an existing site. Internal admin access required.",
+        "operationId": "sites.showcase.create",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "websitePath": "string"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CreateSiteShowcaseRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "customerServingStatus": "inactive",
+                  "showcase": {
+                    "defaultLang": "string",
+                    "status": "active",
+                    "url": "string",
+                    "websitePath": "string"
+                  },
+                  "showcaseServingStatus": "inactive",
+                  "siteId": "string"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SiteShowcaseResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create site showcase namespace",
+        "tags": [
+          "Sites",
+          "Admin"
         ]
       }
     },

--- a/content/docs/_generated/backend-playbooks.snapshot.md
+++ b/content/docs/_generated/backend-playbooks.snapshot.md
@@ -34,6 +34,17 @@ Human workflow playbooks built on top of generated operation contracts. Payload 
 7. Generate language switcher snippets for custom frontend integration:
    - `operationId`: `sites.switcherSnippets.get`
 
+## Playbook: Admin Managed Demos
+
+1. List managed demo sites across the current internal admin account:
+   - `operationId`: `admin.managedDemos.list`
+2. Create a managed demo account, first site, and showcase namespace:
+   - `operationId`: `admin.managedDemos.create`
+3. Inspect and manage the showcase namespace for a managed demo site:
+   - `operationId`: `sites.showcase.get`
+   - `operationId`: `sites.showcase.create`
+   - `operationId`: `sites.showcase.update`
+
 ## Playbook: Serving Access and Previews
 
 1. Ensure locale serving is enabled:

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,17 +1,17 @@
 {
-  "generatedAt": "2026-03-23T21:39:03+09:00",
+  "generatedAt": "2026-03-24T13:14:42+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
-      "bytes": 64655,
-      "sha256": "8412e2e4d0627dfe51986e402807aa0dbded5a6360698fb4dc86d3324391acb0"
+      "bytes": 68753,
+      "sha256": "f5e32b644ad46258b1df91cf6e597feff825eeee9e11dd0f3c29586acb82525d"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 250837,
-      "sha256": "dc4a117537884398e4fccf3f607c7568a046f0ad93f4471126d61a7cf9930922"
+      "bytes": 274934,
+      "sha256": "a7da148f3c9aa31df4bd7f2a624d90dd01dcd263adbbc6dbdf23788bc0232c24"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
-      "bytes": 6021,
-      "sha256": "c59f0bf9aab6355e9602e7c397a764239a1e03607fd3444764eca652e102f7e8"
+      "bytes": 6489,
+      "sha256": "2c7e6ec9313e4801f0b42174d88a4c0a9614e9db55c8c40899e0e0696752dd1b"
     }
   },
   "requiredEnv": [
@@ -20,19 +20,19 @@
   "schemaVersion": 1,
   "sourceFiles": {
     "docs/reference/API_PLAYBOOKS.md": {
-      "bytes": 6021,
-      "sha256": "c59f0bf9aab6355e9602e7c397a764239a1e03607fd3444764eca652e102f7e8"
+      "bytes": 6489,
+      "sha256": "2c7e6ec9313e4801f0b42174d88a4c0a9614e9db55c8c40899e0e0696752dd1b"
     },
     "docs/reference/feature-catalog.generated.json": {
-      "bytes": 59589,
-      "sha256": "48e51f4b8310488891a33312c40c5b7d53ee2cd4e936d25089c670e5863b90bf"
+      "bytes": 63575,
+      "sha256": "d5ec8a69baf2d6a6165bfe6e3d746fc3f8dd8c1d74b8cc6b25c58446cb0a8816"
     },
     "docs/reference/openapi.json": {
-      "bytes": 195039,
-      "sha256": "552efed88a095fea6ded74a3896b61b1e5e0fcf0108ab086403a290090f93a32"
+      "bytes": 213998,
+      "sha256": "e7e35836511f8446e733fc4b3a6850e20a7638ba31b0d4b47f429b9a6a752200"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-03-23T21:39:03+09:00",
+  "sourceRepoCommitTimestamp": "2026-03-24T13:14:42+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "fbc22b37186a40eaea30d1b8da3e2ad9187c8899"
+  "sourceRepoSha": "96d10b45ac13cd577ddab78de216f83eaaee6e52"
 }

--- a/docs/backend/DASHBOARD_SPECS.md
+++ b/docs/backend/DASHBOARD_SPECS.md
@@ -121,6 +121,17 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
 
 - Use for listing and inviting managed customer accounts.
 
+### Internal admin managed demos
+
+`GET /api/admin/managed-demos` and `POST /api/admin/managed-demos`
+
+- Internal-admin-only surfaces for pre-sales demo operations.
+- `GET` returns the managed demo inventory linked to the authenticated admin actor, including showcase state and deployment summary.
+- `POST` creates a managed demo account, first site, and showcase namespace together.
+- Website mapping:
+  - `/dashboard/ops/showcases` lists existing demos and creates new ones.
+  - "Open site admin" should switch workspace into the managed demo account, then redirect to `/dashboard/sites/:id/admin`.
+
 ### Sites (onboarding & management)
 
 `POST /api/sites`
@@ -151,6 +162,16 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
 - Response:
   - Default: `{ site, deployments }`.
   - With `includePages=true`: `{ site, deployments, pages, pagination }`.
+
+`GET /api/sites/:id/showcase`, `POST /api/sites/:id/showcase`, `PATCH /api/sites/:id/showcase`
+
+- Internal-admin-only showcase namespace management for a specific site.
+- `GET` returns `{ siteId, customerServingStatus, showcaseServingStatus, showcase }`.
+- `POST` reserves a showcase namespace on `t2.weblingo.app`.
+- `PATCH` updates showcase `defaultLang` and `status` (`active | disabled`).
+- Website mapping:
+  - Render the showcase card on `/dashboard/sites/:id/admin` for internal admins only.
+  - Keep showcase access public; only creation and mutation are admin-gated.
 
 `PATCH /api/sites/:id`
 
@@ -295,6 +316,8 @@ Legend:
 | `accounts.me`                          | GA        | live   | dashboard | Dashboard entitlements/flags bootstrap and plan gating.       |
 | `agency.customers.list`                | GA        | live   | dashboard | Agency customer list and workspace switching.                 |
 | `agency.customers.create`              | GA        | live   | dashboard | Agency invite/create customer workflow.                       |
+| `admin.managedDemos.list`              | Beta      | live   | dashboard | Internal admin managed demo inventory page.                   |
+| `admin.managedDemos.create`            | Beta      | live   | dashboard | Internal admin managed demo bootstrap flow.                   |
 | `auth.token.mint`                      | GA        | live   | dashboard | Supabase-to-webhooks JWT bridge used for all dashboard calls. |
 | `dashboard.bootstrap`                  | GA        | live   | dashboard | One-call auth + entitlements + account context bootstrap.     |
 | `digests.subscription.upsert`          | Beta      | live   | dashboard | Site details “Automation and notifications” card.             |
@@ -305,6 +328,9 @@ Legend:
 | `sites.create`                         | GA        | live   | dashboard | Onboarding create site action.                                |
 | `sites.get`                            | GA        | live   | dashboard | Site detail loading and admin context.                        |
 | `sites.dashboard.get`                  | GA        | live   | dashboard | Consolidated site dashboard payload for detail pages.         |
+| `sites.showcase.get`                   | Beta      | live   | dashboard | Site-admin showcase card read path.                           |
+| `sites.showcase.create`                | Beta      | live   | dashboard | Site-admin showcase bootstrap for managed demo sites.         |
+| `sites.showcase.update`                | Beta      | live   | dashboard | Site-admin showcase default-lang / status updates.            |
 | `sites.update`                         | GA        | live   | dashboard | Site settings updates (status/locales/config/profile).        |
 | `sites.crawl.trigger`                  | GA        | live   | dashboard | Crawl trigger controls on site/admin pages.                   |
 | `sites.crawl_translate.trigger`        | GA        | live   | dashboard | Site details “Crawl + translate selection” control.           |

--- a/docs/dashboard-flow-and-use-cases.md
+++ b/docs/dashboard-flow-and-use-cases.md
@@ -12,6 +12,7 @@ Purpose: describe the user journeys and UX expectations for the customer dashboa
 - Normal customer: owns a single account and manages only their own sites.
 - Agency admin: manages their own agency account plus multiple customer accounts.
 - Agency-managed customer: a standard customer account that is managed by an agency (same UI as normal customer, but accessed via agency context).
+- Internal admin operator: an agency admin with `internal_ops` access who provisions and maintains pre-sales showcase demos.
 
 ## Core flows (normal customer)
 
@@ -42,12 +43,24 @@ Purpose: describe the user journeys and UX expectations for the customer dashboa
 6. Manage customer sites using the same UI as a normal customer.
 7. Switch back to agency workspace for global metrics.
 
+## Core flows (internal admin operator)
+
+1. Stay in the admin workspace and open `/dashboard/ops/showcases`.
+2. Create a managed demo:
+   - Source URL + source language.
+   - Target languages.
+   - Optional showcase path override.
+3. The system creates the managed demo account, first site, and public showcase namespace together.
+4. Review the public `t2.weblingo.app` URL from the managed demo inventory.
+5. Jump directly into the managed workspace from the inventory to continue site-level operations.
+6. On `/dashboard/sites/:id/admin`, adjust showcase default language or disable the showcase namespace without changing customer-domain verification rules.
+
 ## Current state (weblingo_website)
 
 The current dashboard is implemented in `app/dashboard` and uses the webhooks worker API.
 
 - Auth + entitlements: `internal/dashboard/auth.ts` exchanges Supabase tokens for a webhooks JWT and fetches `/accounts/me`.
-- Navigation: Overview, Sites, Developer tools; agencies also see Agency overview + Customers (`app/dashboard/layout.tsx`).
+- Navigation: Overview, Sites, Developer tools; agencies also see Agency overview + Customers, and internal admins also see Showcases (`app/dashboard/layout.tsx`).
 - Overview: summary cards for active sites, unverified domains, and configured locales (`app/dashboard/page.tsx`).
 - Sites list: list + summary per site; plan + usage badges live in the shared header (`app/dashboard/sites/page.tsx`).
 - Site detail: domains, deployments, trigger crawl, glossary, overrides, slugs (`app/dashboard/sites/[id]/page.tsx`).
@@ -56,6 +69,7 @@ The current dashboard is implemented in `app/dashboard` and uses the webhooks wo
 - Onboarding: uses `maxLocales` from `/accounts/me` and blocks adding targets past the cap (`app/dashboard/sites/new/onboarding-form.tsx`).
 - Domain onboarding: handles CNAME instructions (provision/refresh) or TXT verification (`app/dashboard/sites/[id]/page.tsx`).
 - Agency surface: workspace switcher + agency overview/customers list (with filters and invite flow).
+- Internal admin surface: `/dashboard/ops/showcases` for managed demo bootstrap/listing and a showcase card on site-admin pages.
 - Auth refresh policy: dashboard exchanges Supabase tokens for webhooks JWTs server-side on each request, refreshes pre-expiry (5-minute buffer), and retries once on 401.
 - Billing policy: mutations require both actor and subject plans to be active; billing banners warn the billing owner (agency when acting as agency, customer when in own workspace) without showing agency billing warnings to customer workspaces.
 - Polling policy: `/api/dashboard/sites/{siteId}/status` returns only `{ site }` so crawl-status polling does not overfetch deployments.
@@ -114,6 +128,7 @@ Agency admins (in agency context):
 - `/dashboard/sites` — Agency-owned sites (same component as normal customers).
 - `/dashboard/sites/new` — Create agency-owned site (when allowed).
 - `/dashboard/developer-tools` — Tokens/config.
+- `/dashboard/ops/showcases` — Internal managed demo inventory + bootstrap flow.
 
 Workspace switcher (header):
 

--- a/internal/dashboard/auth.ts
+++ b/internal/dashboard/auth.ts
@@ -50,6 +50,13 @@ export type DashboardAuth = {
   has: (requirement: HasCheck) => boolean;
 };
 
+export function hasActorInternalOps(
+  auth: Pick<DashboardAuth, "actorAccount" | "account">,
+): boolean {
+  const actor = auth.actorAccount ?? auth.account;
+  return actor?.planType === "agency" && actor.featureFlags.internalOpsEnabled === true;
+}
+
 const BOOTSTRAP_CACHE_NAMESPACE = "dashboard:bootstrap";
 const BOOTSTRAP_CACHE_MAX_TTL_SECONDS = 300;
 const BOOTSTRAP_CACHE_MIN_TTL_SECONDS = 30;

--- a/internal/dashboard/auth.ts
+++ b/internal/dashboard/auth.ts
@@ -176,6 +176,10 @@ function getBootstrapCacheKey(
   return `${BOOTSTRAP_CACHE_NAMESPACE}:${getCacheEnvPrefix()}:${digest}`;
 }
 
+function shouldBypassBootstrapCache(): boolean {
+  return isDashboardE2eMockEnabled();
+}
+
 function getBootstrapCacheTtlSeconds(expiresAt: string): number | null {
   const parsed = Date.parse(expiresAt);
   if (!Number.isFinite(parsed)) {
@@ -318,14 +322,16 @@ async function getBootstrap({
 }: BootstrapOptions): Promise<BootstrapCacheEntry> {
   const cacheKey = getBootstrapCacheKey(supabaseAccessToken, subjectAccountId);
 
-  try {
-    const cached = await redis.get<BootstrapCacheEntry>(cacheKey);
-    if (cached) {
-      console.info("[dashboard] bootstrap cache hit");
-      return cached;
+  if (!shouldBypassBootstrapCache()) {
+    try {
+      const cached = await redis.get<BootstrapCacheEntry>(cacheKey);
+      if (cached) {
+        console.info("[dashboard] bootstrap cache hit");
+        return cached;
+      }
+    } catch (error) {
+      console.warn("[dashboard] bootstrap cache read failed:", error);
     }
-  } catch (error) {
-    console.warn("[dashboard] bootstrap cache read failed:", error);
   }
 
   console.info("[dashboard] bootstrap cache miss");
@@ -369,12 +375,14 @@ async function getBootstrap({
       }
     }
 
-    const ttlSeconds = getBootstrapCacheTtlSeconds(payload.expiresAt);
-    if (ttlSeconds) {
-      try {
-        await redis.set(cacheKey, payload, { ex: ttlSeconds });
-      } catch (error) {
-        console.warn("[dashboard] bootstrap cache write failed:", error);
+    if (!shouldBypassBootstrapCache()) {
+      const ttlSeconds = getBootstrapCacheTtlSeconds(payload.expiresAt);
+      if (ttlSeconds) {
+        try {
+          await redis.set(cacheKey, payload, { ex: ttlSeconds });
+        } catch (error) {
+          console.warn("[dashboard] bootstrap cache write failed:", error);
+        }
       }
     }
 
@@ -386,6 +394,22 @@ async function getBootstrap({
     return await promise;
   } finally {
     bootstrapInflight.delete(cacheKey);
+  }
+}
+
+export async function invalidateDashboardBootstrapCache(
+  supabaseAccessToken: string,
+  subjectAccountId?: string | null,
+): Promise<void> {
+  if (!supabaseAccessToken || shouldBypassBootstrapCache()) {
+    return;
+  }
+  const cacheKey = getBootstrapCacheKey(supabaseAccessToken, subjectAccountId);
+  bootstrapInflight.delete(cacheKey);
+  try {
+    await redis.del(cacheKey);
+  } catch (error) {
+    console.warn("[dashboard] bootstrap cache invalidate failed:", error);
   }
 }
 

--- a/internal/dashboard/webhooks.openapi-contract.test.ts
+++ b/internal/dashboard/webhooks.openapi-contract.test.ts
@@ -68,30 +68,32 @@ function resolveOpenApiRef(
   definitionsIndex: Map<string, unknown>,
   schema: unknown,
 ): unknown {
-  if (!schema || typeof schema !== "object") {
-    return schema;
-  }
-  const ref = (schema as { $ref?: unknown }).$ref;
-  if (typeof ref !== "string") {
-    return schema;
+  let current = schema;
+  const seen = new Set<string>();
+
+  while (current && typeof current === "object") {
+    const ref = (current as { $ref?: unknown }).$ref;
+    if (typeof ref !== "string") {
+      return current;
+    }
+    if (seen.has(ref)) {
+      throw new Error(`[contracts] Cyclic OpenAPI $ref: ${ref}`);
+    }
+    seen.add(ref);
+
+    const match = ref.match(/^#\/components\/schemas\/(.+)$/);
+    if (!match) {
+      throw new Error(`[contracts] Unsupported OpenAPI $ref: ${ref}`);
+    }
+    const name = match[1];
+    const resolved = spec.components?.schemas?.[name] ?? definitionsIndex.get(name);
+    if (!resolved) {
+      throw new Error(`[contracts] OpenAPI ref not found: ${ref}`);
+    }
+    current = resolved;
   }
 
-  const match = ref.match(/^#\/components\/schemas\/(.+)$/);
-  if (!match) {
-    throw new Error(`[contracts] Unsupported OpenAPI $ref: ${ref}`);
-  }
-  const name = match[1];
-  const resolved = spec.components?.schemas?.[name];
-  if (resolved) {
-    return resolved;
-  }
-
-  const fromDefinitions = definitionsIndex.get(name);
-  if (fromDefinitions) {
-    return fromDefinitions;
-  }
-
-  throw new Error(`[contracts] OpenAPI ref not found: ${ref}`);
+  return current;
 }
 
 function normalizeOpenApiSchema(
@@ -355,12 +357,17 @@ describe("webhooks OpenAPI contract (dashboard client)", () => {
       { path: "/accounts/me", method: "get" },
       { path: "/agency/customers", method: "get" },
       { path: "/agency/customers", method: "post" },
+      { path: "/admin/managed-demos", method: "get" },
+      { path: "/admin/managed-demos", method: "post" },
       { path: "/digests/subscription", method: "put" },
       { path: "/sites", method: "get" },
       { path: "/sites", method: "post" },
       { path: "/sites/{siteId}", method: "get" },
       { path: "/sites/{siteId}", method: "patch" },
       { path: "/sites/{siteId}/dashboard", method: "get" },
+      { path: "/sites/{siteId}/showcase", method: "get" },
+      { path: "/sites/{siteId}/showcase", method: "post" },
+      { path: "/sites/{siteId}/showcase", method: "patch" },
       { path: "/sites/{siteId}/crawl", method: "post" },
       { path: "/sites/{siteId}/crawl-translate", method: "post" },
       { path: "/sites/{siteId}/translate", method: "post" },
@@ -413,6 +420,18 @@ describe("webhooks OpenAPI contract (dashboard client)", () => {
       {
         name: "CreateAgencyCustomerResponse",
         schema: __webhooksZodContracts.createAgencyCustomerResponseSchema,
+      },
+      {
+        name: "ListManagedDemoSitesResponse",
+        schema: __webhooksZodContracts.listManagedDemoSitesResponseSchema,
+      },
+      {
+        name: "CreateManagedDemoSiteResponse",
+        schema: __webhooksZodContracts.createManagedDemoSiteResponseSchema,
+      },
+      {
+        name: "SiteShowcaseResponse",
+        schema: __webhooksZodContracts.siteShowcaseResponseSchema,
       },
       {
         name: "DigestSubscriptionResponse",

--- a/internal/dashboard/webhooks.openapi-contract.test.ts
+++ b/internal/dashboard/webhooks.openapi-contract.test.ts
@@ -526,4 +526,17 @@ describe("webhooks OpenAPI contract (dashboard client)", () => {
       }
     }
   });
+
+  it("keeps SiteShowcaseResponse.showcaseServingStatus required and non-null", async () => {
+    const spec = readOpenApiSpecFromEnv();
+    const openApiSchema = spec.components?.schemas?.SiteShowcaseResponse as
+      | {
+          required?: string[];
+          properties?: Record<string, { nullable?: boolean }>;
+        }
+      | undefined;
+    expect(openApiSchema).toBeTruthy();
+    expect(openApiSchema?.required).toContain("showcaseServingStatus");
+    expect(openApiSchema?.properties?.showcaseServingStatus?.nullable ?? false).toBe(false);
+  });
 });

--- a/internal/dashboard/webhooks.timeout.test.ts
+++ b/internal/dashboard/webhooks.timeout.test.ts
@@ -219,6 +219,70 @@ describe("webhooks request wrapper", () => {
     expect(timeoutValues).toContain(10_000);
   });
 
+  it("accepts site dashboard payloads with operational summary fields", async () => {
+    const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("Authorization")).toBe("Bearer token");
+
+      return new Response(
+        JSON.stringify({
+          site: {
+            id: "site-1",
+            accountId: "acct-1",
+            sourceUrl: "https://example.com",
+            status: "active",
+            servingMode: "strict",
+            maxLocales: null,
+            siteProfile: null,
+            locales: [],
+            domains: [],
+            latestCrawlRun: null,
+          },
+          deployments: [],
+          operationalSummary: {
+            retry: {
+              activeRunCount: 1,
+              pagesCompleted: 1,
+              pagesPending: 2,
+              pagesInProgress: 0,
+              pagesFailed: 0,
+            },
+            dlq: {
+              total: 1,
+              perWorker: { translate: 1 },
+              oldest: "2026-03-25T00:00:00.000Z",
+              newest: "2026-03-25T00:00:00.000Z",
+              truncated: false,
+              complete: true,
+              invalidEntries: 0,
+              unreadableEntries: 0,
+              monitorPath: "/api/sites/site-1/dlq",
+              replayPath: "/api/sites/site-1/dlq/replay",
+            },
+            health: {
+              readyPaths: {
+                webhooks: "/api/health/ready",
+                serve: "/health/ready",
+                ops: "/health/ready",
+              },
+              heartbeatKey: "heartbeat:v1:webhooks.scheduled",
+              runbookPath: "/docs/ops/V1_OPERATIONS.md#queue-backlog--pipeline-stalls",
+            },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    (globalThis as { fetch: typeof fetch }).fetch = fetchSpy as typeof fetch;
+
+    vi.resetModules();
+    const { fetchSiteDashboard } = await import("./webhooks");
+    const payload = await fetchSiteDashboard("token", "site-1");
+
+    expect(payload.operationalSummary?.health.heartbeatKey).toBe("heartbeat:v1:webhooks.scheduled");
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
   it("requests deployment history with optional filters", async () => {
     const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();

--- a/internal/dashboard/webhooks.timeout.test.ts
+++ b/internal/dashboard/webhooks.timeout.test.ts
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const ORIGINAL_ENV = { ...process.env };
 const ORIGINAL_FETCH = globalThis.fetch;
 
+function setEnv(name: string, value: string | undefined) {
+  (process.env as Record<string, string | undefined>)[name] = value;
+}
+
 function setClientEnv() {
   process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
   process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test_123";
@@ -404,5 +408,35 @@ describe("webhooks request wrapper", () => {
     expect(snippets.snippets).toHaveLength(1);
 
     expect(fetchSpy).toHaveBeenCalledTimes(5);
+  });
+
+  it("keeps managed-demo mock payloads aligned with strict dashboard schemas", async () => {
+    setEnv("DASHBOARD_E2E_MOCK", "1");
+    setEnv("NODE_ENV", "test");
+    setEnv("VERCEL_ENV", "preview");
+
+    vi.resetModules();
+    const { createManagedDemo, listManagedDemos } = await import("./webhooks");
+
+    const created = await createManagedDemo("token", {
+      site: {
+        sourceUrl: "https://www.autotrim.com",
+        sourceLang: "en",
+        targetLangs: ["fr"],
+        subdomainPattern: "https://{lang}.autotrim.com",
+        servingMode: "strict",
+        maxLocales: null,
+      },
+      showcase: {
+        defaultLang: "fr",
+      },
+    });
+    const listed = await listManagedDemos("token");
+
+    expect(created.accountId).toBe("acct-demo-managed");
+    expect(created.site.id).toBe("site-smoke-1");
+    expect(created.site.crawlStatus).toEqual({ enqueued: true });
+    expect(created.showcase.websitePath).toBe("source.example.test");
+    expect(listed.items[0]?.showcaseServingStatus).toBe("ready");
   });
 });

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -738,7 +738,7 @@ const siteShowcaseResponseSchema = z
   .object({
     siteId: z.string(),
     customerServingStatus: deploymentServingStatusSchema,
-    showcaseServingStatus: deploymentServingStatusSchema.nullable(),
+    showcaseServingStatus: deploymentServingStatusSchema,
     showcase: siteShowcaseSchema,
   })
   .strict();

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -211,6 +211,53 @@ const sitePagesSummarySchema = z
   })
   .strict();
 
+const siteRetrySummarySchema = z
+  .object({
+    activeRunCount: z.number().int().nonnegative(),
+    pagesCompleted: z.number().int().nonnegative(),
+    pagesPending: z.number().int().nonnegative(),
+    pagesInProgress: z.number().int().nonnegative(),
+    pagesFailed: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const siteDlqSummarySchema = z
+  .object({
+    total: z.number().int().nonnegative(),
+    perWorker: z.record(z.string(), z.number().int().nonnegative()),
+    oldest: z.string().nullable().optional(),
+    newest: z.string().nullable().optional(),
+    truncated: z.boolean(),
+    complete: z.boolean(),
+    invalidEntries: z.number().int().nonnegative(),
+    unreadableEntries: z.number().int().nonnegative(),
+    monitorPath: z.string(),
+    replayPath: z.string(),
+  })
+  .strict();
+
+const siteHealthSummarySchema = z
+  .object({
+    readyPaths: z
+      .object({
+        webhooks: z.string(),
+        serve: z.string(),
+        ops: z.string(),
+      })
+      .strict(),
+    heartbeatKey: z.string(),
+    runbookPath: z.string(),
+  })
+  .strict();
+
+const siteOperationalSummarySchema = z
+  .object({
+    retry: siteRetrySummarySchema.nullable(),
+    dlq: siteDlqSummarySchema.nullable(),
+    health: siteHealthSummarySchema,
+  })
+  .strict();
+
 const crawlStatusSchema = z.object({
   enqueued: z.boolean(),
   error: z.string().optional(),
@@ -597,6 +644,7 @@ const siteDashboardResponseSchema = z
     site: siteSchema,
     deployments: z.array(deploymentSchema),
     pagesSummary: sitePagesSummarySchema.optional(),
+    operationalSummary: siteOperationalSummarySchema.optional(),
     pages: z.array(sitePageSummarySchema).optional(),
     pagination: listSitePagesResponseSchema.shape.pagination.optional(),
   })

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -1303,9 +1303,6 @@ function resolveDashboardE2eMockPayload(input: {
       accountId: "acct-demo-managed",
       site: {
         ...createDashboardE2eMockSite(DASHBOARD_E2E_MOCK_SITE_ID),
-        customerServingStatus: "needs_domain" as const,
-        showcaseServingStatus: "ready" as const,
-        showcase: createDashboardE2eMockSiteShowcase(DASHBOARD_E2E_MOCK_SITE_ID).showcase,
         crawlStatus: {
           enqueued: true,
         },

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -247,7 +247,7 @@ const setLocaleServingResponseSchema = z
   .object({
     targetLang: z.string(),
     serveEnabled: z.boolean(),
-    servingStatus: z.enum(["inactive", "disabled", "needs_domain", "ready", "serving"]),
+    servingStatus: z.enum(["inactive", "disabled", "needs_domain", "ready", "serving", "degraded"]),
     activeDeploymentId: z.string().nullable().optional(),
   })
   .strict();
@@ -357,6 +357,15 @@ const artifactManifestSchema = z
   .nullable()
   .optional();
 
+const deploymentServingStatusSchema = z.enum([
+  "inactive",
+  "disabled",
+  "needs_domain",
+  "ready",
+  "serving",
+  "degraded",
+]);
+
 const deploymentCompletenessStatusSchema = z.enum([
   "not_started",
   "partial",
@@ -385,7 +394,7 @@ const deploymentSchema = z.object({
   domain: z.string().nullable().optional(),
   domainStatus: z.enum(["pending", "verified", "failed"]).nullable().optional(),
   serveEnabled: z.boolean(),
-  servingStatus: z.enum(["inactive", "disabled", "needs_domain", "ready", "serving"]),
+  servingStatus: deploymentServingStatusSchema,
   translationRun: translationRunSchema.nullable().optional(),
   completeness: deploymentCompletenessSchema,
 });
@@ -712,6 +721,70 @@ const createAgencyCustomerResponseSchema = z
   })
   .strict();
 
+const managedDemoShowcaseStatusSchema = z.enum(["active", "disabled"]);
+
+const siteShowcaseSchema = z
+  .object({
+    websitePath: z.string(),
+    defaultLang: z.string().nullable(),
+    status: managedDemoShowcaseStatusSchema,
+    url: z.string().nullable(),
+    createdAt: z.string().nullable().optional(),
+    updatedAt: z.string().nullable().optional(),
+  })
+  .strict();
+
+const siteShowcaseResponseSchema = z
+  .object({
+    siteId: z.string(),
+    customerServingStatus: deploymentServingStatusSchema,
+    showcaseServingStatus: deploymentServingStatusSchema.nullable(),
+    showcase: siteShowcaseSchema,
+  })
+  .strict();
+
+const managedDemoDeploymentSummarySchema = z
+  .object({
+    targetLang: z.string(),
+    deploymentId: z.string().nullable(),
+    status: z.string().nullable(),
+    activatedAt: z.string().nullable().optional(),
+    activeDeploymentId: z.string().nullable(),
+    activeDeploymentRowId: z.string().nullable(),
+    activeDeploymentStatus: z.string().nullable(),
+    activeActivatedAt: z.string().nullable().optional(),
+  })
+  .strict();
+
+const managedDemoSiteSummarySchema = z
+  .object({
+    accountId: z.string(),
+    siteId: z.string(),
+    sourceUrl: z.string(),
+    siteStatus: z.enum(["active", "inactive"]),
+    customerServingStatus: deploymentServingStatusSchema,
+    showcaseServingStatus: deploymentServingStatusSchema,
+    showcase: siteShowcaseSchema,
+    deployment: managedDemoDeploymentSummarySchema.nullable(),
+    createdAt: z.string().nullable().optional(),
+    updatedAt: z.string().nullable().optional(),
+  })
+  .strict();
+
+const listManagedDemoSitesResponseSchema = z
+  .object({
+    items: z.array(managedDemoSiteSummarySchema),
+  })
+  .strict();
+
+const createManagedDemoSiteResponseSchema = z
+  .object({
+    accountId: z.string(),
+    site: siteWithCrawlStatusSchema,
+    showcase: siteShowcaseSchema,
+  })
+  .strict();
+
 const dashboardBootstrapResponseSchema = z
   .object({
     token: z.string().min(1),
@@ -812,6 +885,12 @@ export type AgencyCustomersSummary = z.infer<typeof agencyCustomersSummarySchema
 export type AgencyCustomersResponse = z.infer<typeof listAgencyCustomersResponseSchema>;
 export type CreateAgencyCustomerResponse = z.infer<typeof createAgencyCustomerResponseSchema>;
 export type DashboardBootstrapResponse = z.infer<typeof dashboardBootstrapResponseSchema>;
+export type SiteShowcase = z.infer<typeof siteShowcaseSchema>;
+export type SiteShowcaseResponse = z.infer<typeof siteShowcaseResponseSchema>;
+export type ManagedDemoDeploymentSummary = z.infer<typeof managedDemoDeploymentSummarySchema>;
+export type ManagedDemoSiteSummary = z.infer<typeof managedDemoSiteSummarySchema>;
+export type ListManagedDemoSitesResponse = z.infer<typeof listManagedDemoSitesResponseSchema>;
+export type CreateManagedDemoSiteResponse = z.infer<typeof createManagedDemoSiteResponseSchema>;
 
 // Exported for cross-repo contract tests only (OpenAPI ↔ website zod schemas).
 export const __webhooksZodContracts = {
@@ -821,6 +900,9 @@ export const __webhooksZodContracts = {
   accountMeSchema,
   listAgencyCustomersResponseSchema,
   createAgencyCustomerResponseSchema,
+  listManagedDemoSitesResponseSchema,
+  createManagedDemoSiteResponseSchema,
+  siteShowcaseResponseSchema,
   listSitesResponseSchema,
   siteSummarySchema,
   siteSchema,
@@ -1144,6 +1226,55 @@ function createDashboardE2eMockDashboardPayload(siteId: string, searchParams: UR
   return payload;
 }
 
+function createDashboardE2eMockSiteShowcase(siteId: string) {
+  const now = new Date().toISOString();
+  return {
+    siteId,
+    customerServingStatus: "needs_domain" as const,
+    showcaseServingStatus: "ready" as const,
+    showcase: {
+      websitePath: "source.example.test",
+      defaultLang: "fr",
+      status: "active" as const,
+      url: "https://t2.weblingo.app/source.example.test/fr",
+      createdAt: now,
+      updatedAt: now,
+    },
+  };
+}
+
+function createDashboardE2eMockManagedDemoSummary() {
+  const now = new Date().toISOString();
+  return {
+    accountId: "acct-demo-managed",
+    siteId: DASHBOARD_E2E_MOCK_SITE_ID,
+    sourceUrl: DASHBOARD_E2E_MOCK_SOURCE_URL,
+    siteStatus: "active" as const,
+    customerServingStatus: "needs_domain" as const,
+    showcaseServingStatus: "ready" as const,
+    showcase: {
+      websitePath: "source.example.test",
+      defaultLang: "fr",
+      status: "active" as const,
+      url: "https://t2.weblingo.app/source.example.test/fr",
+      createdAt: now,
+      updatedAt: now,
+    },
+    deployment: {
+      targetLang: "fr",
+      deploymentId: "dep-site-smoke-1-fr-current",
+      status: "active",
+      activatedAt: now,
+      activeDeploymentId: "dep-site-smoke-1-fr-current",
+      activeDeploymentRowId: "deployment-row-fr",
+      activeDeploymentStatus: "active",
+      activeActivatedAt: now,
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
 function resolveDashboardE2eMockPayload(input: {
   path: string;
   method: string;
@@ -1163,6 +1294,26 @@ function resolveDashboardE2eMockPayload(input: {
     return { languages: FALLBACK_SUPPORTED_LANGUAGES.slice(0, 3) };
   }
 
+  if (method === "GET" && pathname === "/admin/managed-demos") {
+    return { items: [createDashboardE2eMockManagedDemoSummary()] };
+  }
+
+  if (method === "POST" && pathname === "/admin/managed-demos") {
+    return {
+      accountId: "acct-demo-managed",
+      site: {
+        ...createDashboardE2eMockSite(DASHBOARD_E2E_MOCK_SITE_ID),
+        customerServingStatus: "needs_domain" as const,
+        showcaseServingStatus: "ready" as const,
+        showcase: createDashboardE2eMockSiteShowcase(DASHBOARD_E2E_MOCK_SITE_ID).showcase,
+        crawlStatus: {
+          enqueued: true,
+        },
+      },
+      showcase: createDashboardE2eMockSiteShowcase(DASHBOARD_E2E_MOCK_SITE_ID).showcase,
+    };
+  }
+
   const siteMatch = pathname.match(/^\/sites\/([^/]+)$/);
   if (siteMatch && method === "GET") {
     return createDashboardE2eMockSite(siteMatch[1]);
@@ -1174,6 +1325,35 @@ function resolveDashboardE2eMockPayload(input: {
   const siteDashboardMatch = pathname.match(/^\/sites\/([^/]+)\/dashboard$/);
   if (siteDashboardMatch && method === "GET") {
     return createDashboardE2eMockDashboardPayload(siteDashboardMatch[1], url.searchParams);
+  }
+
+  const siteShowcaseMatch = pathname.match(/^\/sites\/([^/]+)\/showcase$/);
+  if (siteShowcaseMatch && method === "GET") {
+    return createDashboardE2eMockSiteShowcase(siteShowcaseMatch[1]);
+  }
+  if (siteShowcaseMatch && (method === "POST" || method === "PATCH")) {
+    const payload = getBodyRecord(input.body);
+    const current = createDashboardE2eMockSiteShowcase(siteShowcaseMatch[1]);
+    return {
+      ...current,
+      showcase: {
+        ...current.showcase,
+        websitePath:
+          typeof payload.websitePath === "string" && payload.websitePath.trim().length > 0
+            ? payload.websitePath.trim()
+            : current.showcase.websitePath,
+        defaultLang:
+          payload.defaultLang === null
+            ? null
+            : typeof payload.defaultLang === "string"
+              ? payload.defaultLang
+              : current.showcase.defaultLang,
+        status:
+          payload.status === "disabled" || payload.status === "active"
+            ? payload.status
+            : current.showcase.status,
+      },
+    };
   }
 
   const deploymentsMatch = pathname.match(/^\/sites\/([^/]+)\/deployments$/);
@@ -1720,6 +1900,37 @@ export async function createAgencyCustomer(
   });
 }
 
+export type CreateManagedDemoSitePayload = {
+  site: CreateSitePayload;
+  showcase?: {
+    websitePath?: string;
+    defaultLang?: string | null;
+  };
+};
+
+export async function listManagedDemos(auth: AuthInput): Promise<ListManagedDemoSitesResponse> {
+  return request({
+    path: "/admin/managed-demos",
+    auth,
+    schema: listManagedDemoSitesResponseSchema,
+    timeoutProfile: "list",
+  });
+}
+
+export async function createManagedDemo(
+  auth: AuthInput,
+  payload: CreateManagedDemoSitePayload,
+): Promise<CreateManagedDemoSiteResponse> {
+  return request({
+    path: "/admin/managed-demos",
+    method: "POST",
+    auth,
+    body: payload,
+    schema: createManagedDemoSiteResponseSchema,
+    timeoutProfile: "mutation",
+  });
+}
+
 export async function listSupportedLanguages(): Promise<SupportedLanguage[]> {
   try {
     const data = await request({
@@ -1777,6 +1988,48 @@ export async function fetchSiteDashboard(
     auth,
     schema: siteDashboardResponseSchema,
     timeoutProfile: "detail",
+  });
+}
+
+export async function getSiteShowcase(
+  auth: AuthInput,
+  siteId: string,
+): Promise<SiteShowcaseResponse> {
+  return request({
+    path: `/sites/${siteId}/showcase`,
+    auth,
+    schema: siteShowcaseResponseSchema,
+    timeoutProfile: "detail",
+  });
+}
+
+export async function createSiteShowcase(
+  auth: AuthInput,
+  siteId: string,
+  payload: { websitePath: string; defaultLang?: string | null },
+): Promise<SiteShowcaseResponse> {
+  return request({
+    path: `/sites/${siteId}/showcase`,
+    method: "POST",
+    auth,
+    body: payload,
+    schema: siteShowcaseResponseSchema,
+    timeoutProfile: "mutation",
+  });
+}
+
+export async function updateSiteShowcase(
+  auth: AuthInput,
+  siteId: string,
+  payload: { defaultLang?: string | null; status?: "active" | "disabled" },
+): Promise<SiteShowcaseResponse> {
+  return request({
+    path: `/sites/${siteId}/showcase`,
+    method: "PATCH",
+    auth,
+    body: payload,
+    schema: siteShowcaseResponseSchema,
+    timeoutProfile: "mutation",
   });
 }
 


### PR DESCRIPTION
## Summary

- Why:
  Add the matching admin UI for managed showcase demos so internal admins can create demos, inspect inventory, and jump into managed workspaces from the website dashboard.
- What:
  Add the managed demos ops page and site-admin showcase controls, wire them to the new backend showcase/admin APIs, sync backend OpenAPI/docs snapshots, and harden the dashboard mock/fallback behavior for managed-demo flows.

## Testing

- [x] `corepack pnpm test`
- [x] `corepack pnpm check`
- [x] `corepack pnpm test:contracts`
- [x] `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm docs:sync:check`
- [x] Other: `corepack pnpm vitest --run internal/dashboard/webhooks.timeout.test.ts app/dashboard/actions.capabilities.test.ts`

## Docs sync and capability matrix

- [x] Updated `docs/backend/DASHBOARD_SPECS.md` if user-facing backend capability coverage changed.
- [x] Ran `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm docs:sync` and committed `content/docs/_generated/*` when backend HEAD advanced.
