### PR TITLE
Add showcase regression fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Trust checkout for git-based tests
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Dashboard smoke (mock auth)
         run: corepack pnpm test:e2e:smoke
 
+      - name: Showcase fixture regression smoke
+        run: corepack pnpm test:showcase:fixtures
+
   docs-sync-token-check:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           version: 9.12.0
 
@@ -129,7 +129,7 @@ jobs:
           token: ${{ secrets.CROSS_REPO_CHECKOUT_TOKEN }}
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
         with:
           version: 9.12.0
 

--- a/app/fixtures/showcase/[[...slug]]/route.test.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.test.ts
@@ -157,6 +157,29 @@ describe("showcase fixture pages", () => {
     expect(body).not.toContain(payload);
   });
 
+  it("sanitizes malformed urlencoded marketing form bodies without throwing", async () => {
+    const payload = "%E0%A4%A";
+    const response = await POST(
+      requestFor("/fixtures/showcase/marketing/contact", {
+        method: "POST",
+        body: `email=${payload}`,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+      routeContext(["marketing", "contact"]),
+    );
+
+    const body = await response.text();
+
+    expect(response.status).toBe(400);
+    expectNoStoreFixtureCache(response);
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(response.headers.get("content-security-policy")).toBe(
+      "default-src 'none'; base-uri 'none';",
+    );
+    expect(body).toBe("A valid work email is required.");
+    expect(body).not.toContain(payload);
+  });
+
   it("rejects unsupported marketing form bodies without throwing", async () => {
     const response = await POST(
       requestFor("/fixtures/showcase/marketing/contact", {

--- a/app/fixtures/showcase/[[...slug]]/route.test.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { GET } from "./route";
+import { GET, POST } from "./route";
 
 const BASE_URL = "https://weblingo.app";
 
-function requestFor(path: string): Request {
-  return new Request(`${BASE_URL}${path}`, { method: "GET" });
+function requestFor(path: string, init: RequestInit = { method: "GET" }): Request {
+  return new Request(`${BASE_URL}${path}`, init);
 }
 
 function routeContext(slug?: string[]) {
@@ -35,9 +35,12 @@ describe("showcase fixture pages", () => {
     expect(html).toContain('hreflang="fr"');
     expect(html).toContain('href="./about?tab=story#team"');
     expect(html).toContain('href="/fixtures/showcase/original-only?from=marketing#faq"');
+    expect(html).toContain('rel="preload" as="image"');
+    expect(html).toContain('rel="modulepreload"');
+    expect(html).toContain('data-check="responsive-image"');
     expect(html).toContain('href="/fixtures/showcase/showcase.css?v=20260416"');
     expect(html).toContain('src="/fixtures/showcase/widget.js?v=20260416"');
-    expect(html).toContain('action="/fixtures/showcase/marketing/contact?source=form#thanks"');
+    expect(html).toContain('action="/fixtures/showcase/marketing/contact?source=form"');
   });
 
   it("serves nested docs fixture pages with base-url and source-only sentinels", async () => {
@@ -54,8 +57,21 @@ describe("showcase fixture pages", () => {
     expect(html).toContain('<base href="/fixtures/showcase/docs/"');
     expect(html).toContain('href="./api?topic=keys#authentication"');
     expect(html).toContain('href="../marketing?from=docs"');
+    expect(html).toContain('href="../../showcase/marketing/pricing?from=docs#buy"');
     expect(html).toContain('href="/fixtures/showcase/docs/source-only?from=docs#legacy"');
     expect(html).toContain('href="#authentication"');
+  });
+
+  it("serves the docs root used by base-fragment browser navigation", async () => {
+    const response = await GET(requestFor("/fixtures/showcase/docs"), routeContext(["docs"]));
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("docs");
+    expect(response.headers.get("x-weblingo-showcase-page")).toBe("docs-root");
+    expect(html).toContain("Docs fixture root with anchor target");
+    expect(html).toContain('id="authentication"');
   });
 
   it("serves an app-style fixture with interactive controls", async () => {
@@ -83,6 +99,41 @@ describe("showcase fixture pages", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("x-weblingo-showcase-page")).toBe("marketing-root");
     expect(html).toContain("Translate product pages without losing the buyer path");
+  });
+
+  it("redirects valid marketing form submissions to a stable thank-you fixture", async () => {
+    const response = await POST(
+      requestFor("/fixtures/showcase/marketing/contact?source=form", {
+        method: "POST",
+        body: new URLSearchParams({ email: "buyer@example.com" }),
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+      routeContext(["marketing", "contact"]),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "/fixtures/showcase/marketing/contact/thanks?source=form#thanks",
+    );
+  });
+
+  it("rejects invalid marketing form submissions without rendering user input", async () => {
+    const payload = "<script>alert(1)</script>";
+    const response = await POST(
+      requestFor("/fixtures/showcase/marketing/contact", {
+        method: "POST",
+        body: new URLSearchParams({ email: payload }),
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+      routeContext(["marketing", "contact"]),
+    );
+
+    const body = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(body).toBe("A valid work email is required.");
+    expect(body).not.toContain(payload);
   });
 
   it("returns a sanitized 404 for unknown fixture pages", async () => {

--- a/app/fixtures/showcase/[[...slug]]/route.test.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.test.ts
@@ -32,6 +32,12 @@ describe("showcase fixture pages", () => {
     expect(html).toContain(
       'rel="canonical" href="https://weblingo.app/fixtures/showcase/marketing"',
     );
+    expect(html).toContain(
+      'property="og:url" content="https://weblingo.app/fixtures/showcase/marketing"',
+    );
+    expect(html).toContain(
+      'name="twitter:url" content="https://weblingo.app/fixtures/showcase/marketing"',
+    );
     expect(html).toContain('hreflang="fr"');
     expect(html).toContain('href="./about?tab=story#team"');
     expect(html).toContain('href="/fixtures/showcase/original-only?from=marketing#faq"');
@@ -134,6 +140,26 @@ describe("showcase fixture pages", () => {
     expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
     expect(body).toBe("A valid work email is required.");
     expect(body).not.toContain(payload);
+  });
+
+  it("rejects malformed marketing form bodies without throwing", async () => {
+    const response = await POST(
+      requestFor("/fixtures/showcase/marketing/contact", {
+        method: "POST",
+        body: JSON.stringify({ email: "buyer@example.com" }),
+        headers: { "content-type": "application/json" },
+      }),
+      routeContext(["marketing", "contact"]),
+    );
+
+    const body = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(response.headers.get("content-security-policy")).toBe(
+      "default-src 'none'; base-uri 'none';",
+    );
+    expect(body).toBe("Malformed showcase fixture form.");
   });
 
   it("returns a sanitized 404 for unknown fixture pages", async () => {

--- a/app/fixtures/showcase/[[...slug]]/route.test.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.test.ts
@@ -118,6 +118,7 @@ describe("showcase fixture pages", () => {
     );
 
     expect(response.status).toBe(303);
+    expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("location")).toBe(
       "/fixtures/showcase/marketing/contact/thanks?source=form#thanks",
     );
@@ -137,6 +138,7 @@ describe("showcase fixture pages", () => {
     const body = await response.text();
 
     expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
     expect(body).toBe("A valid work email is required.");
     expect(body).not.toContain(payload);
@@ -155,6 +157,7 @@ describe("showcase fixture pages", () => {
     const body = await response.text();
 
     expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
     expect(response.headers.get("content-security-policy")).toBe(
       "default-src 'none'; base-uri 'none';",

--- a/app/fixtures/showcase/[[...slug]]/route.test.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+const BASE_URL = "https://weblingo.app";
+
+function requestFor(path: string): Request {
+  return new Request(`${BASE_URL}${path}`, { method: "GET" });
+}
+
+function routeContext(slug?: string[]) {
+  return { params: Promise.resolve({ slug }) };
+}
+
+describe("showcase fixture pages", () => {
+  it("serves the marketing fixture with link and asset sentinels", async () => {
+    const response = await GET(
+      requestFor("/fixtures/showcase/marketing"),
+      routeContext(["marketing"]),
+    );
+
+    const html = await response.text();
+    const csp = response.headers.get("content-security-policy") ?? "";
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-weblingo-showcase-fixture")).toBe("1");
+    expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("marketing");
+    expect(response.headers.get("x-weblingo-showcase-page")).toBe("marketing-root");
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).not.toContain("'unsafe-eval'");
+    expect(html).toContain('data-fixture-page="marketing-root"');
+    expect(html).toContain('<base href="/fixtures/showcase/marketing/"');
+    expect(html).toContain(
+      'rel="canonical" href="https://weblingo.app/fixtures/showcase/marketing"',
+    );
+    expect(html).toContain('hreflang="fr"');
+    expect(html).toContain('href="./about?tab=story#team"');
+    expect(html).toContain('href="/fixtures/showcase/original-only?from=marketing#faq"');
+    expect(html).toContain('href="/fixtures/showcase/showcase.css?v=20260416"');
+    expect(html).toContain('src="/fixtures/showcase/widget.js?v=20260416"');
+    expect(html).toContain('action="/fixtures/showcase/marketing/contact?source=form#thanks"');
+  });
+
+  it("serves nested docs fixture pages with base-url and source-only sentinels", async () => {
+    const response = await GET(
+      requestFor("/fixtures/showcase/docs/start"),
+      routeContext(["docs", "start"]),
+    );
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("docs");
+    expect(response.headers.get("x-weblingo-showcase-page")).toBe("docs-start");
+    expect(html).toContain('<base href="/fixtures/showcase/docs/"');
+    expect(html).toContain('href="./api?topic=keys#authentication"');
+    expect(html).toContain('href="../marketing?from=docs"');
+    expect(html).toContain('href="/fixtures/showcase/docs/source-only?from=docs#legacy"');
+    expect(html).toContain('href="#authentication"');
+  });
+
+  it("serves an app-style fixture with interactive controls", async () => {
+    const response = await GET(
+      requestFor("/fixtures/showcase/app/dashboard"),
+      routeContext(["app", "dashboard"]),
+    );
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("app");
+    expect(response.headers.get("x-weblingo-showcase-page")).toBe("app-dashboard");
+    expect(html).toContain("data-fixture-widget");
+    expect(html).toContain("data-fixture-toggle");
+    expect(html).toContain('href="/fixtures/showcase/docs/start?from=dashboard#authentication"');
+    expect(html).toContain('href="/fixtures/showcase/app/source-only?from=dashboard#settings"');
+  });
+
+  it("uses the marketing fixture as the default optional catch-all page", async () => {
+    const response = await GET(requestFor("/fixtures/showcase"), routeContext());
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-weblingo-showcase-page")).toBe("marketing-root");
+    expect(html).toContain("Translate product pages without losing the buyer path");
+  });
+
+  it("returns a sanitized 404 for unknown fixture pages", async () => {
+    const payload = "<img src=x onerror=alert(1)>";
+    const response = await GET(requestFor("/fixtures/showcase/unknown"), routeContext([payload]));
+
+    const body = await response.text();
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-weblingo-showcase-fixture")).toBe("1");
+    expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("unknown");
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(response.headers.get("content-security-policy")).toBe(
+      "default-src 'none'; base-uri 'none';",
+    );
+    expect(body).toBe("Unknown showcase fixture page.");
+    expect(body).not.toContain(payload);
+    expect(body).not.toContain("<img");
+  });
+});

--- a/app/fixtures/showcase/[[...slug]]/route.test.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.test.ts
@@ -41,6 +41,7 @@ describe("showcase fixture pages", () => {
     expect(html).toContain(
       'rel="canonical" href="https://weblingo.app/fixtures/showcase/marketing"',
     );
+    expect(html).toContain('<link rel="icon" href="data:,"');
     expect(html).toContain(
       'property="og:url" content="https://weblingo.app/fixtures/showcase/marketing"',
     );
@@ -71,6 +72,8 @@ describe("showcase fixture pages", () => {
     expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("docs");
     expect(response.headers.get("x-weblingo-showcase-page")).toBe("docs-start");
     expect(html).toContain('<base href="/fixtures/showcase/docs/"');
+    expect(html).toContain('<link rel="icon" href="data:,"');
+    expect(html).not.toContain('rel="preload" as="image"');
     expect(html).toContain('href="./api?topic=keys#authentication"');
     expect(html).toContain('href="../marketing?from=docs"');
     expect(html).toContain('href="../../showcase/marketing/pricing?from=docs#buy"');

--- a/app/fixtures/showcase/[[...slug]]/route.test.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.test.ts
@@ -11,6 +11,14 @@ function routeContext(slug?: string[]) {
   return { params: Promise.resolve({ slug }) };
 }
 
+function expectPublicFixtureCache(response: Response): void {
+  expect(response.headers.get("cache-control")).toBe("public, max-age=60");
+}
+
+function expectNoStoreFixtureCache(response: Response): void {
+  expect(response.headers.get("cache-control")).toBe("no-store");
+}
+
 describe("showcase fixture pages", () => {
   it("serves the marketing fixture with link and asset sentinels", async () => {
     const response = await GET(
@@ -22,6 +30,7 @@ describe("showcase fixture pages", () => {
     const csp = response.headers.get("content-security-policy") ?? "";
 
     expect(response.status).toBe(200);
+    expectPublicFixtureCache(response);
     expect(response.headers.get("x-weblingo-showcase-fixture")).toBe("1");
     expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("marketing");
     expect(response.headers.get("x-weblingo-showcase-page")).toBe("marketing-root");
@@ -58,6 +67,7 @@ describe("showcase fixture pages", () => {
     const html = await response.text();
 
     expect(response.status).toBe(200);
+    expectPublicFixtureCache(response);
     expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("docs");
     expect(response.headers.get("x-weblingo-showcase-page")).toBe("docs-start");
     expect(html).toContain('<base href="/fixtures/showcase/docs/"');
@@ -74,6 +84,7 @@ describe("showcase fixture pages", () => {
     const html = await response.text();
 
     expect(response.status).toBe(200);
+    expectPublicFixtureCache(response);
     expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("docs");
     expect(response.headers.get("x-weblingo-showcase-page")).toBe("docs-root");
     expect(html).toContain("Docs fixture root with anchor target");
@@ -89,6 +100,7 @@ describe("showcase fixture pages", () => {
     const html = await response.text();
 
     expect(response.status).toBe(200);
+    expectPublicFixtureCache(response);
     expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("app");
     expect(response.headers.get("x-weblingo-showcase-page")).toBe("app-dashboard");
     expect(html).toContain("data-fixture-widget");
@@ -103,6 +115,7 @@ describe("showcase fixture pages", () => {
     const html = await response.text();
 
     expect(response.status).toBe(200);
+    expectPublicFixtureCache(response);
     expect(response.headers.get("x-weblingo-showcase-page")).toBe("marketing-root");
     expect(html).toContain("Translate product pages without losing the buyer path");
   });
@@ -118,7 +131,7 @@ describe("showcase fixture pages", () => {
     );
 
     expect(response.status).toBe(303);
-    expect(response.headers.get("cache-control")).toBe("no-store");
+    expectNoStoreFixtureCache(response);
     expect(response.headers.get("location")).toBe(
       "/fixtures/showcase/marketing/contact/thanks?source=form#thanks",
     );
@@ -138,13 +151,13 @@ describe("showcase fixture pages", () => {
     const body = await response.text();
 
     expect(response.status).toBe(400);
-    expect(response.headers.get("cache-control")).toBe("no-store");
+    expectNoStoreFixtureCache(response);
     expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
     expect(body).toBe("A valid work email is required.");
     expect(body).not.toContain(payload);
   });
 
-  it("rejects malformed marketing form bodies without throwing", async () => {
+  it("rejects unsupported marketing form bodies without throwing", async () => {
     const response = await POST(
       requestFor("/fixtures/showcase/marketing/contact", {
         method: "POST",
@@ -157,7 +170,28 @@ describe("showcase fixture pages", () => {
     const body = await response.text();
 
     expect(response.status).toBe(400);
-    expect(response.headers.get("cache-control")).toBe("no-store");
+    expectNoStoreFixtureCache(response);
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(response.headers.get("content-security-policy")).toBe(
+      "default-src 'none'; base-uri 'none';",
+    );
+    expect(body).toBe("Malformed showcase fixture form.");
+  });
+
+  it("rejects malformed multipart marketing form bodies without throwing", async () => {
+    const response = await POST(
+      requestFor("/fixtures/showcase/marketing/contact", {
+        method: "POST",
+        body: "not a multipart body",
+        headers: { "content-type": "multipart/form-data; boundary=fixture-boundary" },
+      }),
+      routeContext(["marketing", "contact"]),
+    );
+
+    const body = await response.text();
+
+    expect(response.status).toBe(400);
+    expectNoStoreFixtureCache(response);
     expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
     expect(response.headers.get("content-security-policy")).toBe(
       "default-src 'none'; base-uri 'none';",
@@ -172,6 +206,7 @@ describe("showcase fixture pages", () => {
     const body = await response.text();
 
     expect(response.status).toBe(404);
+    expectPublicFixtureCache(response);
     expect(response.headers.get("x-weblingo-showcase-fixture")).toBe("1");
     expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("unknown");
     expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");

--- a/app/fixtures/showcase/[[...slug]]/route.test.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.test.ts
@@ -109,6 +109,54 @@ describe("showcase fixture pages", () => {
     expect(html).toContain('href="/fixtures/showcase/app/source-only?from=dashboard#settings"');
   });
 
+  it("serves a root-base fixture with root-resolved relative URLs", async () => {
+    const response = await GET(
+      requestFor("/fixtures/showcase/root-base"),
+      routeContext(["root-base"]),
+    );
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expectPublicFixtureCache(response);
+    expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("root-base");
+    expect(response.headers.get("x-weblingo-showcase-page")).toBe("root-base");
+    expect(html).toContain('<base href="/"');
+    expect(html).toContain(
+      'rel="canonical" href="https://weblingo.app/fixtures/showcase/root-base"',
+    );
+    expect(html).toContain(
+      'property="og:url" content="https://weblingo.app/fixtures/showcase/root-base"',
+    );
+    expect(html).toContain(
+      'name="twitter:url" content="https://weblingo.app/fixtures/showcase/root-base"',
+    );
+    expect(html).toContain('href="fixtures/showcase/marketing/pricing?from=root-base#buy"');
+    expect(html).toContain('href="fixtures/showcase/docs/start?from=root-base#authentication"');
+    expect(html).toContain('href="fixtures/showcase/original-only?from=root-base#faq"');
+    expect(html).toContain('src="fixtures/showcase/logo.svg?v=20260416&root-base=1"');
+  });
+
+  it("serves a multipart marketing form fixture", async () => {
+    const response = await GET(
+      requestFor("/fixtures/showcase/marketing/multipart"),
+      routeContext(["marketing", "multipart"]),
+    );
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expectPublicFixtureCache(response);
+    expect(response.headers.get("x-weblingo-showcase-scenario")).toBe("marketing");
+    expect(response.headers.get("x-weblingo-showcase-page")).toBe("marketing-multipart");
+    expect(html).toContain("Multipart lead form fixture");
+    expect(html).toContain('method="post"');
+    expect(html).toContain('enctype="multipart/form-data"');
+    expect(html).toContain(
+      'action="/fixtures/showcase/marketing/contact-multipart?source=multipart"',
+    );
+  });
+
   it("uses the marketing fixture as the default optional catch-all page", async () => {
     const response = await GET(requestFor("/fixtures/showcase"), routeContext());
 
@@ -135,6 +183,27 @@ describe("showcase fixture pages", () => {
     expect(response.headers.get("location")).toBe(
       "/fixtures/showcase/marketing/contact/thanks?source=form#thanks",
     );
+  });
+
+  it("redirects valid multipart marketing form submissions to a stable thank-you fixture", async () => {
+    const formData = new FormData();
+    formData.set("email", "buyer@example.com");
+    formData.set("company", "WebLingo Fixture Co");
+
+    const response = await POST(
+      requestFor("/fixtures/showcase/marketing/contact-multipart?source=multipart", {
+        method: "POST",
+        body: formData,
+      }),
+      routeContext(["marketing", "contact-multipart"]),
+    );
+
+    expect(response.status).toBe(303);
+    expectNoStoreFixtureCache(response);
+    expect(response.headers.get("location")).toBe(
+      "/fixtures/showcase/marketing/contact/thanks?source=multipart#thanks",
+    );
+    expect(response.headers.get("x-weblingo-showcase-page")).toBe("marketing-contact-multipart");
   });
 
   it("rejects invalid marketing form submissions without rendering user input", async () => {

--- a/app/fixtures/showcase/[[...slug]]/route.test.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.test.ts
@@ -131,6 +131,12 @@ describe("showcase fixture pages", () => {
     expect(html).toContain(
       'name="twitter:url" content="https://weblingo.app/fixtures/showcase/root-base"',
     );
+    expect(html).toContain(
+      'data-check="root-base-relative-stylesheet" rel="stylesheet" href="fixtures/showcase/showcase.css?v=20260416&root-base=1"',
+    );
+    expect(html).toContain(
+      'data-check="root-base-relative-script" defer src="fixtures/showcase/widget.js?v=20260416&root-base=1"',
+    );
     expect(html).toContain('href="fixtures/showcase/marketing/pricing?from=root-base#buy"');
     expect(html).toContain('href="fixtures/showcase/docs/start?from=root-base#authentication"');
     expect(html).toContain('href="fixtures/showcase/original-only?from=root-base#faq"');
@@ -288,6 +294,28 @@ describe("showcase fixture pages", () => {
     expect(response.headers.get("content-security-policy")).toBe(
       "default-src 'none'; base-uri 'none';",
     );
+    expect(body).toBe("Malformed showcase fixture form.");
+  });
+
+  it("rejects malformed multipart bodies on the multipart endpoint without throwing", async () => {
+    const response = await POST(
+      requestFor("/fixtures/showcase/marketing/contact-multipart", {
+        method: "POST",
+        body: "not a multipart body",
+        headers: { "content-type": "multipart/form-data; boundary=fixture-boundary" },
+      }),
+      routeContext(["marketing", "contact-multipart"]),
+    );
+
+    const body = await response.text();
+
+    expect(response.status).toBe(400);
+    expectNoStoreFixtureCache(response);
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(response.headers.get("content-security-policy")).toBe(
+      "default-src 'none'; base-uri 'none';",
+    );
+    expect(response.headers.get("x-weblingo-showcase-page")).toBe("marketing-contact-multipart");
     expect(body).toBe("Malformed showcase fixture form.");
   });
 

--- a/app/fixtures/showcase/[[...slug]]/route.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.ts
@@ -1,5 +1,5 @@
 type FixturePage = {
-  scenario: "marketing" | "docs" | "app";
+  scenario: "marketing" | "docs" | "app" | "root-base";
   pageId: string;
   title: string;
   description: string;
@@ -107,6 +107,30 @@ const PAGES: Record<string, FixturePage> = {
       </section>
     `,
   },
+  "marketing/multipart": {
+    scenario: "marketing",
+    pageId: "marketing-multipart",
+    title: "Showcase Fixture: multipart form",
+    description: "A multipart lead-form fixture used to exercise browser form encoding.",
+    canonicalPath: "/fixtures/showcase/marketing/multipart",
+    heading: "Multipart lead form fixture",
+    bodyHtml: `
+      <section class="fixture-panel" id="multipart">
+        <p>This page submits a browser-generated multipart body to the showcase fixture handler.</p>
+        <form action="/fixtures/showcase/marketing/contact-multipart?source=multipart" method="post" enctype="multipart/form-data" data-check="multipart-lead-form">
+          <label>
+            Work email
+            <input name="email" type="email" value="buyer@example.com" required />
+          </label>
+          <label>
+            Company
+            <input name="company" value="WebLingo Fixture Co" />
+          </label>
+          <button type="submit">Request multipart preview</button>
+        </form>
+      </section>
+    `,
+  },
   "docs/start": {
     scenario: "docs",
     pageId: "docs-start",
@@ -173,6 +197,30 @@ const PAGES: Record<string, FixturePage> = {
         <output data-fixture-output>Drawer closed</output>
         <a data-check="app-docs" href="/fixtures/showcase/docs/start?from=dashboard#authentication">Read setup docs</a>
         <a data-check="app-source-fallback" href="/fixtures/showcase/app/source-only?from=dashboard#settings">Original settings</a>
+      </section>
+    `,
+  },
+  "root-base": {
+    scenario: "root-base",
+    pageId: "root-base",
+    title: "Showcase Fixture: root base",
+    description: "A root-base fixture that proves relative URLs stay inside showcase namespaces.",
+    canonicalPath: "/fixtures/showcase/root-base",
+    baseHref: "/",
+    heading: "Root base showcase links stay in namespace",
+    bodyHtml: `
+      <section class="fixture-panel" id="root-base">
+        <p>This page uses <code>&lt;base href="/"&gt;</code> plus root-base relative URLs.</p>
+        <a data-check="root-base-pricing" href="fixtures/showcase/marketing/pricing?from=root-base#buy">Pricing through root base</a>
+        <a data-check="root-base-docs" href="fixtures/showcase/docs/start?from=root-base#authentication">Docs through root base</a>
+        <a data-check="root-base-source-fallback" href="fixtures/showcase/original-only?from=root-base#faq">Source fallback through root base</a>
+        <img
+          data-check="root-base-relative-image"
+          src="fixtures/showcase/logo.svg?v=${ASSET_VERSION}&root-base=1"
+          width="96"
+          height="96"
+          alt="Root-base relative fixture logo"
+        />
       </section>
     `,
   },
@@ -344,7 +392,12 @@ export async function POST(
   const { slug } = await context.params;
   const normalized = normalizeSlug(slug);
 
-  if (normalized !== "marketing/contact") {
+  const contactPage =
+    normalized === "marketing/contact" || normalized === "marketing/contact-multipart"
+      ? normalized
+      : null;
+
+  if (!contactPage) {
     return new Response("Unknown showcase fixture form.", {
       status: 404,
       headers: {
@@ -372,9 +425,15 @@ export async function POST(
     status: 303,
     headers: {
       ...FORM_RESPONSE_HEADERS,
-      location: "/fixtures/showcase/marketing/contact/thanks?source=form#thanks",
+      location:
+        contactPage === "marketing/contact-multipart"
+          ? "/fixtures/showcase/marketing/contact/thanks?source=multipart#thanks"
+          : "/fixtures/showcase/marketing/contact/thanks?source=form#thanks",
       "x-weblingo-showcase-scenario": "marketing",
-      "x-weblingo-showcase-page": "marketing-contact",
+      "x-weblingo-showcase-page":
+        contactPage === "marketing/contact-multipart"
+          ? "marketing-contact-multipart"
+          : "marketing-contact",
     },
   });
 }

--- a/app/fixtures/showcase/[[...slug]]/route.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.ts
@@ -5,6 +5,7 @@ type FixturePage = {
   description: string;
   canonicalPath: string;
   baseHref?: string;
+  headHtml?: string;
   heading: string;
   bodyHtml: string;
 };
@@ -207,6 +208,9 @@ const PAGES: Record<string, FixturePage> = {
     description: "A root-base fixture that proves relative URLs stay inside showcase namespaces.",
     canonicalPath: "/fixtures/showcase/root-base",
     baseHref: "/",
+    headHtml: `
+    <link data-check="root-base-relative-stylesheet" rel="stylesheet" href="fixtures/showcase/showcase.css?v=${ASSET_VERSION}&root-base=1" />
+    <script data-check="root-base-relative-script" defer src="fixtures/showcase/widget.js?v=${ASSET_VERSION}&root-base=1"></script>`,
     heading: "Root base showcase links stay in namespace",
     bodyHtml: `
       <section class="fixture-panel" id="root-base">
@@ -288,7 +292,7 @@ const FORM_RESPONSE_HEADERS = {
   "cache-control": "no-store",
 };
 
-function formError(message: string): Response {
+function formError(message: string, pageId = "marketing-contact"): Response {
   return new Response(message, {
     status: 400,
     headers: {
@@ -296,7 +300,7 @@ function formError(message: string): Response {
       "content-type": "text/plain; charset=utf-8",
       "content-security-policy": "default-src 'none'; base-uri 'none';",
       "x-weblingo-showcase-scenario": "marketing",
-      "x-weblingo-showcase-page": "marketing-contact",
+      "x-weblingo-showcase-page": pageId,
     },
   });
 }
@@ -343,6 +347,7 @@ ${baseTag}    <title>${escapeHtml(page.title)}</title>
     <link rel="modulepreload" href="/fixtures/showcase/widget.js?v=${ASSET_VERSION}&modulepreload=1" />
     <link rel="stylesheet" href="/fixtures/showcase/showcase.css?v=${ASSET_VERSION}" />
     <script defer src="/fixtures/showcase/widget.js?v=${ASSET_VERSION}"></script>
+${page.headHtml ?? ""}
   </head>
   <body data-fixture-page="${page.pageId}">
     <main class="fixture-shell">
@@ -396,6 +401,10 @@ export async function POST(
     normalized === "marketing/contact" || normalized === "marketing/contact-multipart"
       ? normalized
       : null;
+  const contactPageId =
+    contactPage === "marketing/contact-multipart"
+      ? "marketing-contact-multipart"
+      : "marketing-contact";
 
   if (!contactPage) {
     return new Response("Unknown showcase fixture form.", {
@@ -413,12 +422,12 @@ export async function POST(
   try {
     formData = await request.formData();
   } catch {
-    return formError("Malformed showcase fixture form.");
+    return formError("Malformed showcase fixture form.", contactPageId);
   }
 
   const email = formData.get("email");
   if (typeof email !== "string" || email.trim().length === 0 || !email.includes("@")) {
-    return formError("A valid work email is required.");
+    return formError("A valid work email is required.", contactPageId);
   }
 
   return new Response(null, {
@@ -430,10 +439,7 @@ export async function POST(
           ? "/fixtures/showcase/marketing/contact/thanks?source=multipart#thanks"
           : "/fixtures/showcase/marketing/contact/thanks?source=form#thanks",
       "x-weblingo-showcase-scenario": "marketing",
-      "x-weblingo-showcase-page":
-        contactPage === "marketing/contact-multipart"
-          ? "marketing-contact-multipart"
-          : "marketing-contact",
+      "x-weblingo-showcase-page": contactPageId,
     },
   });
 }

--- a/app/fixtures/showcase/[[...slug]]/route.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.ts
@@ -31,6 +31,7 @@ const PAGES: Record<string, FixturePage> = {
       </section>
       <nav class="fixture-nav" aria-label="Fixture navigation">
         <a data-check="same-page-query" href="?ref=nav#overview">Overview</a>
+        <a data-check="query-only" href="?audience=buyers#overview">Audience query</a>
         <a data-check="relative-sibling" href="./about?tab=story#team">About relative</a>
         <a data-check="parent-relative" href="../docs/start?from=marketing#setup">Docs relative</a>
         <a data-check="source-fallback-root" href="/fixtures/showcase/original-only?from=marketing#faq">Original only</a>
@@ -39,15 +40,42 @@ const PAGES: Record<string, FixturePage> = {
       <article id="overview" class="fixture-panel">
         <h2 data-fixture-accent>Preserve the sales path</h2>
         <p>Buyer journeys need localized canonical tags, stable assets, and translated internal links.</p>
-        <img src="/fixtures/showcase/logo.svg?v=${ASSET_VERSION}" width="96" height="96" alt="WebLingo fixture logo" />
+        <picture data-check="responsive-image" class="fixture-picture">
+          <source
+            media="(min-width: 700px)"
+            srcset="/fixtures/showcase/logo.svg?v=${ASSET_VERSION}&variant=wide 1x"
+          />
+          <img
+            src="/fixtures/showcase/logo.svg?v=${ASSET_VERSION}"
+            srcset="/fixtures/showcase/logo.svg?v=${ASSET_VERSION} 1x, /fixtures/showcase/logo.svg?v=${ASSET_VERSION}&density=2 2x"
+            sizes="96px"
+            width="96"
+            height="96"
+            alt="WebLingo fixture logo"
+          />
+        </picture>
       </article>
-      <form action="/fixtures/showcase/marketing/contact?source=form#thanks" method="post" data-check="lead-form">
+      <form action="/fixtures/showcase/marketing/contact?source=form" method="post" data-check="lead-form">
         <label>
           Work email
-          <input name="email" type="email" value="buyer@example.com" />
+          <input name="email" type="email" value="buyer@example.com" required />
         </label>
         <button type="submit">Request localized preview</button>
       </form>
+    `,
+  },
+  "marketing/contact/thanks": {
+    scenario: "marketing",
+    pageId: "marketing-contact-thanks",
+    title: "Showcase Fixture: lead form submitted",
+    description: "A thank-you page fixture used to prove showcase form actions stay routable.",
+    canonicalPath: "/fixtures/showcase/marketing/contact/thanks",
+    heading: "Preview request received",
+    bodyHtml: `
+      <section class="fixture-panel" id="thanks">
+        <p>The form action kept its query string and landed on a stable showcase route.</p>
+        <a data-check="thanks-back" href="/fixtures/showcase/marketing?from=thanks#overview">Back to overview</a>
+      </section>
     `,
   },
   "marketing/pricing": {
@@ -91,6 +119,7 @@ const PAGES: Record<string, FixturePage> = {
       <aside class="fixture-nav" aria-label="Docs navigation">
         <a data-check="docs-api" href="./api?topic=keys#authentication">API reference</a>
         <a data-check="docs-marketing" href="../marketing?from=docs">Marketing home</a>
+        <a data-check="docs-deep-relative" href="../../showcase/marketing/pricing?from=docs#buy">Pricing from docs</a>
         <a data-check="docs-source-fallback" href="/fixtures/showcase/docs/source-only?from=docs#legacy">Legacy source only</a>
         <a data-check="docs-fragment" href="#authentication">Jump to authentication</a>
       </aside>
@@ -98,6 +127,22 @@ const PAGES: Record<string, FixturePage> = {
         <h2>Authentication references</h2>
         <p>Nested docs paths exercise base URL behavior and section-scoped relative navigation.</p>
         <code>curl https://api.example.test/v1/locales</code>
+      </section>
+    `,
+  },
+  docs: {
+    scenario: "docs",
+    pageId: "docs-root",
+    title: "Showcase Fixture: docs root",
+    description: "A docs root page used to settle base-fragment navigation behavior.",
+    canonicalPath: "/fixtures/showcase/docs",
+    baseHref: "/fixtures/showcase/docs/",
+    heading: "Docs fixture root with anchor target",
+    bodyHtml: `
+      <section class="fixture-panel" id="authentication">
+        <h2>Authentication references</h2>
+        <p>Fragment-only links under the docs base resolve here by browser URL rules.</p>
+        <a data-check="docs-root-start" href="./start?from=root#authentication">Back to docs start</a>
       </section>
     `,
   },
@@ -228,6 +273,8 @@ ${baseTag}    <title>${escapeHtml(page.title)}</title>
     <link rel="alternate" hreflang="x-default" href="${escapeHtml(alternateEnglish)}" />
     <meta property="og:url" content="${escapeHtml(canonicalUrl)}" />
     <meta name="twitter:url" content="${escapeHtml(canonicalUrl)}" />
+    <link rel="preload" as="image" href="/fixtures/showcase/logo.svg?v=${ASSET_VERSION}" />
+    <link rel="modulepreload" href="/fixtures/showcase/widget.js?v=${ASSET_VERSION}&modulepreload=1" />
     <link rel="stylesheet" href="/fixtures/showcase/showcase.css?v=${ASSET_VERSION}" />
     <script defer src="/fixtures/showcase/widget.js?v=${ASSET_VERSION}"></script>
   </head>
@@ -268,6 +315,51 @@ export async function GET(
       "content-security-policy": STRICT_CSP,
       "x-weblingo-showcase-scenario": page.scenario,
       "x-weblingo-showcase-page": page.pageId,
+    },
+  });
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ slug?: string[] }> },
+): Promise<Response> {
+  const { slug } = await context.params;
+  const normalized = normalizeSlug(slug);
+
+  if (normalized !== "marketing/contact") {
+    return new Response("Unknown showcase fixture form.", {
+      status: 404,
+      headers: {
+        ...RESPONSE_HEADERS,
+        "content-type": "text/plain; charset=utf-8",
+        "content-security-policy": "default-src 'none'; base-uri 'none';",
+        "x-weblingo-showcase-scenario": "unknown",
+      },
+    });
+  }
+
+  const formData = await request.formData();
+  const email = formData.get("email");
+  if (typeof email !== "string" || email.trim().length === 0 || !email.includes("@")) {
+    return new Response("A valid work email is required.", {
+      status: 400,
+      headers: {
+        ...RESPONSE_HEADERS,
+        "content-type": "text/plain; charset=utf-8",
+        "content-security-policy": "default-src 'none'; base-uri 'none';",
+        "x-weblingo-showcase-scenario": "marketing",
+        "x-weblingo-showcase-page": "marketing-contact",
+      },
+    });
+  }
+
+  return new Response(null, {
+    status: 303,
+    headers: {
+      ...RESPONSE_HEADERS,
+      location: "/fixtures/showcase/marketing/contact/thanks?source=form#thanks",
+      "x-weblingo-showcase-scenario": "marketing",
+      "x-weblingo-showcase-page": "marketing-contact",
     },
   });
 }

--- a/app/fixtures/showcase/[[...slug]]/route.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.ts
@@ -235,11 +235,16 @@ const RESPONSE_HEADERS = {
   "x-weblingo-showcase-fixture": "1",
 };
 
+const FORM_RESPONSE_HEADERS = {
+  ...RESPONSE_HEADERS,
+  "cache-control": "no-store",
+};
+
 function formError(message: string): Response {
   return new Response(message, {
     status: 400,
     headers: {
-      ...RESPONSE_HEADERS,
+      ...FORM_RESPONSE_HEADERS,
       "content-type": "text/plain; charset=utf-8",
       "content-security-policy": "default-src 'none'; base-uri 'none';",
       "x-weblingo-showcase-scenario": "marketing",
@@ -343,7 +348,7 @@ export async function POST(
     return new Response("Unknown showcase fixture form.", {
       status: 404,
       headers: {
-        ...RESPONSE_HEADERS,
+        ...FORM_RESPONSE_HEADERS,
         "content-type": "text/plain; charset=utf-8",
         "content-security-policy": "default-src 'none'; base-uri 'none';",
         "x-weblingo-showcase-scenario": "unknown",
@@ -366,7 +371,7 @@ export async function POST(
   return new Response(null, {
     status: 303,
     headers: {
-      ...RESPONSE_HEADERS,
+      ...FORM_RESPONSE_HEADERS,
       location: "/fixtures/showcase/marketing/contact/thanks?source=form#thanks",
       "x-weblingo-showcase-scenario": "marketing",
       "x-weblingo-showcase-page": "marketing-contact",

--- a/app/fixtures/showcase/[[...slug]]/route.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.ts
@@ -235,6 +235,19 @@ const RESPONSE_HEADERS = {
   "x-weblingo-showcase-fixture": "1",
 };
 
+function formError(message: string): Response {
+  return new Response(message, {
+    status: 400,
+    headers: {
+      ...RESPONSE_HEADERS,
+      "content-type": "text/plain; charset=utf-8",
+      "content-security-policy": "default-src 'none'; base-uri 'none';",
+      "x-weblingo-showcase-scenario": "marketing",
+      "x-weblingo-showcase-page": "marketing-contact",
+    },
+  });
+}
+
 function normalizeSlug(slug: string[] | undefined): string {
   if (!slug || slug.length === 0) {
     return "marketing";
@@ -338,19 +351,16 @@ export async function POST(
     });
   }
 
-  const formData = await request.formData();
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return formError("Malformed showcase fixture form.");
+  }
+
   const email = formData.get("email");
   if (typeof email !== "string" || email.trim().length === 0 || !email.includes("@")) {
-    return new Response("A valid work email is required.", {
-      status: 400,
-      headers: {
-        ...RESPONSE_HEADERS,
-        "content-type": "text/plain; charset=utf-8",
-        "content-security-policy": "default-src 'none'; base-uri 'none';",
-        "x-weblingo-showcase-scenario": "marketing",
-        "x-weblingo-showcase-page": "marketing-contact",
-      },
-    });
+    return formError("A valid work email is required.");
   }
 
   return new Response(null, {

--- a/app/fixtures/showcase/[[...slug]]/route.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.ts
@@ -1,0 +1,273 @@
+type FixturePage = {
+  scenario: "marketing" | "docs" | "app";
+  pageId: string;
+  title: string;
+  description: string;
+  canonicalPath: string;
+  baseHref?: string;
+  heading: string;
+  bodyHtml: string;
+};
+
+const SOURCE_ORIGIN = "https://weblingo.app";
+const ASSET_VERSION = "20260416";
+const STRICT_CSP =
+  "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; base-uri 'self' https://weblingo.app; object-src 'none'; form-action 'self';";
+
+const PAGES: Record<string, FixturePage> = {
+  marketing: {
+    scenario: "marketing",
+    pageId: "marketing-root",
+    title: "Showcase Fixture: marketing landing",
+    description: "A sales landing page fixture with source-only and translated navigation cases.",
+    canonicalPath: "/fixtures/showcase/marketing",
+    baseHref: "/fixtures/showcase/marketing/",
+    heading: "Translate product pages without losing the buyer path",
+    bodyHtml: `
+      <section class="fixture-hero" data-fixture-section="hero">
+        <p class="fixture-kicker">Showcase marketing fixture</p>
+        <p>Use this page to validate sales-critical links, CSS, metadata, forms, and assets.</p>
+        <a class="fixture-button" data-check="root-internal" href="/fixtures/showcase/marketing/pricing?utm=nav#buy">View pricing</a>
+      </section>
+      <nav class="fixture-nav" aria-label="Fixture navigation">
+        <a data-check="same-page-query" href="?ref=nav#overview">Overview</a>
+        <a data-check="relative-sibling" href="./about?tab=story#team">About relative</a>
+        <a data-check="parent-relative" href="../showcase/docs/start?from=marketing#setup">Docs relative</a>
+        <a data-check="source-fallback-root" href="/fixtures/showcase/original-only?from=marketing#faq">Original only</a>
+        <a data-check="external" href="https://developer.mozilla.org/en-US/">External reference</a>
+      </nav>
+      <article id="overview" class="fixture-panel">
+        <h2 data-fixture-accent>Preserve the sales path</h2>
+        <p>Buyer journeys need localized canonical tags, stable assets, and translated internal links.</p>
+        <img src="/fixtures/showcase/logo.svg?v=${ASSET_VERSION}" width="96" height="96" alt="WebLingo fixture logo" />
+      </article>
+      <form action="/fixtures/showcase/marketing/contact?source=form#thanks" method="post" data-check="lead-form">
+        <label>
+          Work email
+          <input name="email" type="email" value="buyer@example.com" />
+        </label>
+        <button type="submit">Request localized preview</button>
+      </form>
+    `,
+  },
+  "marketing/pricing": {
+    scenario: "marketing",
+    pageId: "marketing-pricing",
+    title: "Showcase Fixture: pricing",
+    description: "A pricing page fixture used to prove deep showcase links remain routable.",
+    canonicalPath: "/fixtures/showcase/marketing/pricing",
+    heading: "Pricing that keeps translated links stable",
+    bodyHtml: `
+      <section class="fixture-panel" id="buy">
+        <p>Pricing fixture for deep navigation, query strings, and fragments.</p>
+        <a data-check="pricing-back" href="/fixtures/showcase/marketing?from=pricing#overview">Back to overview</a>
+        <a data-check="pricing-source-only" href="/fixtures/showcase/pricing-original-only?from=pricing#faq">Original pricing FAQ</a>
+      </section>
+    `,
+  },
+  "marketing/about": {
+    scenario: "marketing",
+    pageId: "marketing-about",
+    title: "Showcase Fixture: about",
+    description: "A relative-link target used by showcase rewriting tests.",
+    canonicalPath: "/fixtures/showcase/marketing/about",
+    heading: "About the localized showcase fixture",
+    bodyHtml: `
+      <section class="fixture-panel" id="team">
+        <p>This about page exists so relative sibling links can be translated into showcase URLs.</p>
+        <a data-check="about-pricing" href="./pricing?from=about#buy">Pricing sibling</a>
+      </section>
+    `,
+  },
+  "docs/start": {
+    scenario: "docs",
+    pageId: "docs-start",
+    title: "Showcase Fixture: docs start",
+    description: "A documentation fixture with nested paths and language-neutral anchors.",
+    canonicalPath: "/fixtures/showcase/docs/start",
+    baseHref: "/fixtures/showcase/docs/",
+    heading: "Set up translated docs without breaking references",
+    bodyHtml: `
+      <aside class="fixture-nav" aria-label="Docs navigation">
+        <a data-check="docs-api" href="./api?topic=keys#authentication">API reference</a>
+        <a data-check="docs-marketing" href="../marketing?from=docs">Marketing home</a>
+        <a data-check="docs-source-fallback" href="/fixtures/showcase/docs/source-only?from=docs#legacy">Legacy source only</a>
+        <a data-check="docs-fragment" href="#authentication">Jump to authentication</a>
+      </aside>
+      <section class="fixture-panel" id="authentication">
+        <h2>Authentication references</h2>
+        <p>Nested docs paths exercise base URL behavior and section-scoped relative navigation.</p>
+        <code>curl https://api.example.test/v1/locales</code>
+      </section>
+    `,
+  },
+  "docs/api": {
+    scenario: "docs",
+    pageId: "docs-api",
+    title: "Showcase Fixture: docs API",
+    description: "A nested documentation page used to verify translated sibling links.",
+    canonicalPath: "/fixtures/showcase/docs/api",
+    heading: "API reference for localized docs",
+    bodyHtml: `
+      <section class="fixture-panel" id="authentication">
+        <p>The API reference target keeps query strings and fragments stable.</p>
+        <a data-check="api-start" href="./start?from=api#authentication">Back to start</a>
+      </section>
+    `,
+  },
+  "app/dashboard": {
+    scenario: "app",
+    pageId: "app-dashboard",
+    title: "Showcase Fixture: app dashboard",
+    description: "An application-style page with controls, media, and root-relative assets.",
+    canonicalPath: "/fixtures/showcase/app/dashboard",
+    heading: "Localized app dashboard controls",
+    bodyHtml: `
+      <section class="fixture-panel fixture-grid" data-fixture-widget>
+        <button type="button" data-fixture-toggle aria-expanded="false">Open usage drawer</button>
+        <output data-fixture-output>Drawer closed</output>
+        <a data-check="app-docs" href="/fixtures/showcase/docs/start?from=dashboard#authentication">Read setup docs</a>
+        <a data-check="app-source-fallback" href="/fixtures/showcase/app/source-only?from=dashboard#settings">Original settings</a>
+      </section>
+    `,
+  },
+  "original-only": {
+    scenario: "marketing",
+    pageId: "source-only",
+    title: "Showcase Fixture: source only",
+    description: "A source-only target that should remain on the source origin when untranslated.",
+    canonicalPath: "/fixtures/showcase/original-only",
+    heading: "Source-only original page",
+    bodyHtml: `
+      <section class="fixture-panel" id="faq">
+        <p>This page exists as a source-origin fallback sentinel.</p>
+      </section>
+    `,
+  },
+  "pricing-original-only": {
+    scenario: "marketing",
+    pageId: "pricing-source-only",
+    title: "Showcase Fixture: pricing source only",
+    description: "A pricing source-only target that should not become a fake showcase page.",
+    canonicalPath: "/fixtures/showcase/pricing-original-only",
+    heading: "Source-only pricing FAQ",
+    bodyHtml: `
+      <section class="fixture-panel" id="faq">
+        <p>This pricing FAQ is a source-origin fallback sentinel.</p>
+      </section>
+    `,
+  },
+  "docs/source-only": {
+    scenario: "docs",
+    pageId: "docs-source-only",
+    title: "Showcase Fixture: docs source only",
+    description: "A docs source-only target for untranslated fallback behavior.",
+    canonicalPath: "/fixtures/showcase/docs/source-only",
+    heading: "Legacy docs source-only page",
+    bodyHtml: `
+      <section class="fixture-panel" id="legacy">
+        <p>This docs page is intentionally safe to leave on the source origin.</p>
+      </section>
+    `,
+  },
+  "app/source-only": {
+    scenario: "app",
+    pageId: "app-source-only",
+    title: "Showcase Fixture: app source only",
+    description: "An app source-only target for untranslated fallback behavior.",
+    canonicalPath: "/fixtures/showcase/app/source-only",
+    heading: "Original app settings",
+    bodyHtml: `
+      <section class="fixture-panel" id="settings">
+        <p>This settings page is a source-origin fallback sentinel.</p>
+      </section>
+    `,
+  },
+};
+
+const RESPONSE_HEADERS = {
+  "cache-control": "public, max-age=60",
+  "x-weblingo-showcase-fixture": "1",
+};
+
+function normalizeSlug(slug: string[] | undefined): string {
+  if (!slug || slug.length === 0) {
+    return "marketing";
+  }
+  return slug
+    .join("/")
+    .replace(/\/+/g, "/")
+    .replace(/^\/|\/$/g, "")
+    .toLowerCase();
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function buildFixtureHtml(page: FixturePage): string {
+  const canonicalUrl = `${SOURCE_ORIGIN}${page.canonicalPath}`;
+  const alternateEnglish = canonicalUrl;
+  const alternateFrench = `${SOURCE_ORIGIN}/fr${page.canonicalPath}`;
+  const baseTag = page.baseHref ? `    <base href="${escapeHtml(page.baseHref)}" />\n` : "";
+
+  return `<!doctype html>
+<html lang="en" data-weblingo-showcase-fixture="${page.scenario}">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+${baseTag}    <title>${escapeHtml(page.title)}</title>
+    <meta name="description" content="${escapeHtml(page.description)}" />
+    <link rel="canonical" href="${escapeHtml(canonicalUrl)}" />
+    <link rel="alternate" hreflang="en" href="${escapeHtml(alternateEnglish)}" />
+    <link rel="alternate" hreflang="fr" href="${escapeHtml(alternateFrench)}" />
+    <link rel="alternate" hreflang="x-default" href="${escapeHtml(alternateEnglish)}" />
+    <meta property="og:url" content="${escapeHtml(canonicalUrl)}" />
+    <meta name="twitter:url" content="${escapeHtml(canonicalUrl)}" />
+    <link rel="stylesheet" href="/fixtures/showcase/showcase.css?v=${ASSET_VERSION}" />
+    <script defer src="/fixtures/showcase/widget.js?v=${ASSET_VERSION}"></script>
+  </head>
+  <body data-fixture-page="${page.pageId}">
+    <main class="fixture-shell">
+      <h1>${escapeHtml(page.heading)}</h1>
+      ${page.bodyHtml}
+    </main>
+  </body>
+</html>`;
+}
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ slug?: string[] }> },
+): Promise<Response> {
+  const { slug } = await context.params;
+  const normalized = normalizeSlug(slug);
+  const page = PAGES[normalized];
+
+  if (!page) {
+    return new Response("Unknown showcase fixture page.", {
+      status: 404,
+      headers: {
+        ...RESPONSE_HEADERS,
+        "content-type": "text/plain; charset=utf-8",
+        "content-security-policy": "default-src 'none'; base-uri 'none';",
+        "x-weblingo-showcase-scenario": "unknown",
+      },
+    });
+  }
+
+  return new Response(buildFixtureHtml(page), {
+    status: 200,
+    headers: {
+      ...RESPONSE_HEADERS,
+      "content-type": "text/html; charset=utf-8",
+      "content-security-policy": STRICT_CSP,
+      "x-weblingo-showcase-scenario": page.scenario,
+      "x-weblingo-showcase-page": page.pageId,
+    },
+  });
+}

--- a/app/fixtures/showcase/[[...slug]]/route.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.ts
@@ -23,6 +23,7 @@ const PAGES: Record<string, FixturePage> = {
     description: "A sales landing page fixture with source-only and translated navigation cases.",
     canonicalPath: "/fixtures/showcase/marketing",
     baseHref: "/fixtures/showcase/marketing/",
+    headHtml: `    <link rel="preload" as="image" href="/fixtures/showcase/logo.svg?v=${ASSET_VERSION}" />`,
     heading: "Translate product pages without losing the buyer path",
     bodyHtml: `
       <section class="fixture-hero" data-fixture-section="hero">
@@ -336,6 +337,7 @@ function buildFixtureHtml(page: FixturePage): string {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 ${baseTag}    <title>${escapeHtml(page.title)}</title>
+    <link rel="icon" href="data:," />
     <meta name="description" content="${escapeHtml(page.description)}" />
     <link rel="canonical" href="${escapeHtml(canonicalUrl)}" />
     <link rel="alternate" hreflang="en" href="${escapeHtml(alternateEnglish)}" />
@@ -343,7 +345,6 @@ ${baseTag}    <title>${escapeHtml(page.title)}</title>
     <link rel="alternate" hreflang="x-default" href="${escapeHtml(alternateEnglish)}" />
     <meta property="og:url" content="${escapeHtml(canonicalUrl)}" />
     <meta name="twitter:url" content="${escapeHtml(canonicalUrl)}" />
-    <link rel="preload" as="image" href="/fixtures/showcase/logo.svg?v=${ASSET_VERSION}" />
     <link rel="modulepreload" href="/fixtures/showcase/widget.js?v=${ASSET_VERSION}&modulepreload=1" />
     <link rel="stylesheet" href="/fixtures/showcase/showcase.css?v=${ASSET_VERSION}" />
     <script defer src="/fixtures/showcase/widget.js?v=${ASSET_VERSION}"></script>

--- a/app/fixtures/showcase/[[...slug]]/route.ts
+++ b/app/fixtures/showcase/[[...slug]]/route.ts
@@ -32,7 +32,7 @@ const PAGES: Record<string, FixturePage> = {
       <nav class="fixture-nav" aria-label="Fixture navigation">
         <a data-check="same-page-query" href="?ref=nav#overview">Overview</a>
         <a data-check="relative-sibling" href="./about?tab=story#team">About relative</a>
-        <a data-check="parent-relative" href="../showcase/docs/start?from=marketing#setup">Docs relative</a>
+        <a data-check="parent-relative" href="../docs/start?from=marketing#setup">Docs relative</a>
         <a data-check="source-fallback-root" href="/fixtures/showcase/original-only?from=marketing#faq">Original only</a>
         <a data-check="external" href="https://developer.mozilla.org/en-US/">External reference</a>
       </nav>

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -1867,6 +1867,15 @@
               }
             ]
           },
+          "urlMode": {
+            "default": "original",
+            "description": "Default: original",
+            "enum": [
+              "original",
+              "translated"
+            ],
+            "type": "string"
+          },
           "webhookSecret": {
             "type": [
               "string",
@@ -4201,8 +4210,9 @@
                     "type": "string"
                   },
                   "retryAfterSeconds": {
+                    "minimum": 0,
                     "type": [
-                      "number",
+                      "integer",
                       "null"
                     ]
                   }
@@ -4539,6 +4549,15 @@
                 "type": "null"
               }
             ]
+          },
+          "urlMode": {
+            "default": "original",
+            "description": "Default: original",
+            "enum": [
+              "original",
+              "translated"
+            ],
+            "type": "string"
           }
         },
         "required": [
@@ -5979,6 +5998,14 @@
                 "type": "null"
               }
             ]
+          },
+          "urlMode": {
+            "description": "Optional on PATCH. If omitted, the existing value is preserved. Allowed values: original or translated.",
+            "enum": [
+              "original",
+              "translated"
+            ],
+            "type": "string"
           },
           "webhookSecret": {
             "type": [

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-16T22:36:34+09:00",
+  "generatedAt": "2026-04-16T22:46:34+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
@@ -32,7 +32,7 @@
       "sha256": "10c803d62ecd517c2bba6af7ad3fb69183388620e7037509f2c70b31411bd133"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-16T22:36:34+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-16T22:46:34+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "ec75c34ffbc3ffdba3fbaa3729e5d5f90600a7df"
+  "sourceRepoSha": "5daf9b8c2e8cce4e93be979ebbc100cbbd3caebb"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-04-11T22:51:42+09:00",
+  "generatedAt": "2026-04-16T22:19:08+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
       "sha256": "ae709eeb6bb93559601e672fd883bf40cf01050b5ab66c2c96eb5b7a90b2e471"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 340943,
-      "sha256": "7ae6fa9ce78d3f035d7775f76ca62889b5ec3c3afc961549ad5c1c11999af04a"
+      "bytes": 341743,
+      "sha256": "2b5c52aa10d3ca4be4ee8fa9bf3077b235953a271f89f844c3f935de76969598"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
       "bytes": 7095,
@@ -28,11 +28,11 @@
       "sha256": "0fe451fc26f0964c79ba679a0432cd8eaa132cc56132606d7493ccbced996571"
     },
     "docs/reference/openapi.json": {
-      "bytes": 267937,
-      "sha256": "2eb6afff14b14de3c4dd8ed172e9de4232f19975390893f01b5255f9249a7e10"
+      "bytes": 268591,
+      "sha256": "10c803d62ecd517c2bba6af7ad3fb69183388620e7037509f2c70b31411bd133"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-11T22:51:42+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-16T22:19:08+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "388131bc49d4d4dde34ee3bb521754a3c78887b3"
+  "sourceRepoSha": "83d3b13bdb2078071165dd94dad4853e4e83c18e"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-16T22:46:34+09:00",
+  "generatedAt": "2026-04-16T22:51:26+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
@@ -32,7 +32,7 @@
       "sha256": "10c803d62ecd517c2bba6af7ad3fb69183388620e7037509f2c70b31411bd133"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-16T22:46:34+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-16T22:51:26+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "5daf9b8c2e8cce4e93be979ebbc100cbbd3caebb"
+  "sourceRepoSha": "c799f2790991c24ffc8a47fd64778c404d31fe77"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-16T22:51:26+09:00",
+  "generatedAt": "2026-04-16T23:06:56+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
@@ -32,7 +32,7 @@
       "sha256": "10c803d62ecd517c2bba6af7ad3fb69183388620e7037509f2c70b31411bd133"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-16T22:51:26+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-16T23:06:56+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "c799f2790991c24ffc8a47fd64778c404d31fe77"
+  "sourceRepoSha": "f3c2131cd3cfb86056a08d5517e1cf7a59f686f8"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-16T22:19:08+09:00",
+  "generatedAt": "2026-04-16T22:23:35+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
@@ -32,7 +32,7 @@
       "sha256": "10c803d62ecd517c2bba6af7ad3fb69183388620e7037509f2c70b31411bd133"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-16T22:19:08+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-16T22:23:35+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "83d3b13bdb2078071165dd94dad4853e4e83c18e"
+  "sourceRepoSha": "3051611f94117e218610ece5c6f9e9ecf269450e"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-16T22:23:35+09:00",
+  "generatedAt": "2026-04-16T22:36:34+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
@@ -32,7 +32,7 @@
       "sha256": "10c803d62ecd517c2bba6af7ad3fb69183388620e7037509f2c70b31411bd133"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-16T22:23:35+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-16T22:36:34+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "3051611f94117e218610ece5c6f9e9ecf269450e"
+  "sourceRepoSha": "ec75c34ffbc3ffdba3fbaa3729e5d5f90600a7df"
 }

--- a/docs/SHOWCASE_FIXTURES.md
+++ b/docs/SHOWCASE_FIXTURES.md
@@ -32,9 +32,9 @@ The `/fixtures/showcase/*` routes are deterministic source pages for WebLingo sh
 
 ## Backend Live Suite
 
-The backend live suite is `corepack pnpm test:playwright:showcase:live` in the `weblingo` repo. It runs only when configured with live showcase URLs.
+The backend live suite is `corepack pnpm test:playwright:showcase:live` in the `weblingo` repo. It is the release-gate command and fails when no live showcase URLs are configured.
 
-For release gates, use `corepack pnpm test:playwright:showcase:live:required` in the backend repo or set `PLAYWRIGHT_LIVE_SHOWCASE_REQUIRED=1`. That turns a missing live fixture configuration into a hard failure instead of a skip.
+For local smoke runs that may skip when live credentials are absent, use `corepack pnpm test:playwright:showcase:live:optional`. `corepack pnpm test:playwright:showcase:live:required` remains as an explicit alias for the required release behavior.
 
 Minimal single-fixture example:
 
@@ -113,4 +113,4 @@ The website repo runs the source fixture browser suite in CI:
 corepack pnpm test:showcase:fixtures
 ```
 
-That Playwright suite submits the marketing form, clicks representative internal/source-only links, checks responsive/preloaded assets, verifies docs base-fragment behavior, and fails on any `/fixtures/showcase/*` response or request failure.
+That Playwright suite submits the marketing form, clicks representative internal/source-only links, checks responsive/preloaded assets, verifies docs base-fragment behavior, asserts canonical/OG/Twitter URL metadata, checks that the external reference remains external without loading it, rejects malformed form bodies, and fails on any unexpected browser request graph entry, including successful off-fixture requests.

--- a/docs/SHOWCASE_FIXTURES.md
+++ b/docs/SHOWCASE_FIXTURES.md
@@ -6,15 +6,21 @@ The `/fixtures/showcase/*` routes are deterministic source pages for WebLingo sh
 
 - `/fixtures/showcase/marketing`
   - Sales landing page.
-  - Includes a `<base>` tag, canonical and hreflang tags, root-relative CSS/JS/image assets, same-page query links, relative links, a form action, an external link, and a source-only fallback link.
+  - Includes a `<base>` tag, canonical and hreflang tags, root-relative CSS/JS/image assets, preload/modulepreload tags, responsive images, same-page query links, query-only links, relative links, a real form action, an external link, and a source-only fallback link.
 - `/fixtures/showcase/marketing/pricing`
   - Deep internal sales page.
   - Keeps query-string and fragment behavior covered.
 - `/fixtures/showcase/marketing/about`
   - Relative sibling target for link rewriting checks.
+- `/fixtures/showcase/marketing/contact/thanks`
+  - Form submission target.
+  - The route handler redirects valid marketing form submissions here with the source query string and final `#thanks` fragment preserved. The form action itself deliberately omits the fragment so strict `form-action 'self'` CSP remains browser-compatible.
 - `/fixtures/showcase/docs/start`
   - Nested documentation page.
-  - Covers section anchors, parent-relative links, and a source-only docs fallback.
+  - Covers section anchors, parent-relative links, deep `../..` relative links, and a source-only docs fallback.
+- `/fixtures/showcase/docs`
+  - Docs root page.
+  - Exists so `<base href="/fixtures/showcase/docs/">` plus `href="#authentication"` follows browser URL semantics to a routable page instead of a 404. Next.js then canonicalizes the final browser URL to `/fixtures/showcase/docs#authentication`.
 - `/fixtures/showcase/docs/api`
   - Nested docs sibling target.
 - `/fixtures/showcase/app/dashboard`
@@ -28,6 +34,8 @@ The `/fixtures/showcase/*` routes are deterministic source pages for WebLingo sh
 
 The backend live suite is `corepack pnpm test:playwright:showcase:live` in the `weblingo` repo. It runs only when configured with live showcase URLs.
 
+For release gates, use `corepack pnpm test:playwright:showcase:live:required` in the backend repo or set `PLAYWRIGHT_LIVE_SHOWCASE_REQUIRED=1`. That turns a missing live fixture configuration into a hard failure instead of a skip.
+
 Minimal single-fixture example:
 
 ```sh
@@ -37,7 +45,72 @@ PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_TEXT="Translate product pages without losing t
 PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_INTERNAL_HREF="https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/marketing/pricing?utm=nav#buy" \
 PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_SOURCE_FALLBACK_HREF="https://weblingo.app/fixtures/showcase/original-only?from=marketing#faq" \
 PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_DEPLOYMENT_ID="deployment-id-from-publish" \
+PLAYWRIGHT_LIVE_SHOWCASE_REQUIRED=1 \
 corepack pnpm test:playwright:showcase:live
 ```
 
-For multiple live showcase scenarios, set `PLAYWRIGHT_LIVE_SHOWCASE_MATRIX` to a JSON array with `pageUrl`, `sourceOrigin`, expected text, internal links, source fallback links, optional `expectedDeploymentId`, optional `allowedAssetOrigins`, optional control-plane config, and optional log-health config.
+For multiple live showcase scenarios, set `PLAYWRIGHT_LIVE_SHOWCASE_MATRIX` to a JSON array with `pageUrl`, `sourceOrigin`, expected text, internal links, source fallback links, `expectedDeploymentId`, optional `allowedAssetOrigins`, optional control-plane config, and optional log-health config.
+
+Same-origin showcase assets are expected to include the configured deployment header by default. Use `expectedAssetDeploymentHeaders: false` only when a fixture intentionally validates source-origin/live assets instead of deployment-scoped immutable snapshots.
+
+Matrix example:
+
+```json
+[
+  {
+    "name": "marketing",
+    "pageUrl": "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/marketing",
+    "sourceOrigin": "https://weblingo.app",
+    "expectedText": ["Translate product pages without losing the buyer path"],
+    "expectedInternalHrefs": [
+      "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/marketing/pricing?utm=nav#buy",
+      "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/docs/start?from=marketing#setup"
+    ],
+    "expectedSourceFallbackHrefs": [
+      "https://weblingo.app/fixtures/showcase/original-only?from=marketing#faq"
+    ],
+    "expectedAssetUrls": [
+      "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/showcase.css?v=20260416",
+      "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/widget.js?v=20260416"
+    ],
+    "expectedDeploymentId": "deployment-id-from-publish"
+  },
+  {
+    "name": "docs",
+    "pageUrl": "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/docs/start",
+    "sourceOrigin": "https://weblingo.app",
+    "expectedText": ["Set up translated docs without breaking references"],
+    "expectedInternalHrefs": [
+      "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/docs/api?topic=keys#authentication",
+      "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/docs/#authentication"
+    ],
+    "expectedSourceFallbackHrefs": [
+      "https://weblingo.app/fixtures/showcase/docs/source-only?from=docs#legacy"
+    ],
+    "expectedDeploymentId": "deployment-id-from-publish"
+  },
+  {
+    "name": "app",
+    "pageUrl": "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/app/dashboard",
+    "sourceOrigin": "https://weblingo.app",
+    "expectedText": ["Localized app dashboard controls"],
+    "expectedInternalHrefs": [
+      "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/docs/start?from=dashboard#authentication"
+    ],
+    "expectedSourceFallbackHrefs": [
+      "https://weblingo.app/fixtures/showcase/app/source-only?from=dashboard#settings"
+    ],
+    "expectedDeploymentId": "deployment-id-from-publish"
+  }
+]
+```
+
+## Website CI Smoke
+
+The website repo runs the source fixture browser suite in CI:
+
+```sh
+corepack pnpm test:showcase:fixtures
+```
+
+That Playwright suite submits the marketing form, clicks representative internal/source-only links, checks responsive/preloaded assets, verifies docs base-fragment behavior, and fails on any `/fixtures/showcase/*` response or request failure.

--- a/docs/SHOWCASE_FIXTURES.md
+++ b/docs/SHOWCASE_FIXTURES.md
@@ -36,7 +36,8 @@ PLAYWRIGHT_LIVE_SHOWCASE_SOURCE_ORIGIN="https://weblingo.app" \
 PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_TEXT="Translate product pages without losing the buyer path" \
 PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_INTERNAL_HREF="https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/marketing/pricing?utm=nav#buy" \
 PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_SOURCE_FALLBACK_HREF="https://weblingo.app/fixtures/showcase/original-only?from=marketing#faq" \
+PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_DEPLOYMENT_ID="deployment-id-from-publish" \
 corepack pnpm test:playwright:showcase:live
 ```
 
-For multiple live showcase scenarios, set `PLAYWRIGHT_LIVE_SHOWCASE_MATRIX` to a JSON array with `pageUrl`, `sourceOrigin`, expected text, internal links, source fallback links, optional control-plane config, and optional log-health config.
+For multiple live showcase scenarios, set `PLAYWRIGHT_LIVE_SHOWCASE_MATRIX` to a JSON array with `pageUrl`, `sourceOrigin`, expected text, internal links, source fallback links, optional `expectedDeploymentId`, optional `allowedAssetOrigins`, optional control-plane config, and optional log-health config.

--- a/docs/SHOWCASE_FIXTURES.md
+++ b/docs/SHOWCASE_FIXTURES.md
@@ -12,9 +12,15 @@ The `/fixtures/showcase/*` routes are deterministic source pages for WebLingo sh
   - Keeps query-string and fragment behavior covered.
 - `/fixtures/showcase/marketing/about`
   - Relative sibling target for link rewriting checks.
+- `/fixtures/showcase/marketing/multipart`
+  - Browser multipart form fixture.
+  - Submits `enctype="multipart/form-data"` to `/fixtures/showcase/marketing/contact-multipart` and redirects to the same thank-you page with `source=multipart`.
 - `/fixtures/showcase/marketing/contact/thanks`
   - Form submission target.
   - The route handler redirects valid marketing form submissions here with the source query string and final `#thanks` fragment preserved. The form action itself deliberately omits the fragment so strict `form-action 'self'` CSP remains browser-compatible.
+- `/fixtures/showcase/root-base`
+  - Root-base fixture with `<base href="/">`.
+  - Uses base-relative links and image assets such as `fixtures/showcase/...` so deployed showcase tests can catch trailing-slash namespace regressions on untouched browser-relative URLs.
 - `/fixtures/showcase/docs/start`
   - Nested documentation page.
   - Covers section anchors, parent-relative links, deep `../..` relative links, and a source-only docs fallback.
@@ -94,6 +100,23 @@ Matrix example:
     "expectedDeploymentId": "deployment-id-from-publish"
   },
   {
+    "name": "root-base",
+    "pageUrl": "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/root-base",
+    "sourceOrigin": "https://weblingo.app",
+    "expectedText": ["Root base showcase links stay in namespace"],
+    "expectedInternalHrefs": [
+      "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/marketing/pricing?from=root-base#buy",
+      "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/docs/start?from=root-base#authentication"
+    ],
+    "expectedSourceFallbackHrefs": [
+      "https://weblingo.app/fixtures/showcase/original-only?from=root-base#faq"
+    ],
+    "expectedAssetUrls": [
+      "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/logo.svg?v=20260416&root-base=1"
+    ],
+    "expectedDeploymentId": "deployment-id-from-publish"
+  },
+  {
     "name": "app",
     "pageUrl": "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/app/dashboard",
     "sourceOrigin": "https://weblingo.app",
@@ -117,7 +140,7 @@ The website repo runs the source fixture browser suite in CI:
 corepack pnpm test:showcase:fixtures
 ```
 
-That Playwright suite submits the marketing form, clicks representative internal/source-only links, checks responsive/preloaded assets, verifies docs base-fragment behavior, asserts canonical/OG/Twitter URL metadata, checks page and static fixture asset cache headers, confirms the external reference does not prefetch and then clicks it through a local route interception, rejects malformed form bodies, and fails on any unexpected browser request graph entry, including successful off-fixture requests.
+That Playwright suite submits urlencoded and multipart marketing forms, clicks representative internal/source-only links, checks responsive/preloaded/root-base assets, verifies docs base-fragment and root-base behavior, asserts canonical/OG/Twitter URL metadata, checks page and static fixture asset cache headers, confirms the external reference does not prefetch and then clicks it through a local route interception, rejects malformed form bodies, and fails on any unexpected browser request graph entry, including successful off-fixture requests.
 
 For a production-server smoke of the same fixture suite, run:
 

--- a/docs/SHOWCASE_FIXTURES.md
+++ b/docs/SHOWCASE_FIXTURES.md
@@ -44,12 +44,13 @@ PLAYWRIGHT_LIVE_SHOWCASE_SOURCE_ORIGIN="https://weblingo.app" \
 PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_TEXT="Translate product pages without losing the buyer path" \
 PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_INTERNAL_HREF="https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/marketing/pricing?utm=nav#buy" \
 PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_SOURCE_FALLBACK_HREF="https://weblingo.app/fixtures/showcase/original-only?from=marketing#faq" \
+PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_FORM_ACTION="https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/marketing/contact?source=form" \
 PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_DEPLOYMENT_ID="deployment-id-from-publish" \
 PLAYWRIGHT_LIVE_SHOWCASE_REQUIRED=1 \
 corepack pnpm test:playwright:showcase:live
 ```
 
-For multiple live showcase scenarios, set `PLAYWRIGHT_LIVE_SHOWCASE_MATRIX` to a JSON array with `pageUrl`, `sourceOrigin`, expected text, internal links, source fallback links, `expectedDeploymentId`, optional `allowedAssetOrigins`, optional control-plane config, and optional log-health config.
+For multiple live showcase scenarios, set `PLAYWRIGHT_LIVE_SHOWCASE_MATRIX` to a JSON array with `pageUrl`, `sourceOrigin`, expected text, internal links, source fallback links, expected form actions, `expectedDeploymentId`, optional `allowedAssetOrigins`, optional control-plane config, and optional log-health config.
 
 Same-origin showcase assets are expected to include the configured deployment header by default. Use `expectedAssetDeploymentHeaders: false` only when a fixture intentionally validates source-origin/live assets instead of deployment-scoped immutable snapshots.
 
@@ -68,6 +69,9 @@ Matrix example:
     ],
     "expectedSourceFallbackHrefs": [
       "https://weblingo.app/fixtures/showcase/original-only?from=marketing#faq"
+    ],
+    "expectedFormActions": [
+      "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/marketing/contact?source=form"
     ],
     "expectedAssetUrls": [
       "https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/showcase.css?v=20260416",
@@ -113,4 +117,12 @@ The website repo runs the source fixture browser suite in CI:
 corepack pnpm test:showcase:fixtures
 ```
 
-That Playwright suite submits the marketing form, clicks representative internal/source-only links, checks responsive/preloaded assets, verifies docs base-fragment behavior, asserts canonical/OG/Twitter URL metadata, checks that the external reference remains external without loading it, rejects malformed form bodies, and fails on any unexpected browser request graph entry, including successful off-fixture requests.
+That Playwright suite submits the marketing form, clicks representative internal/source-only links, checks responsive/preloaded assets, verifies docs base-fragment behavior, asserts canonical/OG/Twitter URL metadata, checks page cache headers, checks that the external reference remains external without loading it, rejects malformed form bodies, and fails on any unexpected browser request graph entry, including successful off-fixture requests.
+
+For a production-server smoke of the same fixture suite, run:
+
+```sh
+corepack pnpm test:showcase:fixtures:production
+```
+
+That command builds the Next.js app and runs the fixture suite against `next start`. It complements the source fixture smoke; the backend deployed live showcase gate is still the coverage that validates translated showcase serving and immutable deployment assets.

--- a/docs/SHOWCASE_FIXTURES.md
+++ b/docs/SHOWCASE_FIXTURES.md
@@ -1,0 +1,42 @@
+# Showcase Regression Fixtures
+
+The `/fixtures/showcase/*` routes are deterministic source pages for WebLingo showcase regression tests. They are intentionally plain route-handler HTML so the backend crawler, renderer, publisher, and showcase serve path see stable markup.
+
+## Fixture Paths
+
+- `/fixtures/showcase/marketing`
+  - Sales landing page.
+  - Includes a `<base>` tag, canonical and hreflang tags, root-relative CSS/JS/image assets, same-page query links, relative links, a form action, an external link, and a source-only fallback link.
+- `/fixtures/showcase/marketing/pricing`
+  - Deep internal sales page.
+  - Keeps query-string and fragment behavior covered.
+- `/fixtures/showcase/marketing/about`
+  - Relative sibling target for link rewriting checks.
+- `/fixtures/showcase/docs/start`
+  - Nested documentation page.
+  - Covers section anchors, parent-relative links, and a source-only docs fallback.
+- `/fixtures/showcase/docs/api`
+  - Nested docs sibling target.
+- `/fixtures/showcase/app/dashboard`
+  - Application-style page with non-eval JavaScript interactivity.
+- `/fixtures/showcase/original-only`
+  - Source-only fallback sentinel. Use it as an untranslated target in live showcase matrices.
+- `/fixtures/showcase/pricing-original-only`, `/fixtures/showcase/docs/source-only`, and `/fixtures/showcase/app/source-only`
+  - Additional source-only sentinels for sales, docs, and app-style flows.
+
+## Backend Live Suite
+
+The backend live suite is `corepack pnpm test:playwright:showcase:live` in the `weblingo` repo. It runs only when configured with live showcase URLs.
+
+Minimal single-fixture example:
+
+```sh
+PLAYWRIGHT_LIVE_SHOWCASE_URL="https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/marketing" \
+PLAYWRIGHT_LIVE_SHOWCASE_SOURCE_ORIGIN="https://weblingo.app" \
+PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_TEXT="Translate product pages without losing the buyer path" \
+PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_INTERNAL_HREF="https://t2.weblingo.app/weblingo.app/en/fixtures/showcase/marketing/pricing?utm=nav#buy" \
+PLAYWRIGHT_LIVE_SHOWCASE_EXPECTED_SOURCE_FALLBACK_HREF="https://weblingo.app/fixtures/showcase/original-only?from=marketing#faq" \
+corepack pnpm test:playwright:showcase:live
+```
+
+For multiple live showcase scenarios, set `PLAYWRIGHT_LIVE_SHOWCASE_MATRIX` to a JSON array with `pageUrl`, `sourceOrigin`, expected text, internal links, source fallback links, optional control-plane config, and optional log-health config.

--- a/docs/SHOWCASE_FIXTURES.md
+++ b/docs/SHOWCASE_FIXTURES.md
@@ -14,13 +14,13 @@ The `/fixtures/showcase/*` routes are deterministic source pages for WebLingo sh
   - Relative sibling target for link rewriting checks.
 - `/fixtures/showcase/marketing/multipart`
   - Browser multipart form fixture.
-  - Submits `enctype="multipart/form-data"` to `/fixtures/showcase/marketing/contact-multipart` and redirects to the same thank-you page with `source=multipart`.
+  - Submits `enctype="multipart/form-data"` to `/fixtures/showcase/marketing/contact-multipart`, asserts the browser sends a `multipart/form-data; boundary=...` request, and redirects to the same thank-you page with `source=multipart`.
 - `/fixtures/showcase/marketing/contact/thanks`
   - Form submission target.
   - The route handler redirects valid marketing form submissions here with the source query string and final `#thanks` fragment preserved. The form action itself deliberately omits the fragment so strict `form-action 'self'` CSP remains browser-compatible.
 - `/fixtures/showcase/root-base`
   - Root-base fixture with `<base href="/">`.
-  - Uses base-relative links and image assets such as `fixtures/showcase/...` so deployed showcase tests can catch trailing-slash namespace regressions on untouched browser-relative URLs.
+  - Uses base-relative links, stylesheet, script, and image assets such as `fixtures/showcase/...` so deployed showcase tests can catch trailing-slash namespace regressions on untouched browser-relative URLs.
 - `/fixtures/showcase/docs/start`
   - Nested documentation page.
   - Covers section anchors, parent-relative links, deep `../..` relative links, and a source-only docs fallback.
@@ -140,7 +140,7 @@ The website repo runs the source fixture browser suite in CI:
 corepack pnpm test:showcase:fixtures
 ```
 
-That Playwright suite submits urlencoded and multipart marketing forms, clicks representative internal/source-only links, checks responsive/preloaded/root-base assets, verifies docs base-fragment and root-base behavior, asserts canonical/OG/Twitter URL metadata, checks page and static fixture asset cache headers, confirms the external reference does not prefetch and then clicks it through a local route interception, rejects malformed form bodies, and fails on any unexpected browser request graph entry, including successful off-fixture requests.
+That Playwright suite submits urlencoded and multipart marketing forms, asserts multipart requests are sent with browser-generated boundaries, clicks representative internal/source-only links, checks responsive/preloaded/root-base CSS/JS/image assets, verifies docs base-fragment and root-base behavior, asserts canonical/OG/Twitter URL metadata, checks page and static fixture asset cache headers, confirms the external reference does not prefetch and then clicks it through a local route interception, rejects malformed form bodies on both form endpoints, and fails on any unexpected browser request graph entry, including successful off-fixture requests.
 
 For a production-server smoke of the same fixture suite, run:
 

--- a/docs/SHOWCASE_FIXTURES.md
+++ b/docs/SHOWCASE_FIXTURES.md
@@ -117,7 +117,7 @@ The website repo runs the source fixture browser suite in CI:
 corepack pnpm test:showcase:fixtures
 ```
 
-That Playwright suite submits the marketing form, clicks representative internal/source-only links, checks responsive/preloaded assets, verifies docs base-fragment behavior, asserts canonical/OG/Twitter URL metadata, checks page cache headers, checks that the external reference remains external without loading it, rejects malformed form bodies, and fails on any unexpected browser request graph entry, including successful off-fixture requests.
+That Playwright suite submits the marketing form, clicks representative internal/source-only links, checks responsive/preloaded assets, verifies docs base-fragment behavior, asserts canonical/OG/Twitter URL metadata, checks page and static fixture asset cache headers, confirms the external reference does not prefetch and then clicks it through a local route interception, rejects malformed form bodies, and fails on any unexpected browser request graph entry, including successful off-fixture requests.
 
 For a production-server smoke of the same fixture suite, run:
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:e2e": "playwright test",
     "test:e2e:smoke": "CI=1 DASHBOARD_E2E_MOCK=1 playwright test tests/smoke/dashboard.smoke.spec.ts",
     "test:showcase:fixtures": "playwright test tests/showcase-fixtures.spec.ts",
+    "test:showcase:fixtures:production": "pnpm run build && PLAYWRIGHT_BASE_URL=http://127.0.0.1:3001 playwright test --config playwright.production.config.ts tests/showcase-fixtures.spec.ts",
     "docs:sync:tsc": "tsc --pretty false --noEmit false --skipLibCheck true --types node --module commonjs --moduleResolution node --target ES2022 --outDir .tmp/docs-sync scripts/docs-sync-shared.ts scripts/docs-sync-weblingo.ts scripts/docs-sync-check.ts",
     "docs:sync": "pnpm docs:sync:tsc && node .tmp/docs-sync/docs-sync-weblingo.js",
     "docs:sync:check": "pnpm docs:sync:tsc && node .tmp/docs-sync/docs-sync-check.js",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
       "qs": "6.14.2",
       "flatted": "3.4.2",
       "fast-xml-parser": "5.5.10",
+      "protobufjs": "7.5.5",
       "picomatch@2.3.1": "2.3.2",
       "picomatch@4.0.3": "4.0.4",
       "happy-dom": "20.8.9",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:contracts": "vitest run internal/dashboard/webhooks.openapi-contract.test.ts tests/docs/docs-feature-coverage.test.ts tests/docs/docs-env-contract.test.ts",
     "test:e2e": "playwright test",
     "test:e2e:smoke": "CI=1 DASHBOARD_E2E_MOCK=1 playwright test tests/smoke/dashboard.smoke.spec.ts",
+    "test:showcase:fixtures": "playwright test tests/showcase-fixtures.spec.ts",
     "docs:sync:tsc": "tsc --pretty false --noEmit false --skipLibCheck true --types node --module commonjs --moduleResolution node --target ES2022 --outDir .tmp/docs-sync scripts/docs-sync-shared.ts scripts/docs-sync-weblingo.ts scripts/docs-sync-check.ts",
     "docs:sync": "pnpm docs:sync:tsc && node .tmp/docs-sync/docs-sync-weblingo.js",
     "docs:sync:check": "pnpm docs:sync:tsc && node .tmp/docs-sync/docs-sync-check.js",

--- a/playwright.production.config.ts
+++ b/playwright.production.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "@playwright/test";
+
+const port = process.env.PLAYWRIGHT_PRODUCTION_PORT ?? "3001";
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: /showcase-fixtures\.spec\.ts/,
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  webServer: {
+    command: `pnpm exec next start --hostname 127.0.0.1 --port ${port}`,
+    env: {
+      ...process.env,
+      DASHBOARD_E2E_MOCK: process.env.DASHBOARD_E2E_MOCK ?? "0",
+    },
+    reuseExistingServer: false,
+    timeout: 120_000,
+    url: baseURL,
+  },
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   qs: 6.14.2
   flatted: 3.4.2
   fast-xml-parser: 5.5.10
+  protobufjs: 7.5.5
   picomatch@2.3.1: 2.3.2
   picomatch@4.0.3: 4.0.4
   happy-dom: 20.8.9
@@ -3213,8 +3214,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
@@ -4643,7 +4644,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -7424,7 +7425,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2

--- a/public/fixtures/showcase/logo.svg
+++ b/public/fixtures/showcase/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
+  <title id="title">WebLingo fixture logo</title>
+  <desc id="desc">A geometric mark used by showcase regression fixtures.</desc>
+  <rect width="96" height="96" rx="16" fill="#18324f" />
+  <path d="M20 50c0-17 13-30 30-30h26v14H50c-9 0-16 7-16 16s7 16 16 16h26v14H50c-17 0-30-13-30-30Z" fill="#ffffff" />
+  <path d="M44 34h32v14H44V34Zm0 20h24v14H44V54Z" fill="#2cb6a3" />
+</svg>

--- a/public/fixtures/showcase/showcase.css
+++ b/public/fixtures/showcase/showcase.css
@@ -1,0 +1,107 @@
+.fixture-shell {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 48px 24px;
+  color: #1d2433;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+.fixture-shell::before {
+  display: block;
+  width: 64px;
+  height: 64px;
+  margin-bottom: 24px;
+  background: url("/fixtures/showcase/logo.svg") center / contain no-repeat;
+  content: "";
+}
+
+.fixture-shell h1 {
+  max-width: 760px;
+  margin: 0 0 24px;
+  font-size: 42px;
+  line-height: 1.05;
+}
+
+.fixture-kicker {
+  margin: 0 0 12px;
+  color: #006b5f;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.fixture-hero,
+.fixture-panel {
+  margin: 24px 0;
+  padding: 24px;
+  border: 1px solid #d3dae6;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.fixture-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 24px 0;
+}
+
+.fixture-nav a,
+.fixture-button,
+.fixture-panel a,
+.fixture-shell button {
+  min-height: 40px;
+  padding: 10px 14px;
+  border: 1px solid #18324f;
+  border-radius: 6px;
+  background: #f4f7fb;
+  color: #18324f;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.fixture-button,
+.fixture-shell button {
+  display: inline-flex;
+  align-items: center;
+  background: #18324f;
+  color: #ffffff;
+}
+
+.fixture-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+}
+
+[data-fixture-accent] {
+  color: #8b2f52;
+}
+
+[data-fixture-output] {
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: #eef7f5;
+}
+
+form {
+  display: grid;
+  gap: 12px;
+  max-width: 460px;
+}
+
+input {
+  display: block;
+  width: 100%;
+  min-height: 40px;
+  margin-top: 6px;
+  border: 1px solid #9aa6ba;
+  border-radius: 6px;
+}

--- a/public/fixtures/showcase/showcase.css
+++ b/public/fixtures/showcase/showcase.css
@@ -85,6 +85,12 @@
   color: #8b2f52;
 }
 
+.fixture-picture {
+  display: inline-flex;
+  width: 96px;
+  height: 96px;
+}
+
 [data-fixture-output] {
   padding: 10px 12px;
   border-radius: 6px;

--- a/public/fixtures/showcase/widget.js
+++ b/public/fixtures/showcase/widget.js
@@ -1,0 +1,14 @@
+(() => {
+  document.documentElement.setAttribute("data-fixture-script-ready", "1");
+
+  for (const toggle of document.querySelectorAll("[data-fixture-toggle]")) {
+    toggle.addEventListener("click", () => {
+      const expanded = toggle.getAttribute("aria-expanded") === "true";
+      toggle.setAttribute("aria-expanded", expanded ? "false" : "true");
+      const output = document.querySelector("[data-fixture-output]");
+      if (output) {
+        output.textContent = expanded ? "Drawer closed" : "Drawer open";
+      }
+    });
+  }
+})();

--- a/tests/showcase-fixtures.spec.ts
+++ b/tests/showcase-fixtures.spec.ts
@@ -353,6 +353,106 @@ test("showcase app fixture runs non-eval interactivity", async ({ page }) => {
   expect(fixtureIssues).toEqual([]);
 });
 
+test("showcase root-base fixture resolves base-relative assets and links", async ({ page }) => {
+  const fixtureIssues = collectFixtureRequestIssues(page);
+
+  await gotoFixture(page, "/fixtures/showcase/root-base");
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.locator("html")).toHaveAttribute("data-weblingo-showcase-fixture", "root-base");
+  await expect(page.locator("base")).toHaveAttribute("href", "/");
+  await expect(
+    page.getByRole("heading", { name: "Root base showcase links stay in namespace" }),
+  ).toBeVisible();
+
+  await expect(page.locator('[data-check="root-base-pricing"]')).toHaveAttribute(
+    "href",
+    "fixtures/showcase/marketing/pricing?from=root-base#buy",
+  );
+  const pricingHref = await page
+    .locator('[data-check="root-base-pricing"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  expectUrlEquivalent(
+    pricingHref,
+    new URL("/fixtures/showcase/marketing/pricing?from=root-base#buy", page.url()).toString(),
+  );
+
+  const docsHref = await page
+    .locator('[data-check="root-base-docs"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  expectUrlEquivalent(
+    docsHref,
+    new URL("/fixtures/showcase/docs/start?from=root-base#authentication", page.url()).toString(),
+  );
+
+  const sourceFallbackHref = await page
+    .locator('[data-check="root-base-source-fallback"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  expectUrlEquivalent(
+    sourceFallbackHref,
+    new URL("/fixtures/showcase/original-only?from=root-base#faq", page.url()).toString(),
+  );
+
+  const relativeImageCurrentSrc = await page
+    .locator('[data-check="root-base-relative-image"]')
+    .evaluate((image: HTMLImageElement) => image.currentSrc);
+  expectUrlEquivalent(
+    relativeImageCurrentSrc,
+    new URL("/fixtures/showcase/logo.svg?v=20260416&root-base=1", page.url()).toString(),
+  );
+
+  await clickAndExpect(
+    page,
+    '[data-check="root-base-pricing"]',
+    new URL("/fixtures/showcase/marketing/pricing?from=root-base#buy", page.url()).toString(),
+    "Pricing that keeps translated links stable",
+  );
+
+  await gotoFixture(page, "/fixtures/showcase/root-base");
+  await clickAndExpect(
+    page,
+    '[data-check="root-base-docs"]',
+    new URL("/fixtures/showcase/docs/start?from=root-base#authentication", page.url()).toString(),
+    "Set up translated docs without breaking references",
+  );
+
+  await gotoFixture(page, "/fixtures/showcase/root-base");
+  await clickAndExpect(
+    page,
+    '[data-check="root-base-source-fallback"]',
+    new URL("/fixtures/showcase/original-only?from=root-base#faq", page.url()).toString(),
+    "Source-only original page",
+  );
+
+  expect(fixtureIssues).toEqual([]);
+});
+
+test("showcase multipart fixture submits browser multipart forms", async ({ page }) => {
+  const fixtureIssues = collectFixtureRequestIssues(page);
+
+  await gotoFixture(page, "/fixtures/showcase/marketing/multipart");
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.locator("html")).toHaveAttribute("data-weblingo-showcase-fixture", "marketing");
+  await expect(page.getByRole("heading", { name: "Multipart lead form fixture" })).toBeVisible();
+  await expect(page.locator('[data-check="multipart-lead-form"]')).toHaveAttribute(
+    "enctype",
+    "multipart/form-data",
+  );
+
+  await page.locator('input[name="email"]').fill("buyer@example.com");
+  await page.getByRole("button", { name: "Request multipart preview" }).click();
+  await expectPageUrlEquivalent(
+    page,
+    new URL(
+      "/fixtures/showcase/marketing/contact/thanks?source=multipart#thanks",
+      page.url(),
+    ).toString(),
+  );
+  await expect(page.getByRole("heading", { name: "Preview request received" })).toBeVisible();
+  expect(fixtureIssues).toEqual([]);
+});
+
 test("showcase docs fixture resolves nested base and relative links in the browser", async ({
   page,
 }) => {

--- a/tests/showcase-fixtures.spec.ts
+++ b/tests/showcase-fixtures.spec.ts
@@ -2,6 +2,13 @@ import { expect, test, type Page, type Response } from "@playwright/test";
 
 const FIXTURE_BASE_ORIGIN = new URL(process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000")
   .origin;
+const FIXTURE_PAGE_CACHE_CONTROL = "public, max-age=60";
+const FIXTURE_STATIC_ASSET_CACHE_CONTROL = "public, max-age=0";
+const STATIC_FIXTURE_ASSET_PATHS = new Set([
+  "/fixtures/showcase/logo.svg",
+  "/fixtures/showcase/showcase.css",
+  "/fixtures/showcase/widget.js",
+]);
 
 type FixtureRequestIssue = {
   url: string;
@@ -57,6 +64,27 @@ function classifyFixtureRequest(value: string, status?: number): string | null {
   return null;
 }
 
+function expectedFixtureCacheControl(response: Response): string | null {
+  if (response.status() < 200 || response.status() >= 300) {
+    return null;
+  }
+  const url = new URL(response.url());
+  if (url.origin !== FIXTURE_BASE_ORIGIN) {
+    return null;
+  }
+  if (STATIC_FIXTURE_ASSET_PATHS.has(url.pathname)) {
+    return FIXTURE_STATIC_ASSET_CACHE_CONTROL;
+  }
+  if (
+    response.request().method() === "GET" &&
+    response.request().resourceType() === "document" &&
+    (url.pathname === "/fixtures/showcase" || url.pathname.startsWith("/fixtures/showcase/"))
+  ) {
+    return FIXTURE_PAGE_CACHE_CONTROL;
+  }
+  return null;
+}
+
 function collectFixtureRequestIssues(page: Page): FixtureRequestIssue[] {
   const issues: FixtureRequestIssue[] = [];
 
@@ -65,6 +93,16 @@ function collectFixtureRequestIssues(page: Page): FixtureRequestIssue[] {
     const reason = classifyFixtureRequest(url, response.status());
     if (reason) {
       issues.push({ url, status: response.status(), reason });
+      return;
+    }
+    const expectedCacheControl = expectedFixtureCacheControl(response);
+    const actualCacheControl = response.headers()["cache-control"] ?? null;
+    if (expectedCacheControl && actualCacheControl !== expectedCacheControl) {
+      issues.push({
+        url,
+        status: response.status(),
+        reason: `cache-control ${actualCacheControl ?? "<missing>"} !== ${expectedCacheControl}`,
+      });
     }
   });
   page.on("requestfailed", (request) => {
@@ -104,15 +142,36 @@ async function gotoFixture(page: Page, path: string): Promise<Response> {
   expect(response, `${path} should return a document response`).not.toBeNull();
   expect(response!.status(), `${path} document status`).toBeGreaterThanOrEqual(200);
   expect(response!.status(), `${path} document status`).toBeLessThan(400);
-  expect(response!.headers()["cache-control"], `${path} cache-control`).toBe("public, max-age=60");
+  expect(response!.headers()["cache-control"], `${path} cache-control`).toBe(
+    FIXTURE_PAGE_CACHE_CONTROL,
+  );
   return response!;
 }
 
 test("showcase marketing fixture exposes link, metadata, and asset sentinels", async ({ page }) => {
   const fixtureIssues = collectFixtureRequestIssues(page);
+  const interceptedExternalRequests: string[] = [];
+  await page.route("https://developer.mozilla.org/**", async (route) => {
+    const request = route.request();
+    interceptedExternalRequests.push(`${request.method()} ${request.url()}`);
+    await route.fulfill({
+      body: [
+        "<!doctype html>",
+        '<html lang="en">',
+        "<head><title>Intercepted external reference</title>",
+        '<link rel="icon" href="data:,">',
+        "</head>",
+        "<body><h1>Intercepted external reference</h1></body>",
+        "</html>",
+      ].join(""),
+      contentType: "text/html; charset=utf-8",
+      status: 200,
+    });
+  });
 
   await gotoFixture(page, "/fixtures/showcase/marketing");
   await page.waitForLoadState("networkidle");
+  expect(interceptedExternalRequests).toEqual([]);
 
   await expect(page.locator("html")).toHaveAttribute("data-weblingo-showcase-fixture", "marketing");
   await expect(page.locator("html")).toHaveAttribute("data-fixture-script-ready", "1");
@@ -183,6 +242,7 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
   const externalUrl = new URL(externalHref);
   expect(externalUrl.origin).toBe("https://developer.mozilla.org");
   expect(externalUrl.origin).not.toBe(FIXTURE_BASE_ORIGIN);
+  expect(interceptedExternalRequests).toEqual([]);
 
   const responsiveImageCurrentSrc = await page
     .locator('[data-check="responsive-image"] img')
@@ -252,6 +312,17 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
   await expect(page.getByRole("heading", { name: "Preview request received" })).toBeVisible();
 
   expect(fixtureIssues).toEqual([]);
+
+  await gotoFixture(page, "/fixtures/showcase/marketing");
+  await page.waitForLoadState("networkidle");
+  expect(fixtureIssues).toEqual([]);
+  expect(interceptedExternalRequests).toEqual([]);
+  await Promise.all([
+    page.waitForURL("https://developer.mozilla.org/en-US/"),
+    page.locator('[data-check="external"]').click(),
+  ]);
+  expect(interceptedExternalRequests).toEqual(["GET https://developer.mozilla.org/en-US/"]);
+  await expect(page.getByRole("heading", { name: "Intercepted external reference" })).toBeVisible();
 });
 
 test("showcase app fixture runs non-eval interactivity", async ({ page }) => {

--- a/tests/showcase-fixtures.spec.ts
+++ b/tests/showcase-fixtures.spec.ts
@@ -34,6 +34,13 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
     new URL("/fixtures/showcase/marketing/about?tab=story#team", page.url()).toString(),
   );
 
+  const parentRelativeHref = await page
+    .locator('[data-check="parent-relative"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  expect(parentRelativeHref).toBe(
+    new URL("/fixtures/showcase/docs/start?from=marketing#setup", page.url()).toString(),
+  );
+
   const sourceFallbackHref = await page
     .locator('[data-check="source-fallback-root"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);

--- a/tests/showcase-fixtures.spec.ts
+++ b/tests/showcase-fixtures.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+
+test("showcase marketing fixture exposes link, metadata, and asset sentinels", async ({ page }) => {
+  const failedFixtureAssets: Array<{ url: string; status: number }> = [];
+  page.on("response", (response) => {
+    const url = response.url();
+    if (url.includes("/fixtures/showcase/") && response.status() >= 400) {
+      failedFixtureAssets.push({ url, status: response.status() });
+    }
+  });
+
+  await page.goto("/fixtures/showcase/marketing");
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.locator("html")).toHaveAttribute("data-weblingo-showcase-fixture", "marketing");
+  await expect(page.locator("html")).toHaveAttribute("data-fixture-script-ready", "1");
+  await expect(
+    page.getByRole("heading", { name: "Translate product pages without losing the buyer path" }),
+  ).toBeVisible();
+
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    "https://weblingo.app/fixtures/showcase/marketing",
+  );
+  await expect(page.locator('link[rel="alternate"][hreflang="fr"]')).toHaveAttribute(
+    "href",
+    "https://weblingo.app/fr/fixtures/showcase/marketing",
+  );
+
+  const relativeSiblingHref = await page
+    .locator('[data-check="relative-sibling"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  expect(relativeSiblingHref).toBe(
+    new URL("/fixtures/showcase/marketing/about?tab=story#team", page.url()).toString(),
+  );
+
+  const sourceFallbackHref = await page
+    .locator('[data-check="source-fallback-root"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  expect(sourceFallbackHref).toBe(
+    new URL("/fixtures/showcase/original-only?from=marketing#faq", page.url()).toString(),
+  );
+
+  const cssBackgroundImage = await page
+    .locator(".fixture-shell")
+    .evaluate((element) => getComputedStyle(element, "::before").backgroundImage);
+  expect(cssBackgroundImage).toContain("/fixtures/showcase/logo.svg");
+  expect(failedFixtureAssets).toEqual([]);
+});
+
+test("showcase app fixture runs non-eval interactivity", async ({ page }) => {
+  await page.goto("/fixtures/showcase/app/dashboard");
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.locator("html")).toHaveAttribute("data-weblingo-showcase-fixture", "app");
+  await expect(page.locator("html")).toHaveAttribute("data-fixture-script-ready", "1");
+  await expect(page.locator("[data-fixture-output]")).toHaveText("Drawer closed");
+
+  await page.locator("[data-fixture-toggle]").click();
+
+  await expect(page.locator("[data-fixture-toggle]")).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator("[data-fixture-output]")).toHaveText("Drawer open");
+});

--- a/tests/showcase-fixtures.spec.ts
+++ b/tests/showcase-fixtures.spec.ts
@@ -1,33 +1,91 @@
 import { expect, test, type Page } from "@playwright/test";
 
-type FixtureFailure = {
+const FIXTURE_BASE_ORIGIN = new URL(process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000")
+  .origin;
+
+type FixtureRequestIssue = {
   url: string;
   status?: number;
   resourceType?: string;
   failure?: string | null;
+  reason: string;
 };
 
-function collectFixtureFailures(page: Page): FixtureFailure[] {
-  const failures: FixtureFailure[] = [];
+function normalizeUrlForAssertion(value: string): string {
+  const url = new URL(value, FIXTURE_BASE_ORIGIN);
+  if (url.pathname.length > 1 && url.pathname.endsWith("/")) {
+    url.pathname = url.pathname.slice(0, -1);
+  }
+  const sortedParams = Array.from(url.searchParams.entries()).sort(
+    ([leftKey, leftValue], [rightKey, rightValue]) =>
+      leftKey.localeCompare(rightKey) || leftValue.localeCompare(rightValue),
+  );
+  url.search = "";
+  for (const [key, paramValue] of sortedParams) {
+    url.searchParams.append(key, paramValue);
+  }
+  return url.toString();
+}
+
+function expectUrlEquivalent(actual: string, expected: string): void {
+  expect(normalizeUrlForAssertion(actual)).toBe(normalizeUrlForAssertion(expected));
+}
+
+async function expectPageUrlEquivalent(page: Page, expectedUrl: string): Promise<void> {
+  await expect
+    .poll(() => normalizeUrlForAssertion(page.url()))
+    .toBe(normalizeUrlForAssertion(expectedUrl));
+}
+
+function classifyFixtureRequest(value: string, status?: number): string | null {
+  const url = new URL(value);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return null;
+  }
+  if (url.pathname === "/favicon.ico") {
+    return null;
+  }
+  if (url.origin !== FIXTURE_BASE_ORIGIN) {
+    return `unexpected origin ${url.origin}`;
+  }
+  if (url.pathname !== "/fixtures/showcase" && !url.pathname.startsWith("/fixtures/showcase/")) {
+    return `unexpected path ${url.pathname}`;
+  }
+  if (status !== undefined && status >= 400) {
+    return `HTTP ${status}`;
+  }
+  return null;
+}
+
+function collectFixtureRequestIssues(page: Page): FixtureRequestIssue[] {
+  const issues: FixtureRequestIssue[] = [];
 
   page.on("response", (response) => {
     const url = response.url();
-    if (url.includes("/fixtures/showcase/") && response.status() >= 400) {
-      failures.push({ url, status: response.status() });
+    const reason = classifyFixtureRequest(url, response.status());
+    if (reason) {
+      issues.push({ url, status: response.status(), reason });
     }
   });
   page.on("requestfailed", (request) => {
     const url = request.url();
-    if (url.includes("/fixtures/showcase/")) {
-      failures.push({
-        url,
-        resourceType: request.resourceType(),
-        failure: request.failure()?.errorText ?? null,
-      });
+    const parsed = new URL(url);
+    if (
+      (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+      parsed.pathname === "/favicon.ico"
+    ) {
+      return;
     }
+    const reason = classifyFixtureRequest(url) ?? "request failed";
+    issues.push({
+      url,
+      resourceType: request.resourceType(),
+      failure: request.failure()?.errorText ?? null,
+      reason,
+    });
   });
 
-  return failures;
+  return issues;
 }
 
 async function clickAndExpect(
@@ -37,12 +95,12 @@ async function clickAndExpect(
   heading: string,
 ): Promise<void> {
   await page.locator(selector).click();
-  await expect(page).toHaveURL(expectedUrl);
+  await expectPageUrlEquivalent(page, expectedUrl);
   await expect(page.getByRole("heading", { name: heading })).toBeVisible();
 }
 
 test("showcase marketing fixture exposes link, metadata, and asset sentinels", async ({ page }) => {
-  const fixtureFailures = collectFixtureFailures(page);
+  const fixtureIssues = collectFixtureRequestIssues(page);
 
   await page.goto("/fixtures/showcase/marketing");
   await page.waitForLoadState("networkidle");
@@ -55,6 +113,14 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
 
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     "href",
+    "https://weblingo.app/fixtures/showcase/marketing",
+  );
+  await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+    "content",
+    "https://weblingo.app/fixtures/showcase/marketing",
+  );
+  await expect(page.locator('meta[name="twitter:url"]')).toHaveAttribute(
+    "content",
     "https://weblingo.app/fixtures/showcase/marketing",
   );
   await expect(page.locator('link[rel="alternate"][hreflang="fr"]')).toHaveAttribute(
@@ -73,30 +139,41 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
   const relativeSiblingHref = await page
     .locator('[data-check="relative-sibling"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
-  expect(relativeSiblingHref).toBe(
+  expectUrlEquivalent(
+    relativeSiblingHref,
     new URL("/fixtures/showcase/marketing/about?tab=story#team", page.url()).toString(),
   );
 
   const parentRelativeHref = await page
     .locator('[data-check="parent-relative"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
-  expect(parentRelativeHref).toBe(
+  expectUrlEquivalent(
+    parentRelativeHref,
     new URL("/fixtures/showcase/docs/start?from=marketing#setup", page.url()).toString(),
   );
 
   const queryOnlyHref = await page
     .locator('[data-check="query-only"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
-  expect(queryOnlyHref).toBe(
+  expectUrlEquivalent(
+    queryOnlyHref,
     new URL("/fixtures/showcase/marketing/?audience=buyers#overview", page.url()).toString(),
   );
 
   const sourceFallbackHref = await page
     .locator('[data-check="source-fallback-root"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
-  expect(sourceFallbackHref).toBe(
+  expectUrlEquivalent(
+    sourceFallbackHref,
     new URL("/fixtures/showcase/original-only?from=marketing#faq", page.url()).toString(),
   );
+
+  const externalHref = await page
+    .locator('[data-check="external"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  const externalUrl = new URL(externalHref);
+  expect(externalUrl.origin).toBe("https://developer.mozilla.org");
+  expect(externalUrl.origin).not.toBe(FIXTURE_BASE_ORIGIN);
 
   const responsiveImageCurrentSrc = await page
     .locator('[data-check="responsive-image"] img')
@@ -142,7 +219,10 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
   await page.goto("/fixtures/showcase/marketing");
   await page.locator('input[name="email"]').fill("not-an-email");
   await page.getByRole("button", { name: "Request localized preview" }).click();
-  await expect(page).toHaveURL(new URL("/fixtures/showcase/marketing", page.url()).toString());
+  await expectPageUrlEquivalent(
+    page,
+    new URL("/fixtures/showcase/marketing", page.url()).toString(),
+  );
   await expect
     .poll(() =>
       page
@@ -153,7 +233,8 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
 
   await page.locator('input[name="email"]').fill("buyer@example.com");
   await page.locator('input[name="email"]').press("Enter");
-  await expect(page).toHaveURL(
+  await expectPageUrlEquivalent(
+    page,
     new URL(
       "/fixtures/showcase/marketing/contact/thanks?source=form#thanks",
       page.url(),
@@ -161,11 +242,11 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
   );
   await expect(page.getByRole("heading", { name: "Preview request received" })).toBeVisible();
 
-  expect(fixtureFailures).toEqual([]);
+  expect(fixtureIssues).toEqual([]);
 });
 
 test("showcase app fixture runs non-eval interactivity", async ({ page }) => {
-  const fixtureFailures = collectFixtureFailures(page);
+  const fixtureIssues = collectFixtureRequestIssues(page);
 
   await page.goto("/fixtures/showcase/app/dashboard");
   await page.waitForLoadState("networkidle");
@@ -189,13 +270,13 @@ test("showcase app fixture runs non-eval interactivity", async ({ page }) => {
 
   await expect(page.locator("[data-fixture-toggle]")).toHaveAttribute("aria-expanded", "true");
   await expect(page.locator("[data-fixture-output]")).toHaveText("Drawer open");
-  expect(fixtureFailures).toEqual([]);
+  expect(fixtureIssues).toEqual([]);
 });
 
 test("showcase docs fixture resolves nested base and relative links in the browser", async ({
   page,
 }) => {
-  const fixtureFailures = collectFixtureFailures(page);
+  const fixtureIssues = collectFixtureRequestIssues(page);
 
   await page.goto("/fixtures/showcase/docs/start");
   await page.waitForLoadState("networkidle");
@@ -209,33 +290,40 @@ test("showcase docs fixture resolves nested base and relative links in the brows
   const apiHref = await page
     .locator('[data-check="docs-api"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
-  expect(apiHref).toBe(
+  expectUrlEquivalent(
+    apiHref,
     new URL("/fixtures/showcase/docs/api?topic=keys#authentication", page.url()).toString(),
   );
 
   const parentHref = await page
     .locator('[data-check="docs-marketing"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
-  expect(parentHref).toBe(new URL("/fixtures/showcase/marketing?from=docs", page.url()).toString());
+  expectUrlEquivalent(
+    parentHref,
+    new URL("/fixtures/showcase/marketing?from=docs", page.url()).toString(),
+  );
 
   const deepRelativeHref = await page
     .locator('[data-check="docs-deep-relative"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
-  expect(deepRelativeHref).toBe(
+  expectUrlEquivalent(
+    deepRelativeHref,
     new URL("/fixtures/showcase/marketing/pricing?from=docs#buy", page.url()).toString(),
   );
 
   const sourceOnlyHref = await page
     .locator('[data-check="docs-source-fallback"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
-  expect(sourceOnlyHref).toBe(
+  expectUrlEquivalent(
+    sourceOnlyHref,
     new URL("/fixtures/showcase/docs/source-only?from=docs#legacy", page.url()).toString(),
   );
 
   const fragmentHref = await page
     .locator('[data-check="docs-fragment"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
-  expect(fragmentHref).toBe(
+  expectUrlEquivalent(
+    fragmentHref,
     new URL("/fixtures/showcase/docs/#authentication", page.url()).toString(),
   );
 
@@ -270,5 +358,5 @@ test("showcase docs fixture resolves nested base and relative links in the brows
     "Docs fixture root with anchor target",
   );
 
-  expect(fixtureFailures).toEqual([]);
+  expect(fixtureIssues).toEqual([]);
 });

--- a/tests/showcase-fixtures.spec.ts
+++ b/tests/showcase-fixtures.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Page, type Response } from "@playwright/test";
 
 const FIXTURE_BASE_ORIGIN = new URL(process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000")
   .origin;
@@ -99,10 +99,19 @@ async function clickAndExpect(
   await expect(page.getByRole("heading", { name: heading })).toBeVisible();
 }
 
+async function gotoFixture(page: Page, path: string): Promise<Response> {
+  const response = await page.goto(path);
+  expect(response, `${path} should return a document response`).not.toBeNull();
+  expect(response!.status(), `${path} document status`).toBeGreaterThanOrEqual(200);
+  expect(response!.status(), `${path} document status`).toBeLessThan(400);
+  expect(response!.headers()["cache-control"], `${path} cache-control`).toBe("public, max-age=60");
+  return response!;
+}
+
 test("showcase marketing fixture exposes link, metadata, and asset sentinels", async ({ page }) => {
   const fixtureIssues = collectFixtureRequestIssues(page);
 
-  await page.goto("/fixtures/showcase/marketing");
+  await gotoFixture(page, "/fixtures/showcase/marketing");
   await page.waitForLoadState("networkidle");
 
   await expect(page.locator("html")).toHaveAttribute("data-weblingo-showcase-fixture", "marketing");
@@ -192,7 +201,7 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
     "Pricing that keeps translated links stable",
   );
 
-  await page.goto("/fixtures/showcase/marketing");
+  await gotoFixture(page, "/fixtures/showcase/marketing");
   await clickAndExpect(
     page,
     '[data-check="relative-sibling"]',
@@ -200,7 +209,7 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
     "About the localized showcase fixture",
   );
 
-  await page.goto("/fixtures/showcase/marketing");
+  await gotoFixture(page, "/fixtures/showcase/marketing");
   await clickAndExpect(
     page,
     '[data-check="parent-relative"]',
@@ -208,7 +217,7 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
     "Set up translated docs without breaking references",
   );
 
-  await page.goto("/fixtures/showcase/marketing");
+  await gotoFixture(page, "/fixtures/showcase/marketing");
   await clickAndExpect(
     page,
     '[data-check="source-fallback-root"]',
@@ -216,7 +225,7 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
     "Source-only original page",
   );
 
-  await page.goto("/fixtures/showcase/marketing");
+  await gotoFixture(page, "/fixtures/showcase/marketing");
   await page.locator('input[name="email"]').fill("not-an-email");
   await page.getByRole("button", { name: "Request localized preview" }).click();
   await expectPageUrlEquivalent(
@@ -248,7 +257,7 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
 test("showcase app fixture runs non-eval interactivity", async ({ page }) => {
   const fixtureIssues = collectFixtureRequestIssues(page);
 
-  await page.goto("/fixtures/showcase/app/dashboard");
+  await gotoFixture(page, "/fixtures/showcase/app/dashboard");
   await page.waitForLoadState("networkidle");
 
   await expect(page.locator("html")).toHaveAttribute("data-weblingo-showcase-fixture", "app");
@@ -278,7 +287,7 @@ test("showcase docs fixture resolves nested base and relative links in the brows
 }) => {
   const fixtureIssues = collectFixtureRequestIssues(page);
 
-  await page.goto("/fixtures/showcase/docs/start");
+  await gotoFixture(page, "/fixtures/showcase/docs/start");
   await page.waitForLoadState("networkidle");
 
   await expect(page.locator("html")).toHaveAttribute("data-weblingo-showcase-fixture", "docs");
@@ -334,7 +343,7 @@ test("showcase docs fixture resolves nested base and relative links in the brows
     "API reference for localized docs",
   );
 
-  await page.goto("/fixtures/showcase/docs/start");
+  await gotoFixture(page, "/fixtures/showcase/docs/start");
   await clickAndExpect(
     page,
     '[data-check="docs-deep-relative"]',
@@ -342,7 +351,7 @@ test("showcase docs fixture resolves nested base and relative links in the brows
     "Pricing that keeps translated links stable",
   );
 
-  await page.goto("/fixtures/showcase/docs/start");
+  await gotoFixture(page, "/fixtures/showcase/docs/start");
   await clickAndExpect(
     page,
     '[data-check="docs-source-fallback"]',
@@ -350,7 +359,7 @@ test("showcase docs fixture resolves nested base and relative links in the brows
     "Legacy docs source-only page",
   );
 
-  await page.goto("/fixtures/showcase/docs/start");
+  await gotoFixture(page, "/fixtures/showcase/docs/start");
   await clickAndExpect(
     page,
     '[data-check="docs-fragment"]',

--- a/tests/showcase-fixtures.spec.ts
+++ b/tests/showcase-fixtures.spec.ts
@@ -18,6 +18,10 @@ type FixtureRequestIssue = {
   reason: string;
 };
 
+type CollectFixtureRequestIssueOptions = {
+  allowedExternalUrls?: ReadonlySet<string>;
+};
+
 function normalizeUrlForAssertion(value: string): string {
   const url = new URL(value, FIXTURE_BASE_ORIGIN);
   if (url.pathname.length > 1 && url.pathname.endsWith("/")) {
@@ -44,9 +48,16 @@ async function expectPageUrlEquivalent(page: Page, expectedUrl: string): Promise
     .toBe(normalizeUrlForAssertion(expectedUrl));
 }
 
-function classifyFixtureRequest(value: string, status?: number): string | null {
+function classifyFixtureRequest(
+  value: string,
+  status?: number,
+  options: CollectFixtureRequestIssueOptions = {},
+): string | null {
   const url = new URL(value);
   if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return null;
+  }
+  if (options.allowedExternalUrls?.has(url.toString())) {
     return null;
   }
   if (url.pathname === "/favicon.ico") {
@@ -85,12 +96,15 @@ function expectedFixtureCacheControl(response: Response): string | null {
   return null;
 }
 
-function collectFixtureRequestIssues(page: Page): FixtureRequestIssue[] {
+function collectFixtureRequestIssues(
+  page: Page,
+  options: CollectFixtureRequestIssueOptions = {},
+): FixtureRequestIssue[] {
   const issues: FixtureRequestIssue[] = [];
 
   page.on("response", (response) => {
     const url = response.url();
-    const reason = classifyFixtureRequest(url, response.status());
+    const reason = classifyFixtureRequest(url, response.status(), options);
     if (reason) {
       issues.push({ url, status: response.status(), reason });
       return;
@@ -114,7 +128,7 @@ function collectFixtureRequestIssues(page: Page): FixtureRequestIssue[] {
     ) {
       return;
     }
-    const reason = classifyFixtureRequest(url) ?? "request failed";
+    const reason = classifyFixtureRequest(url, undefined, options) ?? "request failed";
     issues.push({
       url,
       resourceType: request.resourceType(),
@@ -149,7 +163,10 @@ async function gotoFixture(page: Page, path: string): Promise<Response> {
 }
 
 test("showcase marketing fixture exposes link, metadata, and asset sentinels", async ({ page }) => {
-  const fixtureIssues = collectFixtureRequestIssues(page);
+  const externalReferenceUrl = "https://developer.mozilla.org/en-US/";
+  const fixtureIssues = collectFixtureRequestIssues(page, {
+    allowedExternalUrls: new Set([externalReferenceUrl]),
+  });
   const interceptedExternalRequests: string[] = [];
   await page.route("https://developer.mozilla.org/**", async (route) => {
     const request = route.request();
@@ -241,6 +258,7 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
   const externalUrl = new URL(externalHref);
   expect(externalUrl.origin).toBe("https://developer.mozilla.org");
+  expect(externalUrl.toString()).toBe(externalReferenceUrl);
   expect(externalUrl.origin).not.toBe(FIXTURE_BASE_ORIGIN);
   expect(interceptedExternalRequests).toEqual([]);
 
@@ -318,11 +336,12 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
   expect(fixtureIssues).toEqual([]);
   expect(interceptedExternalRequests).toEqual([]);
   await Promise.all([
-    page.waitForURL("https://developer.mozilla.org/en-US/"),
+    page.waitForURL(externalReferenceUrl),
     page.locator('[data-check="external"]').click(),
   ]);
-  expect(interceptedExternalRequests).toEqual(["GET https://developer.mozilla.org/en-US/"]);
+  expect(interceptedExternalRequests).toEqual([`GET ${externalReferenceUrl}`]);
   await expect(page.getByRole("heading", { name: "Intercepted external reference" })).toBeVisible();
+  expect(fixtureIssues).toEqual([]);
 });
 
 test("showcase app fixture runs non-eval interactivity", async ({ page }) => {
@@ -369,6 +388,14 @@ test("showcase root-base fixture resolves base-relative assets and links", async
     "href",
     "fixtures/showcase/marketing/pricing?from=root-base#buy",
   );
+  await expect(page.locator('[data-check="root-base-relative-stylesheet"]')).toHaveAttribute(
+    "href",
+    "fixtures/showcase/showcase.css?v=20260416&root-base=1",
+  );
+  await expect(page.locator('[data-check="root-base-relative-script"]')).toHaveAttribute(
+    "src",
+    "fixtures/showcase/widget.js?v=20260416&root-base=1",
+  );
   const pricingHref = await page
     .locator('[data-check="root-base-pricing"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
@@ -399,6 +426,20 @@ test("showcase root-base fixture resolves base-relative assets and links", async
   expectUrlEquivalent(
     relativeImageCurrentSrc,
     new URL("/fixtures/showcase/logo.svg?v=20260416&root-base=1", page.url()).toString(),
+  );
+  const relativeStylesheetHref = await page
+    .locator('[data-check="root-base-relative-stylesheet"]')
+    .evaluate((link: HTMLLinkElement) => link.href);
+  expectUrlEquivalent(
+    relativeStylesheetHref,
+    new URL("/fixtures/showcase/showcase.css?v=20260416&root-base=1", page.url()).toString(),
+  );
+  const relativeScriptSrc = await page
+    .locator('[data-check="root-base-relative-script"]')
+    .evaluate((script: HTMLScriptElement) => script.src);
+  expectUrlEquivalent(
+    relativeScriptSrc,
+    new URL("/fixtures/showcase/widget.js?v=20260416&root-base=1", page.url()).toString(),
   );
 
   await clickAndExpect(
@@ -441,7 +482,17 @@ test("showcase multipart fixture submits browser multipart forms", async ({ page
   );
 
   await page.locator('input[name="email"]').fill("buyer@example.com");
+  const multipartRequestPromise = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return (
+      request.method() === "POST" &&
+      url.origin === FIXTURE_BASE_ORIGIN &&
+      url.pathname === "/fixtures/showcase/marketing/contact-multipart"
+    );
+  });
   await page.getByRole("button", { name: "Request multipart preview" }).click();
+  const multipartRequest = await multipartRequestPromise;
+  expect(multipartRequest.headers()["content-type"]).toMatch(/^multipart\/form-data; boundary=/);
   await expectPageUrlEquivalent(
     page,
     new URL(

--- a/tests/showcase-fixtures.spec.ts
+++ b/tests/showcase-fixtures.spec.ts
@@ -1,13 +1,48 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
-test("showcase marketing fixture exposes link, metadata, and asset sentinels", async ({ page }) => {
-  const failedFixtureAssets: Array<{ url: string; status: number }> = [];
+type FixtureFailure = {
+  url: string;
+  status?: number;
+  resourceType?: string;
+  failure?: string | null;
+};
+
+function collectFixtureFailures(page: Page): FixtureFailure[] {
+  const failures: FixtureFailure[] = [];
+
   page.on("response", (response) => {
     const url = response.url();
     if (url.includes("/fixtures/showcase/") && response.status() >= 400) {
-      failedFixtureAssets.push({ url, status: response.status() });
+      failures.push({ url, status: response.status() });
     }
   });
+  page.on("requestfailed", (request) => {
+    const url = request.url();
+    if (url.includes("/fixtures/showcase/")) {
+      failures.push({
+        url,
+        resourceType: request.resourceType(),
+        failure: request.failure()?.errorText ?? null,
+      });
+    }
+  });
+
+  return failures;
+}
+
+async function clickAndExpect(
+  page: Page,
+  selector: string,
+  expectedUrl: string,
+  heading: string,
+): Promise<void> {
+  await page.locator(selector).click();
+  await expect(page).toHaveURL(expectedUrl);
+  await expect(page.getByRole("heading", { name: heading })).toBeVisible();
+}
+
+test("showcase marketing fixture exposes link, metadata, and asset sentinels", async ({ page }) => {
+  const fixtureFailures = collectFixtureFailures(page);
 
   await page.goto("/fixtures/showcase/marketing");
   await page.waitForLoadState("networkidle");
@@ -26,6 +61,14 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
     "href",
     "https://weblingo.app/fr/fixtures/showcase/marketing",
   );
+  await expect(page.locator('link[rel="preload"][as="image"]')).toHaveAttribute(
+    "href",
+    "/fixtures/showcase/logo.svg?v=20260416",
+  );
+  await expect(page.locator('link[rel="modulepreload"]')).toHaveAttribute(
+    "href",
+    "/fixtures/showcase/widget.js?v=20260416&modulepreload=1",
+  );
 
   const relativeSiblingHref = await page
     .locator('[data-check="relative-sibling"]')
@@ -41,6 +84,13 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
     new URL("/fixtures/showcase/docs/start?from=marketing#setup", page.url()).toString(),
   );
 
+  const queryOnlyHref = await page
+    .locator('[data-check="query-only"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  expect(queryOnlyHref).toBe(
+    new URL("/fixtures/showcase/marketing/?audience=buyers#overview", page.url()).toString(),
+  );
+
   const sourceFallbackHref = await page
     .locator('[data-check="source-fallback-root"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
@@ -48,14 +98,75 @@ test("showcase marketing fixture exposes link, metadata, and asset sentinels", a
     new URL("/fixtures/showcase/original-only?from=marketing#faq", page.url()).toString(),
   );
 
+  const responsiveImageCurrentSrc = await page
+    .locator('[data-check="responsive-image"] img')
+    .evaluate((image: HTMLImageElement) => image.currentSrc);
+  expect(responsiveImageCurrentSrc).toContain("/fixtures/showcase/logo.svg");
+
   const cssBackgroundImage = await page
     .locator(".fixture-shell")
     .evaluate((element) => getComputedStyle(element, "::before").backgroundImage);
   expect(cssBackgroundImage).toContain("/fixtures/showcase/logo.svg");
-  expect(failedFixtureAssets).toEqual([]);
+
+  await clickAndExpect(
+    page,
+    '[data-check="root-internal"]',
+    new URL("/fixtures/showcase/marketing/pricing?utm=nav#buy", page.url()).toString(),
+    "Pricing that keeps translated links stable",
+  );
+
+  await page.goto("/fixtures/showcase/marketing");
+  await clickAndExpect(
+    page,
+    '[data-check="relative-sibling"]',
+    new URL("/fixtures/showcase/marketing/about?tab=story#team", page.url()).toString(),
+    "About the localized showcase fixture",
+  );
+
+  await page.goto("/fixtures/showcase/marketing");
+  await clickAndExpect(
+    page,
+    '[data-check="parent-relative"]',
+    new URL("/fixtures/showcase/docs/start?from=marketing#setup", page.url()).toString(),
+    "Set up translated docs without breaking references",
+  );
+
+  await page.goto("/fixtures/showcase/marketing");
+  await clickAndExpect(
+    page,
+    '[data-check="source-fallback-root"]',
+    new URL("/fixtures/showcase/original-only?from=marketing#faq", page.url()).toString(),
+    "Source-only original page",
+  );
+
+  await page.goto("/fixtures/showcase/marketing");
+  await page.locator('input[name="email"]').fill("not-an-email");
+  await page.getByRole("button", { name: "Request localized preview" }).click();
+  await expect(page).toHaveURL(new URL("/fixtures/showcase/marketing", page.url()).toString());
+  await expect
+    .poll(() =>
+      page
+        .locator('input[name="email"]')
+        .evaluate((input: HTMLInputElement) => input.validity.typeMismatch),
+    )
+    .toBe(true);
+
+  await page.locator('input[name="email"]').fill("buyer@example.com");
+  await page.locator('input[name="email"]').press("Enter");
+  await expect(page).toHaveURL(
+    new URL(
+      "/fixtures/showcase/marketing/contact/thanks?source=form#thanks",
+      page.url(),
+    ).toString(),
+  );
+  await expect(page.getByRole("heading", { name: "Preview request received" })).toBeVisible();
+
+  expect(fixtureFailures).toEqual([]);
 });
 
 test("showcase app fixture runs non-eval interactivity", async ({ page }) => {
+  const fixtureFailures = collectFixtureFailures(page);
+
   await page.goto("/fixtures/showcase/app/dashboard");
   await page.waitForLoadState("networkidle");
 
@@ -63,22 +174,28 @@ test("showcase app fixture runs non-eval interactivity", async ({ page }) => {
   await expect(page.locator("html")).toHaveAttribute("data-fixture-script-ready", "1");
   await expect(page.locator("[data-fixture-output]")).toHaveText("Drawer closed");
 
+  await page.locator("[data-fixture-toggle]").focus();
+  await page.keyboard.press("Enter");
+
+  await expect(page.locator("[data-fixture-toggle]")).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator("[data-fixture-output]")).toHaveText("Drawer open");
+
+  await page.keyboard.press("Space");
+
+  await expect(page.locator("[data-fixture-toggle]")).toHaveAttribute("aria-expanded", "false");
+  await expect(page.locator("[data-fixture-output]")).toHaveText("Drawer closed");
+
   await page.locator("[data-fixture-toggle]").click();
 
   await expect(page.locator("[data-fixture-toggle]")).toHaveAttribute("aria-expanded", "true");
   await expect(page.locator("[data-fixture-output]")).toHaveText("Drawer open");
+  expect(fixtureFailures).toEqual([]);
 });
 
 test("showcase docs fixture resolves nested base and relative links in the browser", async ({
   page,
 }) => {
-  const failedFixtureAssets: Array<{ url: string; status: number }> = [];
-  page.on("response", (response) => {
-    const url = response.url();
-    if (url.includes("/fixtures/showcase/") && response.status() >= 400) {
-      failedFixtureAssets.push({ url, status: response.status() });
-    }
-  });
+  const fixtureFailures = collectFixtureFailures(page);
 
   await page.goto("/fixtures/showcase/docs/start");
   await page.waitForLoadState("networkidle");
@@ -101,6 +218,13 @@ test("showcase docs fixture resolves nested base and relative links in the brows
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
   expect(parentHref).toBe(new URL("/fixtures/showcase/marketing?from=docs", page.url()).toString());
 
+  const deepRelativeHref = await page
+    .locator('[data-check="docs-deep-relative"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  expect(deepRelativeHref).toBe(
+    new URL("/fixtures/showcase/marketing/pricing?from=docs#buy", page.url()).toString(),
+  );
+
   const sourceOnlyHref = await page
     .locator('[data-check="docs-source-fallback"]')
     .evaluate((anchor: HTMLAnchorElement) => anchor.href);
@@ -114,5 +238,37 @@ test("showcase docs fixture resolves nested base and relative links in the brows
   expect(fragmentHref).toBe(
     new URL("/fixtures/showcase/docs/#authentication", page.url()).toString(),
   );
-  expect(failedFixtureAssets).toEqual([]);
+
+  await clickAndExpect(
+    page,
+    '[data-check="docs-api"]',
+    new URL("/fixtures/showcase/docs/api?topic=keys#authentication", page.url()).toString(),
+    "API reference for localized docs",
+  );
+
+  await page.goto("/fixtures/showcase/docs/start");
+  await clickAndExpect(
+    page,
+    '[data-check="docs-deep-relative"]',
+    new URL("/fixtures/showcase/marketing/pricing?from=docs#buy", page.url()).toString(),
+    "Pricing that keeps translated links stable",
+  );
+
+  await page.goto("/fixtures/showcase/docs/start");
+  await clickAndExpect(
+    page,
+    '[data-check="docs-source-fallback"]',
+    new URL("/fixtures/showcase/docs/source-only?from=docs#legacy", page.url()).toString(),
+    "Legacy docs source-only page",
+  );
+
+  await page.goto("/fixtures/showcase/docs/start");
+  await clickAndExpect(
+    page,
+    '[data-check="docs-fragment"]',
+    new URL("/fixtures/showcase/docs#authentication", page.url()).toString(),
+    "Docs fixture root with anchor target",
+  );
+
+  expect(fixtureFailures).toEqual([]);
 });

--- a/tests/showcase-fixtures.spec.ts
+++ b/tests/showcase-fixtures.spec.ts
@@ -61,3 +61,51 @@ test("showcase app fixture runs non-eval interactivity", async ({ page }) => {
   await expect(page.locator("[data-fixture-toggle]")).toHaveAttribute("aria-expanded", "true");
   await expect(page.locator("[data-fixture-output]")).toHaveText("Drawer open");
 });
+
+test("showcase docs fixture resolves nested base and relative links in the browser", async ({
+  page,
+}) => {
+  const failedFixtureAssets: Array<{ url: string; status: number }> = [];
+  page.on("response", (response) => {
+    const url = response.url();
+    if (url.includes("/fixtures/showcase/") && response.status() >= 400) {
+      failedFixtureAssets.push({ url, status: response.status() });
+    }
+  });
+
+  await page.goto("/fixtures/showcase/docs/start");
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.locator("html")).toHaveAttribute("data-weblingo-showcase-fixture", "docs");
+  await expect(page.locator("html")).toHaveAttribute("data-fixture-script-ready", "1");
+  await expect(
+    page.getByRole("heading", { name: "Set up translated docs without breaking references" }),
+  ).toBeVisible();
+
+  const apiHref = await page
+    .locator('[data-check="docs-api"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  expect(apiHref).toBe(
+    new URL("/fixtures/showcase/docs/api?topic=keys#authentication", page.url()).toString(),
+  );
+
+  const parentHref = await page
+    .locator('[data-check="docs-marketing"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  expect(parentHref).toBe(new URL("/fixtures/showcase/marketing?from=docs", page.url()).toString());
+
+  const sourceOnlyHref = await page
+    .locator('[data-check="docs-source-fallback"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  expect(sourceOnlyHref).toBe(
+    new URL("/fixtures/showcase/docs/source-only?from=docs#legacy", page.url()).toString(),
+  );
+
+  const fragmentHref = await page
+    .locator('[data-check="docs-fragment"]')
+    .evaluate((anchor: HTMLAnchorElement) => anchor.href);
+  expect(fragmentHref).toBe(
+    new URL("/fixtures/showcase/docs/#authentication", page.url()).toString(),
+  );
+  expect(failedFixtureAssets).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- Why: the live showcase suite needs deterministic sales-critical source fixtures that catch link rewriting, asset, SEO, form, cache, root-base, stale fixture, and browser-noise regressions before the product is public.
- What: add and harden marketing/docs/app/root-base showcase fixtures, fixture route tests, browser smoke tests, strict request-graph assertions, malformed form handling, urlencoded and multipart browser form paths, cache-header assertions, non-cacheable POST responses, OG/Twitter URL assertions, external-link assertions, intercepted external-click coverage, production-server fixture smoke, and synced backend generated docs for the latest backend PR head.
- Subagent negotiation: both validators agreed root-base coverage is the highest-value missing fixture; one validator argued multipart browser-form coverage is a cheap second high-value addition. Redirect/SEO/external-link clones were rejected as lower ROI fixture sprawl for now.
- Final local browser pass: fixture documents now declare a data favicon and only preload the logo on the marketing page that actually consumes it, keeping docs/app/root-base pages free of avoidable favicon 404 and unused-preload console noise.
- CI hardening: added a narrow `protobufjs@7.5.5` pnpm override so the frontend `pnpm audit --audit-level=high` gate clears the current critical advisory pulled via `posthog-js`/OpenTelemetry.

## Testing

- [x] `corepack pnpm install --frozen-lockfile`
- [x] `corepack pnpm audit --audit-level=high --ignore-registry-errors`
- [x] `corepack pnpm licenses list --prod --json` + `node scripts/check-licenses.mjs`
- [x] `corepack pnpm test` with CI workflow env
- [x] `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm check:ci` with CI workflow env
- [x] `corepack pnpm build` with CI workflow env
- [x] `corepack pnpm test:e2e:smoke` with CI workflow env
- [x] `corepack pnpm test:showcase:fixtures` with CI workflow env
- [x] `corepack pnpm test:showcase:fixtures:production` with CI workflow env
- [x] `git diff --check`

## Docs sync and capability matrix

- [ ] Updated `docs/backend/DASHBOARD_SPECS.md` if user-facing backend capability coverage changed. N/A, no dashboard capability surface changed.
- [x] Ran `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync` and committed `content/docs/_generated/*` when backend HEAD advanced.

## Cases handled

- Marketing fixture checks canonical, hreflang, OG URL, Twitter URL, preload, modulepreload, CSS background, responsive image, form submission, query-only links, relative sibling links, parent-relative links, root-internal links, source-only fallback links, and an external reference that must remain external.
- Docs fixture checks nested `<base>` behavior, fragment navigation, sibling links, parent links, deep relative links, and docs source-only fallback links.
- App fixture checks CSP-compatible non-eval interactivity through keyboard and click flows.
- Root-base fixture checks `<base href="/">`, base-relative internal links, base-relative source fallback, and a base-relative image asset. The live matrix docs now include this fixture so deployed showcase runs can catch trailing-slash namespace regressions.
- Multipart marketing fixture submits a browser-generated `multipart/form-data` body to `/fixtures/showcase/marketing/contact-multipart` and verifies the no-store 303 redirect to the shared thank-you page.
- Browser smoke now fails on unexpected request graph entries, including successful off-fixture/off-origin requests that the previous failure-only collector missed.
- Browser fixture navigation now asserts successful fixture page responses and `cache-control: public, max-age=60` on successful fixture GET pages.
- Browser fixture smoke now asserts static public fixture assets (`logo.svg`, `showcase.css`, `widget.js`) return `cache-control: public, max-age=0` when loaded by the page.
- Route tests assert `cache-control: public, max-age=60` for fixture GET responses and fixture 404 pages.
- Malformed URL-encoded form bodies return sanitized validation output with `cache-control: no-store` and no reflected payload.
- Malformed multipart form posts on both form endpoints return a sanitized 400 with strict CSP, `cache-control: no-store`, and the correct fixture page identity.
- Malformed or unsupported form bodies return sanitized 400 responses instead of relying on `request.formData()` not to throw.
- Showcase fixture form POST responses use `cache-control: no-store` for validation errors, malformed bodies, unknown form posts, and valid 303 redirects.
- External-link coverage now asserts no MDN prefetch/off-origin request occurs during fixture load, then clicks the external link through a local Playwright route interception so the test verifies navigation intent without hitting the external network.
- Fixture pages declare a data favicon so local and deployed browser checks do not pick up `/favicon.ico` 404 console noise.
- Logo image preload is page-specific to the marketing fixture, avoiding unused-preload warnings on docs/app/root-base fixtures while preserving the marketing preload sentinel.
- Production fixture smoke runs `next build` plus `next start` through `corepack pnpm test:showcase:fixtures:production` to catch build/start-only fixture regressions.
- Backend generated docs are synced through backend head `f3c2131c`, which includes local premerge live-gate wiring, live form-action assertions, base href hardening, and unknown-locale absolute source-link preservation from Codex review triage.

## Known brittleness and risks

- The production fixture smoke complements the website source fixture tests; it does not replace the backend deployed live suite because it does not exercise deployed translated showcase URLs, deployment-scoped immutable assets, or real backend route-cache behavior.
- Root-base source fixture coverage proves browser semantics locally; the backend deployed live gate must include the documented root-base matrix entry to catch deployed namespace/base rewrite regressions end-to-end.
- The fixture request graph still ignores `/favicon.ico` defensively, but fixture documents now provide a data favicon so expected fixture loads should not trigger that request.
- Successful 2xx fixture documents and static assets have strict cache assertions; framework canonicalization redirects such as `/fixtures/showcase/docs/` -> `/fixtures/showcase/docs` are not treated as fixture page cache responses.
- The browser fixture suite validates source fixtures, not deployed backend showcase URLs. The backend PR live suite remains required for deployed rewrite/provenance coverage.
- `test:showcase:fixtures:production` builds the Next app, so it is more expensive than the normal fixture smoke and is intended for premerge/local release confidence rather than every tiny edit.
- Generated backend docs changed because the backend PR head advanced; this PR commits the synced artifacts so website CI can validate against the same backend snapshot.
- The `protobufjs` override is intentionally narrow and should be removed once upstream `posthog-js`/OpenTelemetry resolves to `>=7.5.5` without an override.

## Review triage

- Resolved Codex review thread for non-cacheable showcase form POST responses in `628e1bd`.
- Follow-up source-fixture hardening in `1de95fd`: added malformed multipart, GET cache-header, and production-server fixture smoke coverage.
- Follow-up backend sync in `193e6b8`: refreshed generated backend manifest to `c799f279`.
- Follow-up edge coverage in `16bd5e0`: added malformed URL-encoded form coverage, static asset cache-header assertions, and locally intercepted external-link click coverage.
- Follow-up backend sync in `fe054ba`: refreshed generated backend manifest to `f3c2131c` after backend Codex review triage.
- Follow-up root-base fixture coverage in `afc59f1`: added root-base and multipart source fixtures, route tests, Playwright smoke coverage, and the documented deployed live matrix root-base entry.
- Follow-up severe-validator hardening in `a0cf254`: asserted multipart content type on the wire, covered malformed multipart on the multipart endpoint with correct page identity, added root-base relative CSS/JS coverage, and reasserted request-graph cleanliness after the intercepted external click.
- Follow-up local browser/CI hardening in `acd6c8d`: removed avoidable fixture favicon/preload browser noise and added the `protobufjs@7.5.5` audit override.
