### PR TITLE
ci: reduce frontend workflow cost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ PUBLIC_PORTAL_MODE=enabled
 
 # PostHog
 NEXT_PUBLIC_POSTHOG_KEY=phc_replace_me
+# Upstream ingestion host. The website proxies browser traffic through /_analytics/posthog.
 NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 
 # Stripe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,18 @@ name: ci
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
     env:
       HOME_PAGE_VARIANT: expansion
       UPSTASH_REDIS__KV_REST_API_TOKEN: dummy
@@ -65,9 +71,6 @@ jobs:
 
       - name: Build
         run: corepack pnpm build
-
-      - name: Install Playwright browser
-        run: corepack pnpm exec playwright install --with-deps chromium
 
       - name: Dashboard smoke (mock auth)
         run: corepack pnpm test:e2e:smoke

--- a/README.md
+++ b/README.md
@@ -100,10 +100,13 @@ SUPABASE_AUTH_TIMEOUT_MS=15000
 
 # Analytics (optional)
 NEXT_PUBLIC_POSTHOG_KEY=phc_...
-NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+# Upstream ingestion host. Browser requests are proxied through /_analytics/posthog.
+NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 ```
 
 `PUBLIC_PORTAL_MODE=disabled` hides the login CTA, disables signup/login actions, blocks checkout, and returns 404 for the login and dashboard onboarding screens. Set it to `enabled` to expose the portal.
+
+PostHog traffic is proxied through the first-party `/_analytics/posthog` route. Keep `NEXT_PUBLIC_POSTHOG_HOST` pointed at the upstream PostHog ingestion host (for example `https://eu.i.posthog.com`), not the browser-facing proxy path.
 
 ## Running Locally
 

--- a/app/[locale]/(marketing)/checkout/cancel/page.tsx
+++ b/app/[locale]/(marketing)/checkout/cancel/page.tsx
@@ -1,8 +1,14 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { AnalyticsPageView } from "@/components/analytics-page-view";
+import { AnalyticsTrackedLink } from "@/components/analytics-tracked-link";
 import { Button } from "@/components/ui/button";
