### PR TITLE
Use backend source lang in site admin

### DIFF
--- a/app/dashboard/sites/[id]/admin/page.test.tsx
+++ b/app/dashboard/sites/[id]/admin/page.test.tsx
@@ -1,0 +1,147 @@
+import { isValidElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireDashboardAuth: vi.fn(),
+  getSiteDashboardCached: vi.fn(),
+  fetchDeploymentHistory: vi.fn(),
+  listSitesCached: vi.fn(),
+  listSupportedLanguagesCached: vi.fn(),
+  getSiteShowcase: vi.fn(),
+  resolvePreferredLocale: vi.fn(() => "en"),
+  resolveLocaleTranslator: vi.fn(async () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  })),
+  SiteAdminForm: vi.fn(() => null),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => new Headers()),
+}));
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("notFound");
+  }),
+}));
+vi.mock("./internal-admin-policy-card", () => ({
+  InternalAdminPolicyCard: () => null,
+}));
+vi.mock("./site-admin-form", () => ({
+  SiteAdminForm: mocks.SiteAdminForm,
+}));
+vi.mock("./site-showcase-card", () => ({
+  SiteShowcaseCard: () => null,
+}));
+vi.mock("@/components/dashboard/action-form", () => ({
+  ActionForm: () => null,
+}));
+vi.mock("@/components/dashboard/error-state-card", () => ({
+  ErrorStateCard: () => null,
+}));
+vi.mock("@/components/dashboard/deployment-completeness-badge", () => ({
+  DeploymentCompletenessBadge: () => null,
+}));
+vi.mock("@/components/dashboard/deployment-history-table", () => ({
+  DeploymentHistoryTable: () => null,
+}));
+vi.mock("@internal/dashboard/auth", () => ({
+  hasActorInternalOps: vi.fn(() => false),
+  requireDashboardAuth: mocks.requireDashboardAuth,
+}));
+vi.mock("@internal/dashboard/data", () => ({
+  getSiteDashboardCached: mocks.getSiteDashboardCached,
+  listSitesCached: mocks.listSitesCached,
+  listSupportedLanguagesCached: mocks.listSupportedLanguagesCached,
+}));
+vi.mock("@internal/dashboard/error-state", () => ({
+  resolveDashboardErrorView: vi.fn((error, fallback) => ({
+    ...fallback,
+    message: error instanceof Error ? error.message : fallback.message,
+  })),
+}));
+vi.mock("@internal/dashboard/webhooks", () => ({
+  fetchDeploymentHistory: mocks.fetchDeploymentHistory,
+  getSiteShowcase: mocks.getSiteShowcase,
+}));
+vi.mock("@internal/i18n", () => ({
+  resolvePreferredLocale: mocks.resolvePreferredLocale,
+  resolveLocaleTranslator: mocks.resolveLocaleTranslator,
+}));
+
+describe("SiteAdminPage", () => {
+  it("prefers backend routeConfig sourceLang over the first locale fallback", async () => {
+    mocks.requireDashboardAuth.mockResolvedValue({
+      webhooksAuth: { token: "token", subjectAccountId: "acct-1" },
+      mutationsAllowed: false,
+      has: vi.fn().mockReturnValue(false),
+      account: null,
+      subjectAccount: null,
+      actorAccount: null,
+      actorAccountId: "acct-1",
+      subjectAccountId: "acct-1",
+      actingAsCustomer: false,
+      subjectFallbackToActor: false,
+    });
+    mocks.getSiteDashboardCached.mockResolvedValue({
+      site: {
+        id: "site-1",
+        accountId: "acct-1",
+        sourceUrl: "https://example.com/",
+        status: "active",
+        servingMode: "strict",
+        maxLocales: null,
+        siteProfile: {},
+        routeConfig: {
+          sourceLang: "ja",
+          sourceOrigin: "https://example.com/",
+          locales: [],
+          clientRuntimeEnabled: true,
+          crawlCaptureMode: "template_plus_hydrated",
+        },
+        locales: [
+          { sourceLang: "en", targetLang: "fr", serveEnabled: true },
+          { sourceLang: "ja", targetLang: "fr", serveEnabled: true },
+        ],
+        domains: [],
+      },
+      deployments: [],
+    });
+    mocks.fetchDeploymentHistory.mockResolvedValue({
+      history: [],
+      perLocaleLimit: 5,
+    });
+    mocks.listSitesCached.mockResolvedValue([]);
+    mocks.listSupportedLanguagesCached.mockResolvedValue([]);
+
+    vi.resetModules();
+    const { default: SiteAdminPage } = await import("./page");
+
+    const tree = await SiteAdminPage({
+      params: Promise.resolve({ id: "site-1" }),
+    });
+
+    function findElement(node: unknown): Record<string, unknown> | null {
+      if (!node) return null;
+      if (Array.isArray(node)) {
+        for (const child of node) {
+          const found = findElement(child);
+          if (found) return found;
+        }
+        return null;
+      }
+      if (!isValidElement(node)) {
+        return null;
+      }
+      if (node.type === mocks.SiteAdminForm) {
+        return node.props as Record<string, unknown>;
+      }
+      return findElement(node.props?.children);
+    }
+
+    const siteAdminForm = findElement(tree);
+    expect(siteAdminForm).toMatchObject({
+      siteId: "site-1",
+      sourceLang: "ja",
+    });
+  });
+});