+import {
+  ANALYTICS_EVENTS,
+  buildCtaAnalyticsProperties,
+  buildPageAnalyticsProperties,
+} from "@internal/analytics/events";
 import { normalizeLocale, resolveLocaleTranslator } from "@internal/i18n";
 
 export default async function CheckoutCancelPage({
@@ -16,9 +22,18 @@ export default async function CheckoutCancelPage({
     notFound();
   }
   const { t } = await resolveLocaleTranslator(Promise.resolve({ locale }));
+  const checkoutCancelPath = `/${locale}/checkout/cancel`;
 
   return (
     <div className="bg-background py-24">
+      <AnalyticsPageView
+        event={ANALYTICS_EVENTS.checkoutCancelView}
+        properties={buildPageAnalyticsProperties({
+          locale,
+          pagePath: checkoutCancelPath,
+          pageType: "checkout_cancel",
+        })}
+      />
       <div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-6 px-6 text-center">
         <span className="text-sm uppercase tracking-[0.3em] text-primary">
           {t("checkout.cancel.tagline")}
@@ -27,10 +42,34 @@ export default async function CheckoutCancelPage({
         <p className="text-base text-muted-foreground">{t("checkout.cancel.description")}</p>
         <div className="mt-4 flex flex-wrap justify-center gap-4">
           <Button asChild size="lg">
-            <Link href={`/${locale}/pricing`}>{t("checkout.cancel.backPricing")}</Link>
+            <AnalyticsTrackedLink
+              analyticsProperties={buildCtaAnalyticsProperties({
+                ctaId: "checkout_cancel_back_pricing",
+                locale,
+                pagePath: checkoutCancelPath,
+                pageType: "checkout_cancel",
+                targetHref: `/${locale}/pricing`,
+              })}
+              event={ANALYTICS_EVENTS.checkoutCtaClicked}
+              href={`/${locale}/pricing`}
+            >
+              {t("checkout.cancel.backPricing")}
+            </AnalyticsTrackedLink>
           </Button>
           <Button asChild size="lg" variant="outline">
-            <Link href={`/${locale}/contact`}>{t("checkout.cancel.contact")}</Link>
+            <AnalyticsTrackedLink
+              analyticsProperties={buildCtaAnalyticsProperties({
+                ctaId: "checkout_cancel_contact",
+                locale,
+                pagePath: checkoutCancelPath,
+                pageType: "checkout_cancel",
+                targetHref: `/${locale}/contact`,
+              })}
+              event={ANALYTICS_EVENTS.checkoutCtaClicked}
+              href={`/${locale}/contact`}
+            >
+              {t("checkout.cancel.contact")}
+            </AnalyticsTrackedLink>
           </Button>
         </div>
       </div>

--- a/app/[locale]/(marketing)/checkout/success/page.tsx
+++ b/app/[locale]/(marketing)/checkout/success/page.tsx
@@ -1,8 +1,14 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { AnalyticsPageView } from "@/components/analytics-page-view";
+import { AnalyticsTrackedLink } from "@/components/analytics-tracked-link";
 import { Button } from "@/components/ui/button";
+import {
+  ANALYTICS_EVENTS,
+  buildCtaAnalyticsProperties,
+  buildPageAnalyticsProperties,
+} from "@internal/analytics/events";
 import { normalizeLocale, resolveLocaleTranslator } from "@internal/i18n";
 
 export default async function CheckoutSuccessPage({
@@ -24,9 +30,19 @@ export default async function CheckoutSuccessPage({
       ? resolvedSearchParams.session_id
       : undefined;
   const maskedSessionId = sessionId ? `${sessionId.slice(0, 6)}…${sessionId.slice(-4)}` : undefined;
+  const checkoutSuccessPath = `/${locale}/checkout/success`;
 
   return (
     <div className="bg-background py-24">
+      <AnalyticsPageView
+        event={ANALYTICS_EVENTS.checkoutSuccessView}
+        properties={buildPageAnalyticsProperties({
+          locale,
+          pagePath: checkoutSuccessPath,
+          pageType: "checkout_success",
+          sessionPresent: Boolean(sessionId),
+        })}
+      />
       <div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-6 px-6 text-center">
         <span className="text-sm uppercase tracking-[0.3em] text-primary">
           {t("checkout.success.tagline")}
@@ -40,10 +56,34 @@ export default async function CheckoutSuccessPage({
         ) : null}
         <div className="mt-4 flex flex-wrap justify-center gap-4">
           <Button asChild variant="outline" size="lg">
-            <Link href={`/${locale}`}>{t("checkout.success.backHome")}</Link>
+            <AnalyticsTrackedLink
+              analyticsProperties={buildCtaAnalyticsProperties({
+                ctaId: "checkout_success_back_home",
+                locale,
+                pagePath: checkoutSuccessPath,
+                pageType: "checkout_success",
+                targetHref: `/${locale}`,
+              })}
+              event={ANALYTICS_EVENTS.checkoutCtaClicked}
+              href={`/${locale}`}
+            >
+              {t("checkout.success.backHome")}
+            </AnalyticsTrackedLink>
           </Button>
           <Button asChild size="lg">
-            <Link href={`/${locale}/pricing`}>{t("checkout.success.reviewPricing")}</Link>
+            <AnalyticsTrackedLink
+              analyticsProperties={buildCtaAnalyticsProperties({
+                ctaId: "checkout_success_review_pricing",
+                locale,
+                pagePath: checkoutSuccessPath,
+                pageType: "checkout_success",
+                targetHref: `/${locale}/pricing`,
+              })}
+              event={ANALYTICS_EVENTS.checkoutCtaClicked}
+              href={`/${locale}/pricing`}
+            >
+              {t("checkout.success.reviewPricing")}
+            </AnalyticsTrackedLink>
           </Button>
         </div>
       </div>

--- a/app/[locale]/(marketing)/page.tsx
+++ b/app/[locale]/(marketing)/page.tsx
@@ -16,7 +16,9 @@ export default async function LocaleHomePage({ params }: { params: Promise<{ loc
   }
 
   if (envServer.HOME_PAGE_VARIANT === "expansion") {
-    return <LandingSegmentPage locale={locale} segment={expansionSegment} />;
+    return (
+      <LandingSegmentPage locale={locale} pagePath={`/${locale}`} segment={expansionSegment} />
+    );
   }
 
   return <ClassicHomePage locale={locale} />;

--- a/app/[locale]/(marketing)/pricing/page.tsx
+++ b/app/[locale]/(marketing)/pricing/page.tsx
@@ -1,11 +1,17 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ArrowRight, Check, ChevronDown } from "lucide-react";
 
+import { AnalyticsPageView } from "@/components/analytics-page-view";
+import { AnalyticsTrackedLink } from "@/components/analytics-tracked-link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ANALYTICS_EVENTS,
+  buildCtaAnalyticsProperties,
+  buildPageAnalyticsProperties,
+} from "@internal/analytics/events";
 import { createLocalizedMetadata, normalizeLocale, resolveLocaleTranslator } from "@internal/i18n";
 import { pricingTiers } from "@modules/pricing";
 
@@ -256,9 +262,18 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
       answer: t("pricing.faq.items.agencies.answer"),
     },
   ];
+  const pricingPagePath = `/${locale}/pricing`;
 
   return (
     <div className="min-h-screen bg-background">
+      <AnalyticsPageView
+        event={ANALYTICS_EVENTS.pricingPageView}
+        properties={buildPageAnalyticsProperties({
+          locale,
+          pagePath: pricingPagePath,
+          pageType: "pricing",
+        })}
+      />
       <section className="relative overflow-hidden px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
         <div className="absolute inset-0 hero-pattern hero-gradient -z-10" />
         <div className="mx-auto max-w-4xl text-center">
@@ -273,13 +288,36 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
           </p>
           <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
             <Button asChild size="lg">
-              <Link href={`/${locale}/login`}>
+              <AnalyticsTrackedLink
+                analyticsProperties={buildCtaAnalyticsProperties({
+                  ctaId: "pricing_header_start_free",
+                  locale,
+                  pagePath: pricingPagePath,
+                  pageType: "pricing",
+                  targetHref: `/${locale}/login`,
+                })}
+                event={ANALYTICS_EVENTS.pricingCtaClicked}
+                href={`/${locale}/login`}
+              >
                 {t("pricing.free.cta")}
                 <ArrowRight className="ml-2 h-4 w-4" />
-              </Link>
+              </AnalyticsTrackedLink>
             </Button>
             <Button asChild size="lg" variant="outline">
-              <a href="mailto:contact@weblingo.app">{t("pricing.header.contactCta")}</a>
+              <AnalyticsTrackedLink
+                analyticsProperties={buildCtaAnalyticsProperties({
+                  ctaId: "pricing_header_contact",
+                  locale,
+                  pagePath: pricingPagePath,
+                  pageType: "pricing",
+                  targetHref: "mailto:contact@weblingo.app",
+                })}
+                event={ANALYTICS_EVENTS.pricingCtaClicked}
+                external
+                href="mailto:contact@weblingo.app"
+              >
+                {t("pricing.header.contactCta")}
+              </AnalyticsTrackedLink>
             </Button>
           </div>
           <div className="mt-6 flex flex-wrap justify-center gap-3">
@@ -319,13 +357,37 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
               </div>
               <div className="flex shrink-0 flex-col gap-3">
                 <Button asChild size="default">
-                  <Link href={`/${locale}/login`}>
+                  <AnalyticsTrackedLink
+                    analyticsProperties={buildCtaAnalyticsProperties({
+                      ctaId: "pricing_free_plan_start_free",
+                      locale,
+                      pagePath: pricingPagePath,
+                      pageType: "pricing",
+                      targetHref: `/${locale}/login`,
+                      planId: "free",
+                    })}
+                    event={ANALYTICS_EVENTS.pricingCtaClicked}
+                    href={`/${locale}/login`}
+                  >
                     {t("pricing.free.cta")}
                     <ArrowRight className="ml-2 h-4 w-4" />
-                  </Link>
+                  </AnalyticsTrackedLink>
                 </Button>
                 <Button asChild size="default" variant="outline">
-                  <Link href={`/${locale}/try`}>{t("pricing.free.previewCta")}</Link>
+                  <AnalyticsTrackedLink
+                    analyticsProperties={buildCtaAnalyticsProperties({
+                      ctaId: "pricing_free_plan_try_preview",
+                      locale,
+                      pagePath: pricingPagePath,
+                      pageType: "pricing",
+                      targetHref: `/${locale}/try`,
+                      planId: "free",
+                    })}
+                    event={ANALYTICS_EVENTS.pricingCtaClicked}
+                    href={`/${locale}/try`}
+                  >
+                    {t("pricing.free.previewCta")}
+                  </AnalyticsTrackedLink>
                 </Button>
                 <p className="max-w-xs text-xs text-muted-foreground">{t("pricing.free.note")}</p>
               </div>
@@ -383,9 +445,36 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
                       variant={highlight ? "default" : "outline"}
                     >
                       {plan.ctaExternal ? (
-                        <a href={plan.ctaHref}>{plan.ctaLabel}</a>
+                        <AnalyticsTrackedLink
+                          analyticsProperties={buildCtaAnalyticsProperties({
+                            ctaId: `pricing_paid_${planId}_cta`,
+                            locale,
+                            pagePath: pricingPagePath,
+                            pageType: "pricing",
+                            targetHref: plan.ctaHref,
+                            planId,
+                          })}
+                          event={ANALYTICS_EVENTS.pricingCtaClicked}
+                          external
+                          href={plan.ctaHref}
+                        >
+                          {plan.ctaLabel}
+                        </AnalyticsTrackedLink>
                       ) : (
-                        <Link href={plan.ctaHref}>{plan.ctaLabel}</Link>
+                        <AnalyticsTrackedLink
+                          analyticsProperties={buildCtaAnalyticsProperties({
+                            ctaId: `pricing_paid_${planId}_cta`,
+                            locale,
+                            pagePath: pricingPagePath,
+                            pageType: "pricing",
+                            targetHref: plan.ctaHref,
+                            planId,
+                          })}
+                          event={ANALYTICS_EVENTS.pricingCtaClicked}
+                          href={plan.ctaHref}
+                        >
+                          {plan.ctaLabel}
+                        </AnalyticsTrackedLink>
                       )}
                     </Button>
                     <p className="text-xs font-semibold uppercase text-muted-foreground">
@@ -487,13 +576,35 @@ export default async function PricingPage({ params }: { params: Promise<{ locale
           <p className="mb-12 text-lg text-muted-foreground">{t("pricing.final.description")}</p>
           <div className="flex flex-col justify-center gap-4 sm:flex-row">
             <Button asChild size="lg">
-              <Link href={`/${locale}/login`}>
+              <AnalyticsTrackedLink
+                analyticsProperties={buildCtaAnalyticsProperties({
+                  ctaId: "pricing_final_start_free",
+                  locale,
+                  pagePath: pricingPagePath,
+                  pageType: "pricing",
+                  targetHref: `/${locale}/login`,
+                })}
+                event={ANALYTICS_EVENTS.pricingCtaClicked}
+                href={`/${locale}/login`}
+              >
                 {t("pricing.final.cta")}
                 <ArrowRight className="ml-2 h-4 w-4" />
-              </Link>
+              </AnalyticsTrackedLink>
             </Button>
             <Button asChild size="lg" variant="outline">
-              <Link href={`/${locale}/try`}>{t("pricing.free.previewCta")}</Link>
+              <AnalyticsTrackedLink
+                analyticsProperties={buildCtaAnalyticsProperties({
+                  ctaId: "pricing_final_try_preview",
+                  locale,
+                  pagePath: pricingPagePath,
+                  pageType: "pricing",
+                  targetHref: `/${locale}/try`,
+                })}
+                event={ANALYTICS_EVENTS.pricingCtaClicked}
+                href={`/${locale}/try`}
+              >
+                {t("pricing.free.previewCta")}
+              </AnalyticsTrackedLink>
             </Button>
           </div>
         </div>

--- a/app/_analytics/posthog/[[...path]]/route.test.ts
+++ b/app/_analytics/posthog/[[...path]]/route.test.ts
@@ -1,0 +1,102 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const ORIGINAL_ENV = { ...process.env };
+const fetchMock = vi.fn<typeof fetch>();
+
+function setRequiredEnv() {
+  process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test";
+  process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
+  process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://eu.i.posthog.com";
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "sb_publishable";
+  process.env.NEXT_PUBLIC_WEBHOOKS_API_BASE = "https://api.example.com/api";
+  process.env.NEXT_PUBLIC_WEBHOOKS_API_TIMEOUT_MS = "15000";
+
+  process.env.PUBLIC_PORTAL_MODE = "enabled";
+  process.env.STRIPE_SECRET_KEY = "sk_test";
+  process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+  process.env.SUPABASE_SECRET_KEY = "sb_secret";
+  process.env.SUPABASE_AUTH_TIMEOUT_MS = "15000";
+
+  process.env.WEBSITE_WAITLIST_RATE_LIMIT_WINDOW_MS = "60000";
+  process.env.WEBSITE_WAITLIST_MAX_PER_WINDOW = "20";
+  process.env.WEBSITE_WAITLIST_MAX_BODY_BYTES = "4096";
+  process.env.WEBSITE_CONTACT_RATE_LIMIT_WINDOW_MS = "60000";
+  process.env.WEBSITE_CONTACT_MAX_PER_WINDOW = "10";
+
+  process.env.UPSTASH_REDIS__KV_REST_API_URL = "https://example.com";
+  process.env.UPSTASH_REDIS__KV_REST_API_TOKEN = "dummy";
+}
+
+function buildRequest(url: string, init?: RequestInit): NextRequest {
+  return new NextRequest(url, init as ConstructorParameters<typeof NextRequest>[1]);
+}
+
+beforeAll(() => {
+  process.env = { ...ORIGINAL_ENV };
+  setRequiredEnv();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("PostHog proxy route", () => {
+  it("forwards POST requests to the configured upstream host", async () => {
+    vi.resetModules();
+    const { POST } = await import("./route");
+    fetchMock.mockResolvedValueOnce(
+      new Response('{"ok":true}', {
+        headers: { "content-type": "application/json" },
+        status: 202,
+      }),
+    );
+
+    const response = await POST(
+      buildRequest("http://localhost:3000/_analytics/posthog/e/?ip=1", {
+        body: '{"event":"preview_ready"}',
+        headers: {
+          "content-type": "application/json",
+          "x-forwarded-for": "1.2.3.4",
+        },
+        method: "POST",
+      }),
+      { params: Promise.resolve({ path: ["e"] }) },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBeInstanceOf(URL);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe("https://eu.i.posthog.com/e?ip=1");
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      method: "POST",
+      redirect: "manual",
+    });
+    expect(response.status).toBe(202);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("forwards GET requests without a request body", async () => {
+    vi.resetModules();
+    const { GET } = await import("./route");
+    fetchMock.mockResolvedValueOnce(
+      new Response("{}", {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      }),
+    );
+
+    await GET(buildRequest("http://localhost:3000/_analytics/posthog/decide/?v=3"), {
+      params: Promise.resolve({ path: ["decide"] }),
+    });
+
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      body: undefined,
+      method: "GET",
+    });
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe("https://eu.i.posthog.com/decide?v=3");
+  });
+});

--- a/app/_analytics/posthog/[[...path]]/route.ts
+++ b/app/_analytics/posthog/[[...path]]/route.ts
@@ -1,0 +1,37 @@
+import { type NextRequest } from "next/server";
+
+import { env } from "@internal/core";
+import {
+  buildPosthogProxyRequestHeaders,
+  buildPosthogProxyResponseHeaders,
+  buildPosthogUpstreamUrl,
+  shouldForwardRequestBody,
+} from "@internal/analytics/proxy";
+
+type RouteContext = {
+  params: Promise<{
+    path?: string[];
+  }>;
+};
+
+async function proxyPosthogRequest(request: NextRequest, context: RouteContext): Promise<Response> {
+  const { path = [] } = await context.params;
+  const upstreamUrl = buildPosthogUpstreamUrl(env.NEXT_PUBLIC_POSTHOG_HOST, path, request.url);
+  const upstreamResponse = await fetch(upstreamUrl, {
+    body: shouldForwardRequestBody(request.method) ? await request.arrayBuffer() : undefined,
+    headers: buildPosthogProxyRequestHeaders(request.headers, request.url),
+    method: request.method,
+    redirect: "manual",
+  });
+
+  return new Response(upstreamResponse.body, {
+    headers: buildPosthogProxyResponseHeaders(upstreamResponse.headers),
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+  });
+}
+
+export const GET = proxyPosthogRequest;
+export const HEAD = proxyPosthogRequest;
+export const OPTIONS = proxyPosthogRequest;
+export const POST = proxyPosthogRequest;

--- a/components/analytics-page-view.test.tsx
+++ b/components/analytics-page-view.test.tsx
@@ -1,6 +1,5 @@
 // @vitest-environment happy-dom
 import { render, waitFor } from "@testing-library/react";
-import { StrictMode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { captureAnalyticsEventMock } = vi.hoisted(() => ({
@@ -20,20 +19,40 @@ describe("AnalyticsPageView", () => {
 
   it("captures a page view once on mount", async () => {
     render(
-      <StrictMode>
-        <AnalyticsPageView
-          event="pricing_page_view"
-          properties={{ locale: "en", page_path: "/en/pricing" }}
-        />
-      </StrictMode>,
+      <AnalyticsPageView
+        event="pricing_page_view"
+        properties={{ locale: "en", page_path: "/en/pricing" }}
+      />,
     );
-
     await waitFor(() => {
       expect(captureAnalyticsEventMock).toHaveBeenCalledWith("pricing_page_view", {
         locale: "en",
         page_path: "/en/pricing",
       });
+      expect(captureAnalyticsEventMock).toHaveBeenCalledTimes(1);
     });
-    expect(captureAnalyticsEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures a new page view when the same page is visited again", async () => {
+    const firstRender = render(
+      <AnalyticsPageView
+        event="pricing_page_view"
+        properties={{ locale: "en", page_path: "/en/pricing" }}
+      />,
+    );
+    await waitFor(() => {
+      expect(captureAnalyticsEventMock).toHaveBeenCalledTimes(1);
+    });
+    firstRender.unmount();
+
+    render(
+      <AnalyticsPageView
+        event="pricing_page_view"
+        properties={{ locale: "en", page_path: "/en/pricing" }}
+      />,
+    );
+    await waitFor(() => {
+      expect(captureAnalyticsEventMock).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/components/analytics-page-view.test.tsx
+++ b/components/analytics-page-view.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+import { render, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { captureAnalyticsEventMock } = vi.hoisted(() => ({
+  captureAnalyticsEventMock: vi.fn(),
+}));
+
+vi.mock("@internal/analytics/client", () => ({
+  captureAnalyticsEvent: captureAnalyticsEventMock,
+}));
+
+import { AnalyticsPageView } from "./analytics-page-view";
+
+describe("AnalyticsPageView", () => {
+  afterEach(() => {
+    captureAnalyticsEventMock.mockReset();
+  });
+
+  it("captures a page view once on mount", async () => {
+    render(
+      <StrictMode>
+        <AnalyticsPageView
+          event="pricing_page_view"
+          properties={{ locale: "en", page_path: "/en/pricing" }}
+        />
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(captureAnalyticsEventMock).toHaveBeenCalledWith("pricing_page_view", {
+        locale: "en",
+        page_path: "/en/pricing",
+      });
+    });
+    expect(captureAnalyticsEventMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/analytics-page-view.tsx
+++ b/components/analytics-page-view.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import {
+  captureAnalyticsEvent,
+  type AnalyticsEventName,
+  type AnalyticsProperties,
+} from "@internal/analytics/client";
+
+const RECENT_PAGE_VIEW_DEDUPE_WINDOW_MS = 1000;
+const recentPageViewKeys = new Map<string, number>();
+
+type AnalyticsPageViewProps = {
+  event: AnalyticsEventName;
+  properties?: AnalyticsProperties;
+};
+
+function createPageViewKey(event: AnalyticsEventName, properties: AnalyticsProperties): string {
+  return JSON.stringify([
+    event,
+    Object.entries(properties).sort(([left], [right]) => left.localeCompare(right)),
+  ]);
+}
+
+export function AnalyticsPageView({ event, properties = {} }: AnalyticsPageViewProps) {
+  const trackedRef = useRef(false);
+
+  useEffect(() => {
+    if (trackedRef.current) {
+      return;
+    }
+
+    trackedRef.current = true;
+    const now = Date.now();
+    const dedupeKey = createPageViewKey(event, properties);
+    const previousTs = recentPageViewKeys.get(dedupeKey);
+
+    if (typeof previousTs === "number" && now - previousTs < RECENT_PAGE_VIEW_DEDUPE_WINDOW_MS) {
+      return;
+    }
+
+    recentPageViewKeys.set(dedupeKey, now);
+    captureAnalyticsEvent(event, properties);
+  }, [event, properties]);
+
+  return null;
+}

--- a/components/analytics-page-view.tsx
+++ b/components/analytics-page-view.tsx
@@ -8,23 +8,14 @@ import {
   type AnalyticsProperties,
 } from "@internal/analytics/client";
 
-const RECENT_PAGE_VIEW_DEDUPE_WINDOW_MS = 1000;
-const recentPageViewKeys = new Map<string, number>();
-
 type AnalyticsPageViewProps = {
   event: AnalyticsEventName;
   properties?: AnalyticsProperties;
 };
 
-function createPageViewKey(event: AnalyticsEventName, properties: AnalyticsProperties): string {
-  return JSON.stringify([
-    event,
-    Object.entries(properties).sort(([left], [right]) => left.localeCompare(right)),
-  ]);
-}
-
 export function AnalyticsPageView({ event, properties = {} }: AnalyticsPageViewProps) {
   const trackedRef = useRef(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (trackedRef.current) {
@@ -32,16 +23,17 @@ export function AnalyticsPageView({ event, properties = {} }: AnalyticsPageViewP
     }
 
     trackedRef.current = true;
-    const now = Date.now();
-    const dedupeKey = createPageViewKey(event, properties);
-    const previousTs = recentPageViewKeys.get(dedupeKey);
+    timeoutRef.current = setTimeout(() => {
+      captureAnalyticsEvent(event, properties);
+      timeoutRef.current = null;
+    }, 0);
 
-    if (typeof previousTs === "number" && now - previousTs < RECENT_PAGE_VIEW_DEDUPE_WINDOW_MS) {
-      return;
-    }
-
-    recentPageViewKeys.set(dedupeKey, now);
-    captureAnalyticsEvent(event, properties);
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
   }, [event, properties]);
 
   return null;

--- a/components/analytics-tracked-link.test.tsx
+++ b/components/analytics-tracked-link.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { AnchorHTMLAttributes } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { captureAnalyticsEventMock } = vi.hoisted(() => ({
+  captureAnalyticsEventMock: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a {...props} href={href}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@internal/analytics/client", () => ({
+  captureAnalyticsEvent: captureAnalyticsEventMock,
+}));
+
+import { AnalyticsTrackedLink } from "./analytics-tracked-link";
+
+describe("AnalyticsTrackedLink", () => {
+  afterEach(() => {
+    captureAnalyticsEventMock.mockReset();
+  });
+
+  it("captures analytics for internal links", () => {
+    render(
+      <AnalyticsTrackedLink
+        analyticsProperties={{ cta_id: "pricing_final_start_free" }}
+        event="pricing_cta_clicked"
+        href="/en/login"
+      >
+        Start free
+      </AnalyticsTrackedLink>,
+    );
+
+    fireEvent.click(screen.getByText("Start free"), { button: 0 });
+
+    expect(captureAnalyticsEventMock).toHaveBeenCalledWith("pricing_cta_clicked", {
+      cta_id: "pricing_final_start_free",
+    });
+  });
+
+  it("skips analytics when a consumer prevents default navigation", () => {
+    render(
+      <AnalyticsTrackedLink
+        event="marketing_cta_clicked"
+        href="/en#try"
+        onClick={(event) => event.preventDefault()}
+      >
+        Try now
+      </AnalyticsTrackedLink>,
+    );
+
+    fireEvent.click(screen.getByText("Try now"), { button: 0 });
+
+    expect(captureAnalyticsEventMock).not.toHaveBeenCalled();
+  });
+
+  it("captures analytics for external links", () => {
+    render(
+      <AnalyticsTrackedLink
+        analyticsProperties={{ cta_id: "pricing_header_contact" }}
+        event="pricing_cta_clicked"
+        external
+        href="mailto:contact@weblingo.app"
+      >
+        Contact sales
+      </AnalyticsTrackedLink>,
+    );
+
+    fireEvent.click(screen.getByText("Contact sales"), { button: 0 });
+
+    expect(captureAnalyticsEventMock).toHaveBeenCalledWith("pricing_cta_clicked", {
+      cta_id: "pricing_header_contact",
+    });
+  });
+});

--- a/components/analytics-tracked-link.tsx
+++ b/components/analytics-tracked-link.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { forwardRef, type AnchorHTMLAttributes, type MouseEvent } from "react";
+
+import {
+  captureAnalyticsEvent,
+  type AnalyticsEventName,
+  type AnalyticsProperties,
+} from "@internal/analytics/client";
+
+type AnalyticsTrackedLinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> & {
+  href: string;
+  event: AnalyticsEventName;
+  analyticsProperties?: AnalyticsProperties;
+  external?: boolean;
+  prefetch?: boolean;
+  replace?: boolean;
+  scroll?: boolean;
+};
+
+function shouldRenderExternalLink(href: string, external?: boolean): boolean {
+  if (external) {
+    return true;
+  }
+
+  return /^[a-z]+:/i.test(href);
+}
+
+export const AnalyticsTrackedLink = forwardRef<HTMLAnchorElement, AnalyticsTrackedLinkProps>(
+  function AnalyticsTrackedLink(
+    { analyticsProperties, event, external, href, onClick, prefetch, replace, scroll, ...rest },
+    ref,
+  ) {
+    const handleClick = (clickEvent: MouseEvent<HTMLAnchorElement>) => {
+      onClick?.(clickEvent);
+
+      if (clickEvent.defaultPrevented) {
+        return;
+      }
+
+      captureAnalyticsEvent(event, analyticsProperties);
+    };
+
+    if (shouldRenderExternalLink(href, external)) {
+      return <a {...rest} ref={ref} href={href} onClick={handleClick} />;
+    }
+
+    return (
+      <Link
+        {...rest}
+        href={href}
+        onClick={handleClick}
+        prefetch={prefetch}
+        ref={ref}
+        replace={replace}
+        scroll={scroll}
+      />
+    );
+  },
+);

--- a/components/preview-status-center.test.tsx
+++ b/components/preview-status-center.test.tsx
@@ -2,12 +2,26 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PreviewStatusCenter } from "./preview-status-center";
+import { ANALYTICS_EVENTS } from "@internal/analytics/client";
 import {
   buildPreviewStatusCenterRequestKey,
   markPreviewStatusCenterJobTerminal,
   resetPreviewStatusCenterStoreForTests,
   upsertPreviewStatusCenterJob,
 } from "@internal/previews/status-center-store";
+
+const { captureAnalyticsEvent } = vi.hoisted(() => ({
+  captureAnalyticsEvent: vi.fn(),
+}));
+vi.mock("@internal/analytics/client", async () => {
+  const actual = await vi.importActual<typeof import("@internal/analytics/client")>(
+    "@internal/analytics/client",
+  );
+  return {
+    ...actual,
+    captureAnalyticsEvent,
+  };
+});
 
 const messages = {
   "try.center.capacityHint": "Capacity hint",
@@ -38,6 +52,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 beforeEach(() => {
   resetPreviewStatusCenterStoreForTests();
   window.localStorage.clear();
+  captureAnalyticsEvent.mockReset();
   vi.stubGlobal(
     "fetch",
     vi.fn(async () =>
@@ -108,7 +123,26 @@ describe("PreviewStatusCenter", () => {
       expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
     });
 
+    const openPreviewLink = screen.getByRole("link", { name: "Open preview" });
+    openPreviewLink.addEventListener("click", (event) => event.preventDefault(), { once: true });
+    fireEvent.click(openPreviewLink);
+    expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.previewStatusCenterOpenClicked,
+      expect.objectContaining({
+        preview_id: "22222222-2222-2222-2222-222222222222",
+        status: "ready",
+      }),
+    );
+
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.previewStatusCenterDismissed,
+      expect.objectContaining({
+        preview_id: "22222222-2222-2222-2222-222222222222",
+        status: "ready",
+      }),
+    );
 
     await waitFor(() => {
       expect(screen.queryByText("Ready")).toBeNull();

--- a/components/preview-status-center.tsx
+++ b/components/preview-status-center.tsx
@@ -2,6 +2,11 @@
 
 import { useMemo, useSyncExternalStore } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  ANALYTICS_EVENTS,
+  buildPreviewAnalyticsProperties,
+  captureAnalyticsEvent,
+} from "@internal/analytics/client";
 import { createClientTranslator, type ClientMessages } from "@internal/i18n";
 import {
   resolvePreviewStatusCenterCapacityHint,
@@ -88,7 +93,24 @@ export function PreviewStatusCenter({ messages }: PreviewStatusCenterProps) {
             <div className="mt-3 flex items-center gap-2">
               {job.status === "ready" && job.previewUrl ? (
                 <Button asChild size="sm" variant="secondary">
-                  <a href={job.previewUrl} target="_blank" rel="noreferrer">
+                  <a
+                    href={job.previewUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={() => {
+                      captureAnalyticsEvent(
+                        ANALYTICS_EVENTS.previewStatusCenterOpenClicked,
+                        buildPreviewAnalyticsProperties({
+                          sourceUrl: job.sourceUrl,
+                          sourceLang: job.sourceLang,
+                          targetLang: job.targetLang,
+                          previewId: job.previewId,
+                          status: job.status,
+                          stage: job.stage,
+                        }),
+                      );
+                    }}
+                  >
                     {t("try.preview.open")}
                   </a>
                 </Button>
@@ -99,6 +121,19 @@ export function PreviewStatusCenter({ messages }: PreviewStatusCenterProps) {
                   size="sm"
                   variant="ghost"
                   onClick={() => {
+                    captureAnalyticsEvent(
+                      ANALYTICS_EVENTS.previewStatusCenterDismissed,
+                      buildPreviewAnalyticsProperties({
+                        sourceUrl: job.sourceUrl,
+                        sourceLang: job.sourceLang,
+                        targetLang: job.targetLang,
+                        previewId: job.previewId,
+                        status: job.status,
+                        stage: job.stage,
+                        errorCode: job.errorCode,
+                        errorStage: job.errorStage,
+                      }),
+                    );
                     removePreviewStatusCenterJob(job.previewId);
                   }}
                 >

--- a/components/try-form.test.tsx
+++ b/components/try-form.test.tsx
@@ -2,9 +2,9 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PreviewStatusCenter } from "./preview-status-center";
-import { resolvePreviewStatusCenterMessage } from "@internal/previews/status-center-i18n";
-import { TryForm, resolveTryFormMode } from "./try-form";
+import { ANALYTICS_EVENTS } from "@internal/analytics/client";
 import type { SupportedLanguage } from "@internal/dashboard/webhooks";
+import { resolvePreviewStatusCenterMessage } from "@internal/previews/status-center-i18n";
 import {
   buildPreviewStatusCenterRequestKey,
   markPreviewStatusCenterJobTerminal,
@@ -12,6 +12,20 @@ import {
   resetPreviewStatusCenterStoreForTests,
   upsertPreviewStatusCenterJob,
 } from "@internal/previews/status-center-store";
+import { TryForm, resolveTryFormMode } from "./try-form";
+
+const { captureAnalyticsEvent } = vi.hoisted(() => ({
+  captureAnalyticsEvent: vi.fn(),
+}));
+vi.mock("@internal/analytics/client", async () => {
+  const actual = await vi.importActual<typeof import("@internal/analytics/client")>(
+    "@internal/analytics/client",
+  );
+  return {
+    ...actual,
+    captureAnalyticsEvent,
+  };
+});
 
 vi.mock("next/dynamic", async () => {
   const React = await import("react");
@@ -176,6 +190,7 @@ beforeEach(() => {
   window.localStorage.clear();
   MockEventSource.instances = [];
   globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+  captureAnalyticsEvent.mockReset();
 });
 
 afterEach(() => {
@@ -188,6 +203,194 @@ afterEach(() => {
 });
 
 describe("TryForm preview status", () => {
+  it("captures try form start, submit, create success, and terminal ready lifecycle events", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          previewId: "99999999-9999-9999-9999-999999999999",
+          statusToken: "status-token",
+          status: "processing",
+          stage: "translating",
+        }),
+      ),
+    );
+
+    renderTryForm();
+
+    const urlInput = screen.getByPlaceholderText("https://example.com");
+    fireEvent.change(urlInput, { target: { value: "https://example.com/docs?secret=1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Generate preview" }));
+
+    await waitFor(() => {
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.tryFormStarted,
+        expect.objectContaining({
+          source_host: "example.com",
+          source_path: "/docs",
+          source_lang: "en",
+          target_lang: "fr",
+        }),
+      );
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.tryFormSubmitted,
+        expect.objectContaining({
+          source_host: "example.com",
+          source_path: "/docs",
+        }),
+      );
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.previewCreateSucceeded,
+        expect.objectContaining({
+          preview_id: "99999999-9999-9999-9999-999999999999",
+          status: "processing",
+          stage: "translating",
+        }),
+      );
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.previewStatusTransition,
+        expect.objectContaining({
+          preview_id: "99999999-9999-9999-9999-999999999999",
+          status: "processing",
+          stage: "translating",
+        }),
+      );
+    });
+
+    const eventSource = MockEventSource.instances[0];
+    expect(eventSource).toBeTruthy();
+    eventSource?.emit("complete", {
+      previewUrl: "https://preview.example.com/p/9999",
+    });
+
+    await waitFor(() => {
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.previewReady,
+        expect.objectContaining({
+          preview_id: "99999999-9999-9999-9999-999999999999",
+          status: "ready",
+        }),
+      );
+    });
+  });
+
+  it("captures preview terminal failures from the create response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          previewId: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+          statusToken: "status-token",
+          status: "failed",
+          errorCode: "render_failed",
+          errorStage: "generating_preview",
+        }),
+      ),
+    );
+
+    renderTryForm();
+
+    fireEvent.change(screen.getByPlaceholderText("https://example.com"), {
+      target: { value: "https://broken.example.com/" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate preview" }));
+
+    await waitFor(() => {
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.previewCreateSucceeded,
+        expect.objectContaining({
+          preview_id: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        }),
+      );
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.previewFailed,
+        expect.objectContaining({
+          preview_id: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+          status: "failed",
+          error_code: "render_failed",
+          error_stage: "generating_preview",
+        }),
+      );
+    });
+  });
+
+  it("captures preview create failures when a 2xx response body is malformed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response("not-json", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    renderTryForm();
+
+    fireEvent.change(screen.getByPlaceholderText("https://example.com"), {
+      target: { value: "https://example.com/docs" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate preview" }));
+
+    await waitFor(() => {
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.previewCreateFailed,
+        expect.objectContaining({
+          source_host: "example.com",
+          source_path: "/docs",
+          source_lang: "en",
+          target_lang: "fr",
+        }),
+      );
+    });
+  });
+
+  it("captures preview open and copy actions after a ready result", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          previewId: "abababab-abab-abab-abab-abababababab",
+          statusToken: "status-token",
+          status: "ready",
+          previewUrl: "https://preview.example.com/p/abab",
+        }),
+      ),
+    );
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+
+    renderTryForm();
+
+    fireEvent.change(screen.getByPlaceholderText("https://example.com"), {
+      target: { value: "https://example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate preview" }));
+
+    const openButton = await screen.findByRole("link", { name: "Open overlay preview" });
+    openButton.addEventListener("click", (event) => event.preventDefault(), { once: true });
+    fireEvent.click(openButton);
+    fireEvent.click(screen.getByRole("button", { name: "Copy link" }));
+
+    await waitFor(() => {
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.previewOpenClicked,
+        expect.objectContaining({
+          preview_id: "abababab-abab-abab-abab-abababababab",
+        }),
+      );
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.previewCopyClicked,
+        expect.objectContaining({
+          preview_id: "abababab-abab-abab-abab-abababababab",
+        }),
+      );
+    });
+  });
+
   it("maps preview phases to deterministic modes", () => {
     expect(resolveTryFormMode(false, null)).toBe("idle");
     expect(resolveTryFormMode(true, null)).toBe("creating");

--- a/components/try-form.test.tsx
+++ b/components/try-form.test.tsx
@@ -317,11 +317,12 @@ describe("TryForm preview status", () => {
   it("captures preview create failures when a 2xx response body is malformed", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () =>
-        new Response("not-json", {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
+      vi.fn(
+        async () =>
+          new Response("not-json", {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
       ),
     );
 
@@ -342,6 +343,33 @@ describe("TryForm preview status", () => {
           target_lang: "fr",
         }),
       );
+    });
+  });
+
+  it("does not double-count preview create failures for malformed success payloads", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          status: "processing",
+          statusToken: "status-token",
+        }),
+      ),
+    );
+
+    renderTryForm();
+
+    fireEvent.change(screen.getByPlaceholderText("https://example.com"), {
+      target: { value: "https://example.com/docs" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate preview" }));
+
+    await waitFor(() => {
+      expect(
+        captureAnalyticsEvent.mock.calls.filter(
+          ([event]) => event === ANALYTICS_EVENTS.previewCreateFailed,
+        ),
+      ).toHaveLength(1);
     });
   });
 
@@ -388,6 +416,41 @@ describe("TryForm preview status", () => {
           preview_id: "abababab-abab-abab-abab-abababababab",
         }),
       );
+    });
+  });
+
+  it("re-emits try form started on a retry attempt after a failed request", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(
+          {
+            error: "Preview failed.",
+          },
+          500,
+        ),
+      ),
+    );
+
+    renderTryForm();
+
+    fireEvent.change(screen.getByPlaceholderText("https://example.com"), {
+      target: { value: "https://example.com/docs" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate preview" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Retry preview" })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry preview" }));
+
+    await waitFor(() => {
+      expect(
+        captureAnalyticsEvent.mock.calls.filter(
+          ([event]) => event === ANALYTICS_EVENTS.tryFormStarted,
+        ),
+      ).toHaveLength(2);
     });
   });
 
@@ -828,6 +891,107 @@ describe("TryForm preview status", () => {
       expect(screen.getByText("restore.example.com • English -> French")).toBeTruthy();
     });
     expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it("tracks restored previews and later terminal transitions", async () => {
+    window.localStorage.setItem(
+      PREVIEW_STATUS_CENTER_STORAGE_KEY,
+      JSON.stringify([
+        {
+          previewId: "restored-analytics-2222-2222-2222-222222222222",
+          requestKey: "https://restore.example.com|en|fr|",
+          statusToken: "restore-token",
+          sourceUrl: "https://restore.example.com",
+          sourceLang: "en",
+          targetLang: "fr",
+          status: "processing",
+          stage: "translating",
+          previewUrl: null,
+          error: null,
+          errorCode: null,
+          errorStage: null,
+          createdAt: Date.now() - 1_000,
+          updatedAt: Date.now() - 1_000,
+          expiresAt: null,
+          retryCount: 0,
+          nextPollAt: Date.now() + 5_000,
+        },
+      ]),
+    );
+
+    renderTryForm();
+
+    await waitFor(() => {
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.previewStatusTransition,
+        expect.objectContaining({
+          preview_id: "restored-analytics-2222-2222-2222-222222222222",
+          stage: "translating",
+          status: "processing",
+        }),
+      );
+    });
+
+    markPreviewStatusCenterJobTerminal("restored-analytics-2222-2222-2222-222222222222", "ready", {
+      previewUrl: "https://preview.example.com/p/restored",
+    });
+
+    await waitFor(() => {
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.previewReady,
+        expect.objectContaining({
+          preview_id: "restored-analytics-2222-2222-2222-222222222222",
+          status: "ready",
+        }),
+      );
+    });
+  });
+
+  it("does not report aborted preview create requests as failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) !== "/api/previews") {
+          return Promise.resolve(jsonResponse({ status: "processing" }));
+        }
+
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("The operation was aborted.", "AbortError")),
+            { once: true },
+          );
+        });
+      }),
+    );
+
+    const rendered = render(
+      <TryForm
+        locale="en"
+        messages={messages}
+        supportedLanguages={supportedLanguages}
+        showEmailField={false}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("https://example.com"), {
+      target: { value: "https://example.com/docs" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate preview" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Creating preview...")).toBeTruthy();
+    });
+
+    rendered.unmount();
+
+    await Promise.resolve();
+
+    expect(
+      captureAnalyticsEvent.mock.calls.filter(
+        ([event]) => event === ANALYTICS_EVENTS.previewCreateFailed,
+      ),
+    ).toHaveLength(0);
   });
 
   it("shows a basic request summary while a request is in flight", async () => {

--- a/components/try-form.tsx
+++ b/components/try-form.tsx
@@ -91,6 +91,23 @@ type ResolvedPreviewError = {
 
 const emailSchema = z.email();
 
+function isAbortLikeError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
+function buildPreviewAnalyticsSignature(job: PreviewStatusCenterJob): string {
+  return JSON.stringify({
+    status: job.status,
+    stage: job.stage ?? null,
+    errorCode: job.errorCode ?? null,
+    errorStage: job.errorStage ?? null,
+    retryHintReason: job.retryHint?.reason ?? null,
+  });
+}
+
 export type TryFormMode =
   | "idle"
   | "creating"
@@ -391,6 +408,9 @@ export function TryForm({
     if (restoreAttemptedRef.current) {
       return;
     }
+    if (lastRequestKey) {
+      return;
+    }
     if (jobs.length === 0) {
       return;
     }
@@ -400,6 +420,22 @@ export function TryForm({
       selectLatestActivePreviewStatusCenterJob(jobs) ?? selectPreferredPreviewStatusCenterJob(jobs);
     if (!restoredJob) {
       return;
+    }
+
+    trackedPreviewIdsRef.current.add(restoredJob.previewId);
+    if (
+      restoredJob.status === "ready" ||
+      restoredJob.status === "failed" ||
+      restoredJob.status === "expired"
+    ) {
+      trackedPreviewTerminalRef.current.add(restoredJob.previewId);
+      trackedPreviewStatusSignaturesRef.current.set(
+        restoredJob.previewId,
+        buildPreviewAnalyticsSignature(restoredJob),
+      );
+    } else {
+      trackedPreviewTerminalRef.current.delete(restoredJob.previewId);
+      trackedPreviewStatusSignaturesRef.current.delete(restoredJob.previewId);
     }
 
     setLastRequestKey(restoredJob.requestKey);
@@ -416,7 +452,7 @@ export function TryForm({
     setUrl((current) => (current ? current : parsedRequest.sourceUrl));
     setSourceLang((current) => (current ? current : parsedRequest.sourceLang));
     setTargetLang((current) => (current ? current : parsedRequest.targetLang));
-  }, [jobs]);
+  }, [jobs, lastRequestKey]);
 
   useEffect(() => {
     if (
@@ -461,13 +497,7 @@ export function TryForm({
       return;
     }
 
-    const signature = JSON.stringify({
-      status: trackedJob.status,
-      stage: trackedJob.stage ?? null,
-      errorCode: trackedJob.errorCode ?? null,
-      errorStage: trackedJob.errorStage ?? null,
-      retryHintReason: trackedJob.retryHint?.reason ?? null,
-    });
+    const signature = buildPreviewAnalyticsSignature(trackedJob);
     const previousSignature = trackedPreviewStatusSignaturesRef.current.get(trackedJob.previewId);
     if (previousSignature === signature) {
       return;
@@ -971,6 +1001,28 @@ export function TryForm({
     }
 
     let requestAttempted = false;
+    let previewCreateFailureTracked = false;
+    const trackPreviewCreateFailed = (overrides?: {
+      previewId?: string | null;
+      errorCode?: string | null;
+      errorStage?: string | null;
+    }) => {
+      previewCreateFailureTracked = true;
+      captureAnalyticsEvent(
+        ANALYTICS_EVENTS.previewCreateFailed,
+        buildPreviewAnalyticsProperties({
+          locale,
+          sourceUrl: trimmedUrl,
+          sourceLang: normalizedSourceLang,
+          targetLang: normalizedTargetLang,
+          previewId: overrides?.previewId ?? null,
+          errorCode: overrides?.errorCode ?? null,
+          errorStage: overrides?.errorStage ?? null,
+          fieldLayout,
+        }),
+      );
+    };
+
     try {
       if (!isValidHttpUrl(trimmedUrl)) {
         const message = t("try.form.invalidUrl");
@@ -1040,18 +1092,10 @@ export function TryForm({
           const payload = await response.json().catch(() => null);
           const reason =
             payload?.error || payload?.message || `Request failed with status ${response.status}`;
-          captureAnalyticsEvent(
-            ANALYTICS_EVENTS.previewCreateFailed,
-            buildPreviewAnalyticsProperties({
-              locale,
-              sourceUrl: trimmedUrl,
-              sourceLang: normalizedSourceLang,
-              targetLang: normalizedTargetLang,
-              errorCode: typeof payload?.errorCode === "string" ? payload.errorCode : null,
-              errorStage: typeof payload?.errorStage === "string" ? payload.errorStage : null,
-              fieldLayout,
-            }),
-          );
+          trackPreviewCreateFailed({
+            errorCode: typeof payload?.errorCode === "string" ? payload.errorCode : null,
+            errorStage: typeof payload?.errorStage === "string" ? payload.errorStage : null,
+          });
           setSubmissionError(resolveErrorMessage(null, reason));
           return;
         }
@@ -1101,18 +1145,10 @@ export function TryForm({
               },
             );
           } else {
-            captureAnalyticsEvent(
-              ANALYTICS_EVENTS.previewCreateFailed,
-              buildPreviewAnalyticsProperties({
-                locale,
-                sourceUrl: trimmedUrl,
-                sourceLang: normalizedSourceLang,
-                targetLang: normalizedTargetLang,
-                errorCode: resolved.code,
-                errorStage: resolved.stage,
-                fieldLayout,
-              }),
-            );
+            trackPreviewCreateFailed({
+              errorCode: resolved.code,
+              errorStage: resolved.stage,
+            });
             setSubmissionError(resolved.message);
           }
           return;
@@ -1120,16 +1156,7 @@ export function TryForm({
 
         if (payload?.status === "ready") {
           if (!previewId || !statusToken) {
-            captureAnalyticsEvent(
-              ANALYTICS_EVENTS.previewCreateFailed,
-              buildPreviewAnalyticsProperties({
-                locale,
-                sourceUrl: trimmedUrl,
-                sourceLang: normalizedSourceLang,
-                targetLang: normalizedTargetLang,
-                fieldLayout,
-              }),
-            );
+            trackPreviewCreateFailed();
             setSubmissionError(t("try.error.default"));
             return;
           }
@@ -1165,30 +1192,11 @@ export function TryForm({
         }
 
         if (!previewId) {
-          captureAnalyticsEvent(
-            ANALYTICS_EVENTS.previewCreateFailed,
-            buildPreviewAnalyticsProperties({
-              locale,
-              sourceUrl: trimmedUrl,
-              sourceLang: normalizedSourceLang,
-              targetLang: normalizedTargetLang,
-              fieldLayout,
-            }),
-          );
+          trackPreviewCreateFailed();
           throw new Error("Preview was created but no ID was returned.");
         }
         if (!statusToken) {
-          captureAnalyticsEvent(
-            ANALYTICS_EVENTS.previewCreateFailed,
-            buildPreviewAnalyticsProperties({
-              locale,
-              sourceUrl: trimmedUrl,
-              sourceLang: normalizedSourceLang,
-              targetLang: normalizedTargetLang,
-              previewId,
-              fieldLayout,
-            }),
-          );
+          trackPreviewCreateFailed({ previewId });
           throw new Error("Preview was created but no status token was returned.");
         }
 
@@ -1230,21 +1238,16 @@ export function TryForm({
         }
       }
     } catch (error) {
-      if (requestAttempted) {
-        captureAnalyticsEvent(
-          ANALYTICS_EVENTS.previewCreateFailed,
-          buildPreviewAnalyticsProperties({
-            locale,
-            sourceUrl: trimmedUrl,
-            sourceLang: normalizedSourceLang,
-            targetLang: normalizedTargetLang,
-            fieldLayout,
-          }),
-        );
+      if (isAbortLikeError(error)) {
+        return;
+      }
+      if (requestAttempted && !previewCreateFailureTracked) {
+        trackPreviewCreateFailed();
       }
       const message = error instanceof Error ? error.message : "Failed to generate preview.";
       setSubmissionError(message);
     } finally {
+      trackedTryStartRef.current = false;
       setIsCreating(false);
     }
   }

--- a/components/try-form.tsx
+++ b/components/try-form.tsx
@@ -13,6 +13,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import {
+  ANALYTICS_EVENTS,
+  buildPreviewAnalyticsProperties,
+  captureAnalyticsEvent,
+} from "@internal/analytics/client";
+import {
   createClientTranslator,
   createLanguageNameResolver,
   getBaseLangTag,
@@ -208,6 +213,10 @@ export function TryForm({
   const timedOutRef = useRef(false);
   const submittedEmailRef = useRef("");
   const restoreAttemptedRef = useRef(false);
+  const trackedTryStartRef = useRef(false);
+  const trackedPreviewIdsRef = useRef<Set<string>>(new Set());
+  const trackedPreviewStatusSignaturesRef = useRef<Map<string, string>>(new Map());
+  const trackedPreviewTerminalRef = useRef<Set<string>>(new Set());
 
   const trimmedUrl = url.trim();
   const submittedEmail = submittedEmailRef.current;
@@ -443,6 +452,86 @@ export function TryForm({
   useEffect(() => {
     setHasCopied(false);
   }, [trackedJob?.previewUrl]);
+
+  useEffect(() => {
+    if (!trackedJob) {
+      return;
+    }
+    if (!trackedPreviewIdsRef.current.has(trackedJob.previewId)) {
+      return;
+    }
+
+    const signature = JSON.stringify({
+      status: trackedJob.status,
+      stage: trackedJob.stage ?? null,
+      errorCode: trackedJob.errorCode ?? null,
+      errorStage: trackedJob.errorStage ?? null,
+      retryHintReason: trackedJob.retryHint?.reason ?? null,
+    });
+    const previousSignature = trackedPreviewStatusSignaturesRef.current.get(trackedJob.previewId);
+    if (previousSignature === signature) {
+      return;
+    }
+
+    trackedPreviewStatusSignaturesRef.current.set(trackedJob.previewId, signature);
+    captureAnalyticsEvent(
+      ANALYTICS_EVENTS.previewStatusTransition,
+      buildPreviewAnalyticsProperties({
+        locale,
+        sourceUrl: trackedJob.sourceUrl,
+        sourceLang: trackedJob.sourceLang,
+        targetLang: trackedJob.targetLang,
+        previewId: trackedJob.previewId,
+        status: trackedJob.status,
+        stage: trackedJob.stage,
+        errorCode: trackedJob.errorCode,
+        errorStage: trackedJob.errorStage,
+        retryHintReason: trackedJob.retryHint?.reason ?? null,
+        fieldLayout,
+      }),
+    );
+
+    if (trackedPreviewTerminalRef.current.has(trackedJob.previewId)) {
+      return;
+    }
+
+    if (trackedJob.status === "ready") {
+      trackedPreviewTerminalRef.current.add(trackedJob.previewId);
+      captureAnalyticsEvent(
+        ANALYTICS_EVENTS.previewReady,
+        buildPreviewAnalyticsProperties({
+          locale,
+          sourceUrl: trackedJob.sourceUrl,
+          sourceLang: trackedJob.sourceLang,
+          targetLang: trackedJob.targetLang,
+          previewId: trackedJob.previewId,
+          status: trackedJob.status,
+          stage: trackedJob.stage,
+          fieldLayout,
+        }),
+      );
+      return;
+    }
+
+    if (trackedJob.status === "failed" || trackedJob.status === "expired") {
+      trackedPreviewTerminalRef.current.add(trackedJob.previewId);
+      captureAnalyticsEvent(
+        ANALYTICS_EVENTS.previewFailed,
+        buildPreviewAnalyticsProperties({
+          locale,
+          sourceUrl: trackedJob.sourceUrl,
+          sourceLang: trackedJob.sourceLang,
+          targetLang: trackedJob.targetLang,
+          previewId: trackedJob.previewId,
+          status: trackedJob.status,
+          stage: trackedJob.stage,
+          errorCode: trackedJob.errorCode,
+          errorStage: trackedJob.errorStage,
+          fieldLayout,
+        }),
+      );
+    }
+  }, [fieldLayout, locale, trackedJob]);
 
   function closeEventSource() {
     if (eventSourceRef.current) {
@@ -855,11 +944,33 @@ export function TryForm({
     connectSSE(previewId, statusToken);
   }
 
+  function trackTryFormStarted(overrides?: {
+    sourceUrl?: string;
+    sourceLang?: string;
+    targetLang?: string;
+  }) {
+    if (trackedTryStartRef.current) {
+      return;
+    }
+    trackedTryStartRef.current = true;
+    captureAnalyticsEvent(
+      ANALYTICS_EVENTS.tryFormStarted,
+      buildPreviewAnalyticsProperties({
+        locale,
+        sourceUrl: overrides?.sourceUrl ?? trimmedUrl,
+        sourceLang: overrides?.sourceLang ?? normalizedSourceLang,
+        targetLang: overrides?.targetLang ?? normalizedTargetLang,
+        fieldLayout,
+      }),
+    );
+  }
+
   async function handleGenerate() {
     if (!trimmedUrl || disabled) {
       return;
     }
 
+    let requestAttempted = false;
     try {
       if (!isValidHttpUrl(trimmedUrl)) {
         const message = t("try.form.invalidUrl");
@@ -877,6 +988,17 @@ export function TryForm({
       setUrlError(null);
       setSubmissionError(null);
       setIsCreating(true);
+      trackTryFormStarted();
+      captureAnalyticsEvent(
+        ANALYTICS_EVENTS.tryFormSubmitted,
+        buildPreviewAnalyticsProperties({
+          locale,
+          sourceUrl: trimmedUrl,
+          sourceLang: normalizedSourceLang,
+          targetLang: normalizedTargetLang,
+          fieldLayout,
+        }),
+      );
       setTimedOut(false);
       setTimedOutWithEmail(false);
       timedOutRef.current = false;
@@ -899,6 +1021,7 @@ export function TryForm({
       abortControllerRef.current = controller;
 
       try {
+        requestAttempted = true;
         const response = await fetch("/api/previews", {
           method: "POST",
           headers: {
@@ -917,6 +1040,18 @@ export function TryForm({
           const payload = await response.json().catch(() => null);
           const reason =
             payload?.error || payload?.message || `Request failed with status ${response.status}`;
+          captureAnalyticsEvent(
+            ANALYTICS_EVENTS.previewCreateFailed,
+            buildPreviewAnalyticsProperties({
+              locale,
+              sourceUrl: trimmedUrl,
+              sourceLang: normalizedSourceLang,
+              targetLang: normalizedTargetLang,
+              errorCode: typeof payload?.errorCode === "string" ? payload.errorCode : null,
+              errorStage: typeof payload?.errorStage === "string" ? payload.errorStage : null,
+              fieldLayout,
+            }),
+          );
           setSubmissionError(resolveErrorMessage(null, reason));
           return;
         }
@@ -928,8 +1063,25 @@ export function TryForm({
           typeof payload?.previewUrl === "string" ? payload.previewUrl : null;
 
         if (payload?.status === "failed") {
+          if (previewId) {
+            trackedPreviewIdsRef.current.add(previewId);
+          }
           const resolved = resolveErrorFromPayload(payload);
           if (previewId && statusToken) {
+            captureAnalyticsEvent(
+              ANALYTICS_EVENTS.previewCreateSucceeded,
+              buildPreviewAnalyticsProperties({
+                locale,
+                sourceUrl: trimmedUrl,
+                sourceLang: normalizedSourceLang,
+                targetLang: normalizedTargetLang,
+                previewId,
+                status: "failed",
+                errorCode: resolved.code,
+                errorStage: resolved.stage,
+                fieldLayout,
+              }),
+            );
             upsertPreviewStatusCenterJob({
               previewId,
               requestKey,
@@ -949,6 +1101,18 @@ export function TryForm({
               },
             );
           } else {
+            captureAnalyticsEvent(
+              ANALYTICS_EVENTS.previewCreateFailed,
+              buildPreviewAnalyticsProperties({
+                locale,
+                sourceUrl: trimmedUrl,
+                sourceLang: normalizedSourceLang,
+                targetLang: normalizedTargetLang,
+                errorCode: resolved.code,
+                errorStage: resolved.stage,
+                fieldLayout,
+              }),
+            );
             setSubmissionError(resolved.message);
           }
           return;
@@ -956,10 +1120,35 @@ export function TryForm({
 
         if (payload?.status === "ready") {
           if (!previewId || !statusToken) {
+            captureAnalyticsEvent(
+              ANALYTICS_EVENTS.previewCreateFailed,
+              buildPreviewAnalyticsProperties({
+                locale,
+                sourceUrl: trimmedUrl,
+                sourceLang: normalizedSourceLang,
+                targetLang: normalizedTargetLang,
+                fieldLayout,
+              }),
+            );
             setSubmissionError(t("try.error.default"));
             return;
           }
 
+          trackedPreviewIdsRef.current.add(previewId);
+          trackedPreviewTerminalRef.current.delete(previewId);
+          trackedPreviewStatusSignaturesRef.current.delete(previewId);
+          captureAnalyticsEvent(
+            ANALYTICS_EVENTS.previewCreateSucceeded,
+            buildPreviewAnalyticsProperties({
+              locale,
+              sourceUrl: trimmedUrl,
+              sourceLang: normalizedSourceLang,
+              targetLang: normalizedTargetLang,
+              previewId,
+              status: "ready",
+              fieldLayout,
+            }),
+          );
           upsertPreviewStatusCenterJob({
             previewId,
             requestKey,
@@ -976,12 +1165,53 @@ export function TryForm({
         }
 
         if (!previewId) {
+          captureAnalyticsEvent(
+            ANALYTICS_EVENTS.previewCreateFailed,
+            buildPreviewAnalyticsProperties({
+              locale,
+              sourceUrl: trimmedUrl,
+              sourceLang: normalizedSourceLang,
+              targetLang: normalizedTargetLang,
+              fieldLayout,
+            }),
+          );
           throw new Error("Preview was created but no ID was returned.");
         }
         if (!statusToken) {
+          captureAnalyticsEvent(
+            ANALYTICS_EVENTS.previewCreateFailed,
+            buildPreviewAnalyticsProperties({
+              locale,
+              sourceUrl: trimmedUrl,
+              sourceLang: normalizedSourceLang,
+              targetLang: normalizedTargetLang,
+              previewId,
+              fieldLayout,
+            }),
+          );
           throw new Error("Preview was created but no status token was returned.");
         }
 
+        trackedPreviewIdsRef.current.add(previewId);
+        trackedPreviewTerminalRef.current.delete(previewId);
+        trackedPreviewStatusSignaturesRef.current.delete(previewId);
+        captureAnalyticsEvent(
+          ANALYTICS_EVENTS.previewCreateSucceeded,
+          buildPreviewAnalyticsProperties({
+            locale,
+            sourceUrl: trimmedUrl,
+            sourceLang: normalizedSourceLang,
+            targetLang: normalizedTargetLang,
+            previewId,
+            status:
+              payload?.status === "pending" || payload?.status === "processing"
+                ? payload.status
+                : "pending",
+            stage: isPreviewStage(payload?.stage) ? payload.stage : null,
+            retryHintReason: resolvePreviewRetryHint(payload)?.reason ?? null,
+            fieldLayout,
+          }),
+        );
         connectStatusUpdates(previewId, statusToken, requestKey, {
           sourceUrl: trimmedUrl,
           sourceLang: normalizedSourceLang,
@@ -1000,6 +1230,18 @@ export function TryForm({
         }
       }
     } catch (error) {
+      if (requestAttempted) {
+        captureAnalyticsEvent(
+          ANALYTICS_EVENTS.previewCreateFailed,
+          buildPreviewAnalyticsProperties({
+            locale,
+            sourceUrl: trimmedUrl,
+            sourceLang: normalizedSourceLang,
+            targetLang: normalizedTargetLang,
+            fieldLayout,
+          }),
+        );
+      }
       const message = error instanceof Error ? error.message : "Failed to generate preview.";
       setSubmissionError(message);
     } finally {
@@ -1014,6 +1256,18 @@ export function TryForm({
     }
     try {
       await navigator.clipboard.writeText(previewUrl);
+      captureAnalyticsEvent(
+        ANALYTICS_EVENTS.previewCopyClicked,
+        buildPreviewAnalyticsProperties({
+          locale,
+          sourceUrl: trackedJob?.sourceUrl ?? trimmedUrl,
+          sourceLang: trackedJob?.sourceLang ?? normalizedSourceLang,
+          targetLang: trackedJob?.targetLang ?? normalizedTargetLang,
+          previewId: trackedJob?.previewId ?? null,
+          status: trackedJob?.status ?? null,
+          fieldLayout,
+        }),
+      );
       setHasCopied(true);
       if (copyTimerRef.current) {
         clearTimeout(copyTimerRef.current);
@@ -1051,6 +1305,18 @@ export function TryForm({
         return;
       }
       submittedEmailRef.current = trimmedPendingEmail;
+      captureAnalyticsEvent(
+        ANALYTICS_EVENTS.previewEmailSaved,
+        buildPreviewAnalyticsProperties({
+          locale,
+          sourceUrl: trackedJob?.sourceUrl ?? trimmedUrl,
+          sourceLang: trackedJob?.sourceLang ?? normalizedSourceLang,
+          targetLang: trackedJob?.targetLang ?? normalizedTargetLang,
+          previewId,
+          status: trackedJob?.status ?? null,
+          fieldLayout,
+        }),
+      );
       setPendingEmailStatus("saved");
     } catch {
       setPendingEmailStatus("error");
@@ -1127,6 +1393,9 @@ export function TryForm({
                     value={url}
                     onChange={(event) => {
                       const value = event.currentTarget.value;
+                      trackTryFormStarted({
+                        sourceUrl: value,
+                      });
                       setUrl(value);
                       if (urlError) {
                         setUrlError(validateUrl(value));
@@ -1156,7 +1425,12 @@ export function TryForm({
                   <span className="font-medium text-foreground">{t("try.form.sourceLabel")}</span>
                   <LanguageTagCombobox
                     value={sourceLang}
-                    onValueChange={setSourceLang}
+                    onValueChange={(value) => {
+                      trackTryFormStarted({
+                        sourceLang: normalizeLangTag(value) ?? value.trim(),
+                      });
+                      setSourceLang(value);
+                    }}
                     supportedLanguages={supportedLanguages}
                     displayLocale={locale}
                     disabled={inputsDisabled}
@@ -1168,7 +1442,12 @@ export function TryForm({
                   <span className="font-medium text-foreground">{t("try.form.targetLabel")}</span>
                   <LanguageTagCombobox
                     value={targetLang}
-                    onValueChange={setTargetLang}
+                    onValueChange={(value) => {
+                      trackTryFormStarted({
+                        targetLang: normalizeLangTag(value) ?? value.trim(),
+                      });
+                      setTargetLang(value);
+                    }}
                     supportedLanguages={supportedLanguages}
                     displayLocale={locale}
                     disabled={inputsDisabled}
@@ -1274,7 +1553,10 @@ export function TryForm({
                       </p>
                       <Input
                         value={pendingEmail}
-                        onChange={(event) => setPendingEmail(event.currentTarget.value)}
+                        onChange={(event) => {
+                          trackTryFormStarted();
+                          setPendingEmail(event.currentTarget.value);
+                        }}
                         placeholder={t("try.form.emailPlaceholder")}
                         type="email"
                         autoComplete="email"
@@ -1326,7 +1608,10 @@ export function TryForm({
               <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
                 <Input
                   value={pendingEmail}
-                  onChange={(event) => setPendingEmail(event.currentTarget.value)}
+                  onChange={(event) => {
+                    trackTryFormStarted();
+                    setPendingEmail(event.currentTarget.value);
+                  }}
                   placeholder={t("try.form.emailPlaceholder")}
                   type="email"
                   autoComplete="email"
@@ -1405,7 +1690,25 @@ export function TryForm({
               {trackedJob.previewUrl ? (
                 <div className="flex flex-col gap-2 sm:flex-row">
                   <Button asChild size="sm" variant="secondary" className="justify-center">
-                    <a href={trackedJob.previewUrl} target="_blank" rel="noreferrer">
+                    <a
+                      href={trackedJob.previewUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      onClick={() => {
+                        captureAnalyticsEvent(
+                          ANALYTICS_EVENTS.previewOpenClicked,
+                          buildPreviewAnalyticsProperties({
+                            locale,
+                            sourceUrl: trackedJob.sourceUrl,
+                            sourceLang: trackedJob.sourceLang,
+                            targetLang: trackedJob.targetLang,
+                            previewId: trackedJob.previewId,
+                            status: trackedJob.status,
+                            fieldLayout,
+                          }),
+                        );
+                      }}
+                    >
                       {t("try.preview.openOverlay")}
                     </a>
                   </Button>

--- a/docs/reports/posthog-funnel-proxy-routing-analysis-2026-04-14.md
+++ b/docs/reports/posthog-funnel-proxy-routing-analysis-2026-04-14.md
@@ -83,13 +83,13 @@ This milestone should prefer client wrappers around the specific CTA surfaces in
 
 ### Milestone 3: First-Party PostHog Proxy Host
 
-Move ingestion from direct `app.posthog.com` usage to a WebLingo-controlled host.
+Move ingestion from direct PostHog browser calls to a first-party WebLingo route.
 
 Recommended approach:
 
 - introduce a dedicated public env for the first-party analytics host
-- keep `NEXT_PUBLIC_POSTHOG_HOST` pointed at the first-party host
-- proxy analytics traffic upstream to PostHog from the website deployment
+- keep `NEXT_PUBLIC_POSTHOG_HOST` pointed at the upstream PostHog ingestion host
+- proxy analytics traffic through a first-party `/_analytics/posthog` route in the website deployment
 - keep the dashboard auth proxy behavior intact
 - document the required domain + deployment configuration in `README.md`
 

--- a/docs/reports/posthog-funnel-proxy-routing-analysis-2026-04-14.md
+++ b/docs/reports/posthog-funnel-proxy-routing-analysis-2026-04-14.md
@@ -1,0 +1,149 @@
+# PostHog Funnel Instrumentation + Proxy Routing Analysis (2026-04-14)
+
+## Scope
+
+Tracked by backend milestone `M6.5` as a release-blocking website/control-plane task:
+
+- Add conversion-funnel instrumentation across landing, try-form, preview lifecycle, pricing, and checkout.
+- Route PostHog ingestion through a first-party WebLingo host to reduce event loss from ad blockers.
+
+## Current State
+
+- `posthog-js` is already installed in `weblingo_website`.
+- Client initialization already exists in `instrumentation-client.ts`.
+- No custom `posthog.capture(...)` calls currently exist, so the product funnel is effectively uninstrumented.
+- The highest-value existing client surfaces are:
+  - marketing home / landing pages
+  - pricing page
+  - try-form
+  - preview status center
+  - checkout success / cancel pages
+
+## Constraints
+
+- Keep env handling centralized in `internal/core/env.ts` and `internal/core/env-server.ts`.
+- Avoid leaking raw emails or full source URLs into analytics properties.
+- Keep analytics client-only and no-op safely when PostHog config is absent or disabled.
+- Avoid ad hoc event names scattered across components.
+- Keep proxy routing isolated from product routes and dashboard auth middleware.
+
+## Recommended Implementation
+
+### Milestone 1: Analytics Layer + Try/Preview Funnel
+
+Create a small typed analytics layer in `internal/analytics/*`:
+
+- event name constants
+- narrow event-property types
+- thin `captureAnalyticsEvent(...)` helper
+- page/CTA helper(s) only where they delete real duplication
+
+Instrument the try/preview funnel first:
+
+- `try_form_started`
+- `try_form_submitted`
+- `preview_create_succeeded`
+- `preview_create_failed`
+- `preview_status_transition`
+- `preview_ready`
+- `preview_failed`
+- `preview_open_clicked`
+- `preview_copy_clicked`
+- `preview_email_saved`
+- `preview_status_center_open_clicked`
+- `preview_status_center_dismissed`
+
+De-duplication rules:
+
+- `try_form_started` should fire once per page view / component lifecycle.
+- `preview_status_transition` should only fire on meaningful `(status, stage, errorCode)` changes, not heartbeats.
+- `preview_ready` / `preview_failed` should fire once per preview id.
+
+### Milestone 2: Landing, Pricing, and Checkout Funnel
+
+Instrument acquisition and commercial actions:
+
+- `marketing_page_view`
+- `marketing_cta_clicked`
+- `pricing_page_view`
+- `pricing_cta_clicked`
+- `checkout_success_view`
+- `checkout_cancel_view`
+
+Recommended CTA properties:
+
+- `page_name`
+- `cta_id`
+- `cta_label`
+- `locale`
+- `segment` or `variant` where relevant
+- `destination_kind` (`try`, `pricing`, `login`, `contact`, `checkout`)
+
+This milestone should prefer client wrappers around the specific CTA surfaces instead of generic DOM click delegation.
+
+### Milestone 3: First-Party PostHog Proxy Host
+
+Move ingestion from direct `app.posthog.com` usage to a WebLingo-controlled host.
+
+Recommended approach:
+
+- introduce a dedicated public env for the first-party analytics host
+- keep `NEXT_PUBLIC_POSTHOG_HOST` pointed at the first-party host
+- proxy analytics traffic upstream to PostHog from the website deployment
+- keep the dashboard auth proxy behavior intact
+- document the required domain + deployment configuration in `README.md`
+
+Routing recommendation:
+
+- Prefer a dedicated analytics subdomain such as `metrics.weblingo.app`.
+- Route that host through the website deployment and proxy upstream requests in `proxy.ts`.
+- Bypass normal dashboard/session middleware for analytics-host traffic.
+
+Required upstream safety:
+
+- only allow the dedicated analytics host to proxy
+- restrict upstream targets to the approved PostHog host(s)
+- pass through method, body, and headers conservatively
+- preserve status codes and content types
+
+## Event Contract
+
+### Shared Properties
+
+- `locale`
+- `page_name`
+- `path`
+- `cta_id` when relevant
+- `source_lang` / `target_lang` for preview flows
+- `source_host` for preview flows
+- `preview_id` only after the backend returns it
+
+### Privacy Rules
+
+- do not send full email addresses
+- do not send full source URLs
+- prefer `source_host` and optionally a trimmed pathname without query strings
+- do not send raw backend error payloads; normalize to `error_code`, `error_stage`, `error_status`
+
+## Validation
+
+Minimum validation for this work:
+
+- unit tests for analytics helper behavior and proxy routing
+- component tests for milestone-1 event emission on try/preview interactions
+- targeted page/component tests for CTA instrumentation
+- `coderabbit review --prompt-only` between milestones
+- a `gpt-5.4-mini` sub-agent review between milestones
+
+## Delivery Order
+
+1. Milestone 1: analytics layer + try/preview instrumentation
+2. Milestone 2: landing/pricing/checkout instrumentation
+3. Milestone 3: first-party PostHog proxy routing + env/docs
+
+## Not In Scope
+
+- backend product analytics APIs
+- user/account identification policy beyond current anonymous funnel capture
+- PostHog dashboard configuration itself
+- experiment rollout logic driven by analytics results

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,7 +1,8 @@
 import posthog from "posthog-js";
 import { env } from "@internal/core";
+import { buildPosthogProxyApiHost } from "@internal/analytics/proxy";
 
 posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
-  api_host: env.NEXT_PUBLIC_POSTHOG_HOST,
+  api_host: buildPosthogProxyApiHost(env.NEXT_PUBLIC_APP_URL),
   defaults: "2025-05-24",
 });

--- a/internal/analytics/client.ts
+++ b/internal/analytics/client.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import posthog from "posthog-js";
+
+import {
+  sanitizeAnalyticsProperties,
+  type AnalyticsEventName,
+  type AnalyticsProperties,
+} from "./events";
+
+export {
+  ANALYTICS_EVENTS,
+  buildPreviewAnalyticsProperties,
+  extractPublicUrlContext,
+  type AnalyticsEventName,
+  type AnalyticsProperties,
+} from "./events";
+
+export function captureAnalyticsEvent(
+  event: AnalyticsEventName,
+  properties: AnalyticsProperties = {},
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    posthog.capture(event, sanitizeAnalyticsProperties(properties));
+  } catch {
+    // Analytics must never break user-facing flows.
+  }
+}

--- a/internal/analytics/client.ts
+++ b/internal/analytics/client.ts
@@ -10,7 +10,10 @@ import {
 
 export {
   ANALYTICS_EVENTS,
+  buildCtaAnalyticsProperties,
+  buildPageAnalyticsProperties,
   buildPreviewAnalyticsProperties,
+  extractLinkTargetContext,
   extractPublicUrlContext,
   type AnalyticsEventName,
   type AnalyticsProperties,

--- a/internal/analytics/events.test.ts
+++ b/internal/analytics/events.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPreviewAnalyticsProperties,
+  extractPublicUrlContext,
+  sanitizeAnalyticsProperties,
+} from "./events";
+
+describe("analytics events helpers", () => {
+  it("extracts a public source host and path without query strings", () => {
+    expect(
+      extractPublicUrlContext("https://Example.COM/docs/getting-started?email=a@example.com#intro"),
+    ).toEqual({
+      sourceHost: "example.com",
+      sourcePath: "/docs/getting-started",
+    });
+  });
+
+  it("drops invalid URLs safely", () => {
+    expect(extractPublicUrlContext("not a valid url")).toEqual({
+      sourceHost: null,
+      sourcePath: null,
+    });
+    expect(extractPublicUrlContext("mailto:alice@example.com")).toEqual({
+      sourceHost: null,
+      sourcePath: null,
+    });
+    expect(extractPublicUrlContext("file:///Users/example/Documents/secrets.txt")).toEqual({
+      sourceHost: null,
+      sourcePath: null,
+    });
+  });
+
+  it("removes undefined fields from analytics payloads", () => {
+    expect(
+      sanitizeAnalyticsProperties({
+        locale: "en",
+        stage: undefined,
+        status: "processing",
+      }),
+    ).toEqual({
+      locale: "en",
+      status: "processing",
+    });
+  });
+
+  it("builds preview analytics properties without leaking full URLs", () => {
+    expect(
+      buildPreviewAnalyticsProperties({
+        locale: "en",
+        sourceUrl: "https://example.com/pricing?email=test@example.com",
+        sourceLang: "en",
+        targetLang: "fr",
+        previewId: "preview-1",
+        status: "processing",
+        stage: "translating",
+        retryHintReason: "browser_capacity_exhausted",
+      }),
+    ).toEqual({
+      locale: "en",
+      source_host: "example.com",
+      source_path: "/pricing",
+      source_lang: "en",
+      target_lang: "fr",
+      preview_id: "preview-1",
+      status: "processing",
+      stage: "translating",
+      retry_hint_reason: "browser_capacity_exhausted",
+    });
+  });
+});

--- a/internal/analytics/events.test.ts
+++ b/internal/analytics/events.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildCtaAnalyticsProperties,
+  buildPageAnalyticsProperties,
   buildPreviewAnalyticsProperties,
+  extractLinkTargetContext,
   extractPublicUrlContext,
   sanitizeAnalyticsProperties,
 } from "./events";
@@ -66,6 +69,85 @@ describe("analytics events helpers", () => {
       status: "processing",
       stage: "translating",
       retry_hint_reason: "browser_capacity_exhausted",
+    });
+  });
+
+  it("extracts safe CTA target context for internal, anchor, external, and mailto links", () => {
+    expect(extractLinkTargetContext("/fr/pricing?coupon=secret#plans")).toEqual({
+      targetKind: "internal",
+      targetHost: null,
+      targetPath: "/fr/pricing",
+    });
+    expect(extractLinkTargetContext("#try")).toEqual({
+      targetKind: "anchor",
+      targetHost: null,
+      targetPath: "#try",
+    });
+    expect(extractLinkTargetContext("https://example.com/docs/start?email=a@example.com")).toEqual({
+      targetKind: "external",
+      targetHost: "example.com",
+      targetPath: "/docs/start",
+    });
+    expect(extractLinkTargetContext("mailto:contact@weblingo.app")).toEqual({
+      targetKind: "mailto",
+      targetHost: null,
+      targetPath: null,
+    });
+  });
+
+  it("builds page analytics properties with normalized page data", () => {
+    expect(
+      buildPageAnalyticsProperties({
+        locale: "ja",
+        pagePath: "/ja/landing/expansion",
+        pageType: "landing",
+        segment: "expansion",
+        variant: "expansion",
+        sessionPresent: true,
+      }),
+    ).toEqual({
+      locale: "ja",
+      page_path: "/ja/landing/expansion",
+      page_type: "landing",
+      segment: "expansion",
+      session_present: true,
+      variant: "expansion",
+    });
+  });
+
+  it("builds CTA analytics properties without leaking query strings or mailto addresses", () => {
+    expect(
+      buildCtaAnalyticsProperties({
+        ctaId: "pricing_header_contact",
+        locale: "en",
+        pagePath: "/en/pricing",
+        pageType: "pricing",
+        planId: "enterprise",
+        targetHref: "mailto:contact@weblingo.app",
+      }),
+    ).toEqual({
+      cta_id: "pricing_header_contact",
+      locale: "en",
+      page_path: "/en/pricing",
+      page_type: "pricing",
+      plan_id: "enterprise",
+      target_kind: "mailto",
+    });
+    expect(
+      buildCtaAnalyticsProperties({
+        ctaId: "pricing_free_plan_try_preview",
+        locale: "en",
+        pagePath: "/en/pricing",
+        pageType: "pricing",
+        targetHref: "/en/try?email=secret@example.com#panel",
+      }),
+    ).toEqual({
+      cta_id: "pricing_free_plan_try_preview",
+      locale: "en",
+      page_path: "/en/pricing",
+      page_type: "pricing",
+      target_kind: "internal",
+      target_path: "/en/try",
     });
   });
 });

--- a/internal/analytics/events.test.ts
+++ b/internal/analytics/events.test.ts
@@ -76,7 +76,7 @@ describe("analytics events helpers", () => {
     expect(extractLinkTargetContext("/fr/pricing?coupon=secret#plans")).toEqual({
       targetKind: "internal",
       targetHost: null,
-      targetPath: "/fr/pricing",
+      targetPath: "/fr/pricing#plans",
     });
     expect(extractLinkTargetContext("#try")).toEqual({
       targetKind: "anchor",
@@ -147,7 +147,7 @@ describe("analytics events helpers", () => {
       page_path: "/en/pricing",
       page_type: "pricing",
       target_kind: "internal",
-      target_path: "/en/try",
+      target_path: "/en/try#panel",
     });
   });
 });

--- a/internal/analytics/events.ts
+++ b/internal/analytics/events.ts
@@ -17,6 +17,7 @@ export const ANALYTICS_EVENTS = {
   pricingCtaClicked: "pricing_cta_clicked",
   checkoutSuccessView: "checkout_success_view",
   checkoutCancelView: "checkout_cancel_view",
+  checkoutCtaClicked: "checkout_cta_clicked",
 } as const;
 
 export type AnalyticsEventName = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];
@@ -39,9 +40,30 @@ type PreviewAnalyticsInput = {
   fieldLayout?: string | null;
 };
 
+type PageAnalyticsInput = {
+  locale?: string | null;
+  pageType?: string | null;
+  pagePath?: string | null;
+  variant?: string | null;
+  segment?: string | null;
+  sessionPresent?: boolean | null;
+};
+
+type CtaAnalyticsInput = PageAnalyticsInput & {
+  ctaId?: string | null;
+  targetHref?: string | null;
+  planId?: string | null;
+};
+
 type PublicUrlContext = {
   sourceHost: string | null;
   sourcePath: string | null;
+};
+
+type LinkTargetContext = {
+  targetKind: string | null;
+  targetHost: string | null;
+  targetPath: string | null;
 };
 
 function normalizeTrimmed(value: string | null | undefined): string | null {
@@ -61,6 +83,14 @@ function normalizeSourcePath(pathname: string): string | null {
   return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
 }
 
+function normalizeAnchorTarget(target: string): string | null {
+  const trimmed = normalizeTrimmed(target);
+  if (!trimmed || !trimmed.startsWith("#")) {
+    return null;
+  }
+  return trimmed.length > 160 ? `${trimmed.slice(0, 157)}...` : trimmed;
+}
+
 export function extractPublicUrlContext(sourceUrl?: string | null): PublicUrlContext {
   const trimmed = normalizeTrimmed(sourceUrl);
   if (!trimmed) {
@@ -78,6 +108,52 @@ export function extractPublicUrlContext(sourceUrl?: string | null): PublicUrlCon
     };
   } catch {
     return { sourceHost: null, sourcePath: null };
+  }
+}
+
+export function extractLinkTargetContext(targetHref?: string | null): LinkTargetContext {
+  const trimmed = normalizeTrimmed(targetHref);
+  if (!trimmed) {
+    return { targetKind: null, targetHost: null, targetPath: null };
+  }
+
+  if (trimmed.startsWith("#")) {
+    return {
+      targetKind: "anchor",
+      targetHost: null,
+      targetPath: normalizeAnchorTarget(trimmed),
+    };
+  }
+
+  if (trimmed.startsWith("/")) {
+    return {
+      targetKind: "internal",
+      targetHost: null,
+      targetPath: normalizeSourcePath(trimmed.split("#", 1)[0]?.split("?", 1)[0] || trimmed),
+    };
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === "mailto:") {
+      return {
+        targetKind: "mailto",
+        targetHost: null,
+        targetPath: null,
+      };
+    }
+
+    if ((parsed.protocol !== "http:" && parsed.protocol !== "https:") || !parsed.hostname) {
+      return { targetKind: null, targetHost: null, targetPath: null };
+    }
+
+    return {
+      targetKind: "external",
+      targetHost: parsed.hostname.trim().toLowerCase() || null,
+      targetPath: normalizeSourcePath(parsed.pathname || "/"),
+    };
+  } catch {
+    return { targetKind: null, targetHost: null, targetPath: null };
   }
 }
 
@@ -106,5 +182,32 @@ export function buildPreviewAnalyticsProperties(
     error_stage: normalizeTrimmed(input.errorStage),
     retry_hint_reason: normalizeTrimmed(input.retryHintReason),
     field_layout: normalizeTrimmed(input.fieldLayout),
+  });
+}
+
+export function buildPageAnalyticsProperties(
+  input: PageAnalyticsInput,
+): Record<string, SanitizedAnalyticsPropertyValue> {
+  return sanitizeAnalyticsProperties({
+    locale: normalizeTrimmed(input.locale),
+    page_type: normalizeTrimmed(input.pageType),
+    page_path: normalizeSourcePath(input.pagePath ?? ""),
+    variant: normalizeTrimmed(input.variant),
+    segment: normalizeTrimmed(input.segment),
+    session_present: input.sessionPresent ?? undefined,
+  });
+}
+
+export function buildCtaAnalyticsProperties(
+  input: CtaAnalyticsInput,
+): Record<string, SanitizedAnalyticsPropertyValue> {
+  const { targetKind, targetHost, targetPath } = extractLinkTargetContext(input.targetHref);
+  return sanitizeAnalyticsProperties({
+    ...buildPageAnalyticsProperties(input),
+    cta_id: normalizeTrimmed(input.ctaId),
+    plan_id: normalizeTrimmed(input.planId),
+    target_kind: targetKind,
+    target_host: targetHost,
+    target_path: targetPath,
   });
 }

--- a/internal/analytics/events.ts
+++ b/internal/analytics/events.ts
@@ -1,0 +1,110 @@
+export const ANALYTICS_EVENTS = {
+  tryFormStarted: "try_form_started",
+  tryFormSubmitted: "try_form_submitted",
+  previewCreateSucceeded: "preview_create_succeeded",
+  previewCreateFailed: "preview_create_failed",
+  previewStatusTransition: "preview_status_transition",
+  previewReady: "preview_ready",
+  previewFailed: "preview_failed",
+  previewOpenClicked: "preview_open_clicked",
+  previewCopyClicked: "preview_copy_clicked",
+  previewEmailSaved: "preview_email_saved",
+  previewStatusCenterOpenClicked: "preview_status_center_open_clicked",
+  previewStatusCenterDismissed: "preview_status_center_dismissed",
+  marketingPageView: "marketing_page_view",
+  marketingCtaClicked: "marketing_cta_clicked",
+  pricingPageView: "pricing_page_view",
+  pricingCtaClicked: "pricing_cta_clicked",
+  checkoutSuccessView: "checkout_success_view",
+  checkoutCancelView: "checkout_cancel_view",
+} as const;
+
+export type AnalyticsEventName = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];
+
+export type AnalyticsPropertyValue = string | number | boolean | null | undefined;
+export type AnalyticsProperties = Record<string, AnalyticsPropertyValue>;
+type SanitizedAnalyticsPropertyValue = Exclude<AnalyticsPropertyValue, null | undefined>;
+
+type PreviewAnalyticsInput = {
+  locale?: string | null;
+  sourceUrl?: string | null;
+  sourceLang?: string | null;
+  targetLang?: string | null;
+  previewId?: string | null;
+  status?: string | null;
+  stage?: string | null;
+  errorCode?: string | null;
+  errorStage?: string | null;
+  retryHintReason?: string | null;
+  fieldLayout?: string | null;
+};
+
+type PublicUrlContext = {
+  sourceHost: string | null;
+  sourcePath: string | null;
+};
+
+function normalizeTrimmed(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normalizeSourcePath(pathname: string): string | null {
+  const trimmed = pathname.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const normalized = trimmed;
+  return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
+}
+
+export function extractPublicUrlContext(sourceUrl?: string | null): PublicUrlContext {
+  const trimmed = normalizeTrimmed(sourceUrl);
+  if (!trimmed) {
+    return { sourceHost: null, sourcePath: null };
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if ((parsed.protocol !== "http:" && parsed.protocol !== "https:") || !parsed.hostname) {
+      return { sourceHost: null, sourcePath: null };
+    }
+    return {
+      sourceHost: parsed.hostname.trim().toLowerCase() || null,
+      sourcePath: normalizeSourcePath(parsed.pathname || "/"),
+    };
+  } catch {
+    return { sourceHost: null, sourcePath: null };
+  }
+}
+
+export function sanitizeAnalyticsProperties(
+  properties: AnalyticsProperties,
+): Record<string, SanitizedAnalyticsPropertyValue> {
+  return Object.fromEntries(
+    Object.entries(properties).filter(([, value]) => value !== undefined && value !== null),
+  ) as Record<string, SanitizedAnalyticsPropertyValue>;
+}
+
+export function buildPreviewAnalyticsProperties(
+  input: PreviewAnalyticsInput,
+): Record<string, SanitizedAnalyticsPropertyValue> {
+  const { sourceHost, sourcePath } = extractPublicUrlContext(input.sourceUrl);
+  return sanitizeAnalyticsProperties({
+    locale: normalizeTrimmed(input.locale),
+    source_host: sourceHost,
+    source_path: sourcePath,
+    source_lang: normalizeTrimmed(input.sourceLang),
+    target_lang: normalizeTrimmed(input.targetLang),
+    preview_id: normalizeTrimmed(input.previewId),
+    status: normalizeTrimmed(input.status),
+    stage: normalizeTrimmed(input.stage),
+    error_code: normalizeTrimmed(input.errorCode),
+    error_stage: normalizeTrimmed(input.errorStage),
+    retry_hint_reason: normalizeTrimmed(input.retryHintReason),
+    field_layout: normalizeTrimmed(input.fieldLayout),
+  });
+}

--- a/internal/analytics/events.ts
+++ b/internal/analytics/events.ts
@@ -91,6 +91,20 @@ function normalizeAnchorTarget(target: string): string | null {
   return trimmed.length > 160 ? `${trimmed.slice(0, 157)}...` : trimmed;
 }
 
+function combinePathWithHash(pathname: string, hash: string): string | null {
+  const normalizedPath = normalizeSourcePath(pathname);
+  const normalizedHash = normalizeAnchorTarget(hash);
+
+  if (!normalizedPath) {
+    return normalizedHash;
+  }
+  if (!normalizedHash) {
+    return normalizedPath;
+  }
+
+  return normalizeSourcePath(`${normalizedPath}${normalizedHash}`);
+}
+
 export function extractPublicUrlContext(sourceUrl?: string | null): PublicUrlContext {
   const trimmed = normalizeTrimmed(sourceUrl);
   if (!trimmed) {
@@ -126,10 +140,11 @@ export function extractLinkTargetContext(targetHref?: string | null): LinkTarget
   }
 
   if (trimmed.startsWith("/")) {
+    const parsed = new URL(trimmed, "https://weblingo.app");
     return {
       targetKind: "internal",
       targetHost: null,
-      targetPath: normalizeSourcePath(trimmed.split("#", 1)[0]?.split("?", 1)[0] || trimmed),
+      targetPath: combinePathWithHash(parsed.pathname || "/", parsed.hash),
     };
   }
 
@@ -150,7 +165,7 @@ export function extractLinkTargetContext(targetHref?: string | null): LinkTarget
     return {
       targetKind: "external",
       targetHost: parsed.hostname.trim().toLowerCase() || null,
-      targetPath: normalizeSourcePath(parsed.pathname || "/"),
+      targetPath: combinePathWithHash(parsed.pathname || "/", parsed.hash),
     };
   } catch {
     return { targetKind: null, targetHost: null, targetPath: null };

--- a/internal/analytics/proxy.test.ts
+++ b/internal/analytics/proxy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPosthogProxyApiHost,
+  buildPosthogProxyRequestHeaders,
+  buildPosthogProxyResponseHeaders,
+  buildPosthogUpstreamUrl,
+  shouldForwardRequestBody,
+} from "./proxy";
+
+describe("PostHog proxy helpers", () => {
+  it("builds the first-party proxy api host from the app URL", () => {
+    expect(buildPosthogProxyApiHost("https://weblingo.app")).toBe(
+      "https://weblingo.app/_analytics/posthog",
+    );
+    expect(buildPosthogProxyApiHost("https://weblingo.app/")).toBe(
+      "https://weblingo.app/_analytics/posthog",
+    );
+  });
+
+  it("builds upstream urls with preserved query strings", () => {
+    expect(
+      buildPosthogUpstreamUrl(
+        "https://eu.i.posthog.com/ingest/",
+        ["e"],
+        "https://weblingo.app/_analytics/posthog/e/?v=2&compression=gzip",
+      ).toString(),
+    ).toBe("https://eu.i.posthog.com/ingest/e?v=2&compression=gzip");
+  });
+
+  it("filters hop-by-hop request headers and sets forwarded headers", () => {
+    const headers = buildPosthogProxyRequestHeaders(
+      new Headers({
+        authorization: "Bearer secret",
+        connection: "keep-alive",
+        "content-length": "123",
+        "content-type": "application/json",
+        cookie: "session=secret",
+        host: "weblingo.app",
+        referer: "https://weblingo.app/dashboard",
+      }),
+      "https://weblingo.app/_analytics/posthog/e",
+    );
+
+    expect(headers.get("authorization")).toBeNull();
+    expect(headers.get("connection")).toBeNull();
+    expect(headers.get("content-length")).toBeNull();
+    expect(headers.get("cookie")).toBeNull();
+    expect(headers.get("host")).toBeNull();
+    expect(headers.get("referer")).toBeNull();
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get("x-forwarded-host")).toBe("weblingo.app");
+    expect(headers.get("x-forwarded-proto")).toBe("https");
+  });
+
+  it("filters hop-by-hop response headers", () => {
+    const headers = buildPosthogProxyResponseHeaders(
+      new Headers({
+        connection: "close",
+        "content-type": "application/json",
+        "transfer-encoding": "chunked",
+      }),
+    );
+
+    expect(headers.get("connection")).toBeNull();
+    expect(headers.get("transfer-encoding")).toBeNull();
+    expect(headers.get("content-type")).toBe("application/json");
+  });
+
+  it("forwards bodies only for non-GET/HEAD methods", () => {
+    expect(shouldForwardRequestBody("GET")).toBe(false);
+    expect(shouldForwardRequestBody("HEAD")).toBe(false);
+    expect(shouldForwardRequestBody("POST")).toBe(true);
+  });
+});

--- a/internal/analytics/proxy.ts
+++ b/internal/analytics/proxy.ts
@@ -1,0 +1,94 @@
+const POSTHOG_PROXY_PATH = "/_analytics/posthog";
+
+const HOP_BY_HOP_REQUEST_HEADERS = new Set([
+  "authorization",
+  "connection",
+  "content-length",
+  "cookie",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "referer",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+function normalizeBasePath(pathname: string): string {
+  if (!pathname || pathname === "/") {
+    return "";
+  }
+
+  return pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
+export function buildPosthogProxyApiHost(appUrl: string): string {
+  return new URL(POSTHOG_PROXY_PATH, appUrl).toString().replace(/\/$/, "");
+}
+
+export function buildPosthogUpstreamUrl(
+  upstreamHost: string,
+  pathSegments: string[],
+  requestUrl: string,
+): URL {
+  const upstreamUrl = new URL(upstreamHost);
+  const incomingUrl = new URL(requestUrl);
+  const encodedPath = pathSegments.map((segment) => encodeURIComponent(segment)).join("/");
+  const basePath = normalizeBasePath(upstreamUrl.pathname);
+
+  upstreamUrl.pathname = encodedPath ? `${basePath}/${encodedPath}` : basePath || "/";
+  upstreamUrl.search = incomingUrl.search;
+
+  return upstreamUrl;
+}
+
+export function buildPosthogProxyRequestHeaders(
+  incomingHeaders: Headers,
+  requestUrl: string,
+): Headers {
+  const forwardedHeaders = new Headers();
+
+  incomingHeaders.forEach((value, key) => {
+    if (HOP_BY_HOP_REQUEST_HEADERS.has(key.toLowerCase())) {
+      return;
+    }
+    forwardedHeaders.set(key, value);
+  });
+
+  const requestOrigin = new URL(requestUrl);
+  forwardedHeaders.set("x-forwarded-host", requestOrigin.host);
+  forwardedHeaders.set("x-forwarded-proto", requestOrigin.protocol.replace(":", ""));
+
+  return forwardedHeaders;
+}
+
+export function buildPosthogProxyResponseHeaders(upstreamHeaders: Headers): Headers {
+  const responseHeaders = new Headers();
+
+  upstreamHeaders.forEach((value, key) => {
+    if (HOP_BY_HOP_RESPONSE_HEADERS.has(key.toLowerCase())) {
+      return;
+    }
+    responseHeaders.set(key, value);
+  });
+
+  return responseHeaders;
+}
+
+export function shouldForwardRequestBody(method: string): boolean {
+  const normalizedMethod = method.trim().toUpperCase();
+  return !["GET", "HEAD"].includes(normalizedMethod);
+}

--- a/modules/home/classic-home.tsx
+++ b/modules/home/classic-home.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { ArrowRight, BarChart3, Cloud, Globe, Lock, RefreshCcw, Zap } from "lucide-react";
 
+import { AnalyticsPageView } from "@/components/analytics-page-view";
+import { AnalyticsTrackedLink } from "@/components/analytics-tracked-link";
 import { TryForm } from "@/components/try-form";
 import { TryPanelHeader } from "@/components/try-panel-header";
 import { Button } from "@/components/ui/button";
+import {
+  ANALYTICS_EVENTS,
+  buildCtaAnalyticsProperties,
+  buildPageAnalyticsProperties,
+} from "@internal/analytics/events";
 import { SUPPORTED_LANGUAGES_STATIC } from "@internal/dashboard/webhooks";
 import { createLocalizedMetadata, resolveLocaleTranslator } from "@internal/i18n";
 
@@ -65,6 +71,15 @@ export async function ClassicHomePage({ locale, basePath }: { locale: string; ba
 
   return (
     <div className="min-h-screen bg-background">
+      <AnalyticsPageView
+        event={ANALYTICS_EVENTS.marketingPageView}
+        properties={buildPageAnalyticsProperties({
+          locale,
+          pagePath: baseHref,
+          pageType: "home",
+          variant: "classic",
+        })}
+      />
       <section
         id="try"
         className="relative overflow-hidden px-4 py-20 sm:px-6 sm:py-28 lg:px-8 lg:py-32"
@@ -115,13 +130,22 @@ export async function ClassicHomePage({ locale, basePath }: { locale: string; ba
           <p className="mb-12 text-lg text-muted-foreground">{t("home.problem.description")}</p>
           <div className="rounded-lg border border-border bg-card p-8">
             <p className="mb-6 text-foreground">{t("home.problem.solution")}</p>
-            <Link
+            <AnalyticsTrackedLink
+              analyticsProperties={buildCtaAnalyticsProperties({
+                ctaId: "classic_home_problem_how_it_works",
+                locale,
+                pagePath: baseHref,
+                pageType: "home",
+                targetHref: howItWorksHref,
+                variant: "classic",
+              })}
+              event={ANALYTICS_EVENTS.marketingCtaClicked}
               href={howItWorksHref}
               className="inline-flex items-center gap-2 font-medium text-primary transition hover:text-primary/80"
             >
               {t("home.problem.cta")}
               <ArrowRight className="h-4 w-4" />
-            </Link>
+            </AnalyticsTrackedLink>
           </div>
         </div>
       </section>
@@ -197,10 +221,21 @@ export async function ClassicHomePage({ locale, basePath }: { locale: string; ba
           </h2>
           <p className="mb-12 text-lg text-muted-foreground">{t("home.final.subtitle")}</p>
           <Button asChild size="lg" className="bg-primary hover:bg-primary/90">
-            <Link href={tryHref}>
+            <AnalyticsTrackedLink
+              analyticsProperties={buildCtaAnalyticsProperties({
+                ctaId: "classic_home_final_try",
+                locale,
+                pagePath: baseHref,
+                pageType: "home",
+                targetHref: tryHref,
+                variant: "classic",
+              })}
+              event={ANALYTICS_EVENTS.marketingCtaClicked}
+              href={tryHref}
+            >
               {t("home.final.cta")}
               <ArrowRight className="ml-2 h-4 w-4" />
-            </Link>
+            </AnalyticsTrackedLink>
           </Button>
         </div>
       </section>

--- a/modules/landing/segment-page.tsx
+++ b/modules/landing/segment-page.tsx
@@ -1,11 +1,17 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 
+import { AnalyticsPageView } from "@/components/analytics-page-view";
+import { AnalyticsTrackedLink } from "@/components/analytics-tracked-link";
 import { TryForm } from "@/components/try-form";
 import { TryPanelHeader } from "@/components/try-panel-header";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import {
+  ANALYTICS_EVENTS,
+  buildCtaAnalyticsProperties,
+  buildPageAnalyticsProperties,
+} from "@internal/analytics/events";
 import { SUPPORTED_LANGUAGES_STATIC } from "@internal/dashboard/webhooks";
 import { createLocalizedMetadata, resolveLocaleTranslator } from "@internal/i18n";
 import { HeroOutcomeRotator } from "./components/hero-outcome-rotator";
@@ -18,10 +24,12 @@ type TryFormFieldLayout = "legacy" | "funnel";
 
 export async function LandingSegmentPage({
   locale,
+  pagePath,
   segment,
   tryFormFieldLayout = "legacy",
 }: {
   locale: string;
+  pagePath?: string;
   segment: LandingSegment;
   tryFormFieldLayout?: TryFormFieldLayout;
 }) {
@@ -30,6 +38,7 @@ export async function LandingSegmentPage({
   const hasPreviewConfig =
     Boolean(process.env.NEXT_PUBLIC_WEBHOOKS_API_BASE) && Boolean(process.env.TRY_NOW_TOKEN);
   const supportedLanguages = SUPPORTED_LANGUAGES_STATIC;
+  const resolvedPagePath = pagePath ?? `/${locale}/landing/${segment}`;
   const shouldRotateHeroTitle = segment === "expansion";
   const heroOutcomes = content.hero.rotatorOutcomeKeys.map((outcomeKey) => t(outcomeKey));
   const howSteps = content.how.items.map((item) => ({
@@ -39,6 +48,16 @@ export async function LandingSegmentPage({
 
   return (
     <div className="min-h-screen bg-background">
+      <AnalyticsPageView
+        event={ANALYTICS_EVENTS.marketingPageView}
+        properties={buildPageAnalyticsProperties({
+          locale,
+          pagePath: resolvedPagePath,
+          pageType: "landing",
+          segment,
+          variant: segment === "expansion" ? "expansion" : undefined,
+        })}
+      />
       <section
         id="try"
         className="relative overflow-hidden px-4 py-20 sm:px-6 sm:py-28 lg:px-8 lg:py-32"
@@ -285,13 +304,40 @@ export async function LandingSegmentPage({
               size="lg"
               className={cn("bg-primary hover:bg-primary/90", styles.buttonMicro)}
             >
-              <Link href={`/${locale}#try`}>
+              <AnalyticsTrackedLink
+                analyticsProperties={buildCtaAnalyticsProperties({
+                  ctaId: `landing_${segment}_primary_try`,
+                  locale,
+                  pagePath: resolvedPagePath,
+                  pageType: "landing",
+                  segment,
+                  targetHref: `/${locale}#try`,
+                  variant: segment === "expansion" ? "expansion" : undefined,
+                })}
+                event={ANALYTICS_EVENTS.marketingCtaClicked}
+                href={`/${locale}#try`}
+              >
                 {t(content.cta.primaryKey)}
                 <ArrowRight className="ml-2 h-4 w-4" />
-              </Link>
+              </AnalyticsTrackedLink>
             </Button>
             <Button asChild size="lg" variant="outline">
-              <a href="mailto:contact@weblingo.app">{t(content.cta.secondaryKey)}</a>
+              <AnalyticsTrackedLink
+                analyticsProperties={buildCtaAnalyticsProperties({
+                  ctaId: `landing_${segment}_secondary_contact`,
+                  locale,
+                  pagePath: resolvedPagePath,
+                  pageType: "landing",
+                  segment,
+                  targetHref: "mailto:contact@weblingo.app",
+                  variant: segment === "expansion" ? "expansion" : undefined,
+                })}
+                event={ANALYTICS_EVENTS.marketingCtaClicked}
+                external
+                href="mailto:contact@weblingo.app"
+              >
+                {t(content.cta.secondaryKey)}
+              </AnalyticsTrackedLink>
             </Button>
           </div>
           <div className="mt-6 space-y-2 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

- Why: frontend CI was running the full workflow on every branch push, which duplicated runs and wasted minutes on the same changes.
- What: limit push-triggered runs to `main`, add concurrency cancellation for stale branch/PR runs, and use the Playwright CI image so the workflow no longer spends time on an explicit browser install step.

## Testing

- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml ok"'`
- [ ] `corepack pnpm test`
- [ ] `corepack pnpm check`
- [ ] `corepack pnpm test:contracts`
- [ ] `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check` (required when CI cross-repo token is unavailable)

## Docs sync and capability matrix

- [ ] Updated `docs/backend/DASHBOARD_SPECS.md` if user-facing backend capability coverage changed.
- [ ] Ran `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync` and committed `content/docs/_generated/*` when backend HEAD advanced.