--- a/app/dashboard/sites/[id]/admin/page.test.tsx
+++ b/app/dashboard/sites/[id]/admin/page.test.tsx
@@ -135,7 +135,8 @@ describe("SiteAdminPage", () => {
       if (node.type === mocks.SiteAdminForm) {
         return node.props as Record<string, unknown>;
       }
-      return findElement(node.props?.children);
+      const props = node.props as { children?: unknown };
+      return findElement(props.children);
     }
 
     const siteAdminForm = findElement(tree);

--- a/app/dashboard/sites/[id]/admin/page.tsx
+++ b/app/dashboard/sites/[id]/admin/page.tsx
@@ -169,6 +169,7 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
     acc[locale.targetLang] = locale.alias ?? null;
     return acc;
   }, {});
+  const sourceLang = site.routeConfig?.sourceLang ?? site.locales[0]?.sourceLang ?? "";
   const verifiedDomains = site.domains.filter((domain) => domain.status === "verified").length;
   const hasVerifiedDomain = verifiedDomains > 0;
   const servingLive = deployments.some((deployment) => deployment.servingStatus === "serving");
@@ -353,7 +354,7 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
       <SiteAdminForm
         siteId={site.id}
         sourceUrl={site.sourceUrl}
-        sourceLang={site.locales[0]?.sourceLang ?? ""}
+        sourceLang={sourceLang}
         targets={targetLangs}
         aliases={localeAliases}
         pattern={site.routeConfig?.pattern ?? null}

--- a/internal/previews/preview-job-machine.test.ts
+++ b/internal/previews/preview-job-machine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  parsePreviewRetryHint,
   reducePreviewJob,
   resolveNextPreviewJobPhase,
   type PreviewJob,
@@ -152,5 +153,41 @@ describe("preview-job-machine", () => {
   it("keeps non-terminal rank progression", () => {
     expect(resolveNextPreviewJobPhase("pending", "processing")).toBe("processing");
     expect(resolveNextPreviewJobPhase("processing", "pending")).toBe("processing");
+  });
+
+  it("rejects invalid retry hints with fractional or negative retry seconds", () => {
+    expect(
+      parsePreviewRetryHint({
+        reason: "browser_capacity_exhausted",
+        retryAfterSeconds: 1.5,
+        emailRecommended: true,
+      }),
+    ).toEqual({
+      reason: "browser_capacity_exhausted",
+      retryAfterSeconds: null,
+      emailRecommended: true,
+    });
+    expect(
+      parsePreviewRetryHint({
+        reason: "browser_capacity_exhausted",
+        retryAfterSeconds: -1,
+        emailRecommended: true,
+      }),
+    ).toEqual({
+      reason: "browser_capacity_exhausted",
+      retryAfterSeconds: null,
+      emailRecommended: true,
+    });
+    expect(
+      parsePreviewRetryHint({
+        reason: "browser_capacity_exhausted",
+        retryAfterSeconds: 60,
+        emailRecommended: true,
+      }),
+    ).toEqual({
+      reason: "browser_capacity_exhausted",
+      retryAfterSeconds: 60,
+      emailRecommended: true,
+    });
   });
 });

--- a/internal/previews/preview-job-machine.ts
+++ b/internal/previews/preview-job-machine.ts
@@ -123,7 +123,10 @@ export function parsePreviewRetryHint(value: unknown): PreviewRetryHint | null {
     return null;
   }
   const retryAfterSeconds =
-    typeof value.retryAfterSeconds === "number" && Number.isFinite(value.retryAfterSeconds)
+    typeof value.retryAfterSeconds === "number" &&
+    Number.isFinite(value.retryAfterSeconds) &&
+    Number.isInteger(value.retryAfterSeconds) &&
+    value.retryAfterSeconds >= 0
       ? value.retryAfterSeconds
       : null;
   return {


### PR DESCRIPTION
## Summary
- Prefer backend `routeConfig.sourceLang` when wiring the site admin form
- Add a regression that proves the admin page no longer guesses the source language from `locales[0]`

## Validation
- `corepack pnpm vitest --run internal/dashboard/webhooks.openapi-contract.test.ts`
- `corepack pnpm vitest --run 'app/dashboard/sites/[id]/admin/page.test.tsx'`