### PR TITLE
Add webhook settings and docs

### DIFF
--- a/app/api/dashboard/sites/[siteId]/status/route.test.ts
+++ b/app/api/dashboard/sites/[siteId]/status/route.test.ts
@@ -64,6 +64,7 @@ const makeSite = (accountId: string): Site => ({
   servingMode: "strict",
   maxLocales: null,
   siteProfile: null,
+  webhookEvents: ["translation.completed", "translation.failed", "translation.summary"],
   locales: [],
   domains: [],
   latestCrawlRun: null,

--- a/app/dashboard/actions.capabilities.test.ts
+++ b/app/dashboard/actions.capabilities.test.ts
@@ -86,12 +86,14 @@ const buildSiteSettingsUpdatePayload = vi.fn();
 const deriveSiteSettingsAccess = vi.fn();
 const parseJsonObject = vi.fn();
 const parseLocaleAliases = vi.fn();
+const parseWebhookEvents = vi.fn();
 const validateSourceUrl = vi.fn();
 vi.mock("@internal/dashboard/site-settings", () => ({
   buildSiteSettingsUpdatePayload,
   deriveSiteSettingsAccess,
   parseJsonObject,
   parseLocaleAliases,
+  parseWebhookEvents,
   validateSourceUrl,
 }));
 
@@ -104,6 +106,11 @@ describe("dashboard capability actions", () => {
     hasActorInternalOps.mockReturnValue(true);
     validateSourceUrl.mockReturnValue(null);
     parseLocaleAliases.mockImplementation((raw: string) => (raw ? JSON.parse(raw) : undefined));
+    parseWebhookEvents.mockImplementation((raw: string | null | undefined) =>
+      raw
+        ? JSON.parse(raw)
+        : ["translation.completed", "translation.failed", "translation.summary"],
+    );
   });
 
   it("queues crawl+translate with parsed csv payload and force flag", async () => {
@@ -209,6 +216,7 @@ describe("dashboard capability actions", () => {
       canEditSpaRefresh: false,
       canEditTranslatableAttributes: false,
       canEditProfile: false,
+      canEditWebhooks: false,
     });
 
     const { updateSiteSettingsAction } = await import("./actions");
@@ -228,6 +236,58 @@ describe("dashboard capability actions", () => {
     });
     expect(buildSiteSettingsUpdatePayload).not.toHaveBeenCalled();
     expect(updateSite).not.toHaveBeenCalled();
+  });
+
+  it("creates a site with webhook settings and allowlisted events", async () => {
+    createSite.mockResolvedValue({
+      id: "site-created",
+      crawlStatus: { enqueued: false },
+    });
+    requireDashboardAuth.mockResolvedValue({
+      account: {
+        accountId: "acct-1",
+        planType: "pro",
+        featureFlags: { maxLocales: null },
+      },
+      webhooksAuth: { token: "webhooks-token", subjectAccountId: "acct-1" },
+      mutationsAllowed: true,
+      billingIssue: null,
+      has: vi.fn(
+        (check: { feature?: string; allFeatures?: string[] }) =>
+          check.feature === "site_create" || check.feature === "edit",
+      ),
+    });
+
+    const { createSiteAction } = await import("./actions");
+    const formData = new FormData();
+    formData.set("sourceUrl", "https://www.example.com");
+    formData.set("sourceLang", "en");
+    formData.append("targetLangs", "fr");
+    formData.set("subdomainPattern", "https://{lang}.example.com");
+    formData.set("servingMode", "strict");
+    formData.set("webhookUrl", "https://hooks.example.com/weblingo");
+    formData.set("webhookSecret", "secret-123");
+    formData.set("webhookEvents", JSON.stringify(["translation.completed", "translation.summary"]));
+
+    const result = await createSiteAction(undefined, formData);
+
+    expect(result).toMatchObject({
+      ok: true,
+      message: "Site created. Verify domains and activate to start crawling.",
+    });
+    expect(createSite).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "webhooks-token" }),
+      expect.objectContaining({
+        sourceUrl: "https://www.example.com",
+        sourceLang: "en",
+        targetLangs: ["fr"],
+        subdomainPattern: "https://{lang}.example.com",
+        servingMode: "strict",
+        webhookUrl: "https://hooks.example.com/weblingo",
+        webhookSecret: "secret-123",
+        webhookEvents: ["translation.completed", "translation.summary"],
+      }),
+    );
   });
 
   it("updates locale summary preferences and invalidates site dashboard cache", async () => {

--- a/app/dashboard/actions.ts
+++ b/app/dashboard/actions.ts
@@ -48,6 +48,7 @@ import {
   deriveSiteSettingsAccess,
   parseJsonObject,
   parseLocaleAliases,
+  parseWebhookEvents,
   validateSourceUrl,
 } from "@internal/dashboard/site-settings";
 
@@ -290,6 +291,9 @@ export async function createSiteAction(
   const localeAliasesRaw = formData.get("localeAliases")?.toString().trim() ?? "";
   const glossaryEntriesRaw = formData.get("glossaryEntries")?.toString().trim() ?? "";
   const servingMode = formData.get("servingMode")?.toString().trim() ?? "";
+  const webhookUrlRaw = formData.get("webhookUrl")?.toString().trim() ?? "";
+  const webhookSecretRaw = formData.get("webhookSecret")?.toString().trim() ?? "";
+  const webhookEventsRaw = formData.get("webhookEvents")?.toString();
 
   const uniqueTargets = Array.from(new Set(targetLangs));
 
@@ -314,6 +318,23 @@ export async function createSiteAction(
   if (typeof localeAliases === "string") {
     return failed(localeAliases);
   }
+  const webhookEvents = parseWebhookEvents(webhookEventsRaw);
+  if (typeof webhookEvents === "string") {
+    return failed(webhookEvents);
+  }
+  let webhookUrl: string | null = null;
+  if (webhookUrlRaw) {
+    try {
+      const parsedUrl = new URL(webhookUrlRaw);
+      if (parsedUrl.protocol !== "https:") {
+        return failed("Webhook URL must use https://.");
+      }
+      webhookUrl = parsedUrl.toString();
+    } catch {
+      return failed("Webhook URL must be a valid HTTPS URL.");
+    }
+  }
+  const webhookSecret = webhookSecretRaw.length > 0 ? webhookSecretRaw : null;
 
   let normalizedGlossary: GlossaryEntry[] = [];
   if (glossaryEntriesRaw) {
@@ -356,6 +377,9 @@ export async function createSiteAction(
       siteProfile,
       maxLocales,
       servingMode,
+      webhookUrl,
+      webhookSecret,
+      webhookEvents,
     });
 
     let toast: string | null = null;

--- a/app/dashboard/sites/[id]/admin/page.test.tsx
+++ b/app/dashboard/sites/[id]/admin/page.test.tsx
@@ -91,6 +91,7 @@ describe("SiteAdminPage", () => {
         servingMode: "strict",
         maxLocales: null,
         siteProfile: {},
+        webhookEvents: ["translation.completed", "translation.failed", "translation.summary"],
         routeConfig: {
           sourceLang: "ja",
           sourceOrigin: "https://example.com/",

--- a/app/dashboard/sites/[id]/admin/page.tsx
+++ b/app/dashboard/sites/[id]/admin/page.tsx
@@ -304,7 +304,8 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
     !settingsAccess.canEditClientRuntime ||
     !settingsAccess.canEditSpaRefresh ||
     !settingsAccess.canEditTranslatableAttributes ||
-    !settingsAccess.canEditProfile;
+    !settingsAccess.canEditProfile ||
+    !settingsAccess.canEditWebhooks;
   const deploymentsByLang = new Map(
     deployments.map((deployment) => [deployment.targetLang, deployment]),
   );
@@ -426,6 +427,10 @@ export default async function SiteAdminPage({ params }: SiteAdminPageProps) {
             help: translatableAttributesHelp,
             placeholder: translatableAttributesPlaceholder,
           }}
+          webhookUrl={site.webhookUrl ?? ""}
+          webhookSecret={site.webhookSecret ?? ""}
+          webhookEvents={site.webhookEvents}
+          canEditWebhooks={settingsAccess.canEditWebhooks}
           lockedHelp={lockedHelp}
           canEditBasics={settingsAccess.canEditBasics}
           canEditLocales={settingsAccess.canEditLocales}

--- a/app/dashboard/sites/[id]/admin/site-admin-form.tsx
+++ b/app/dashboard/sites/[id]/admin/site-admin-form.tsx
@@ -24,7 +24,7 @@ import { useActionToast } from "@internal/dashboard/use-action-toast";
 import { REQUIRED_FIELDS_MESSAGE } from "@internal/dashboard/site-settings";
 import type {
   CrawlCaptureMode,
-  NotifyWebhookEventType,
+  KnownWebhookEventType,
   SpaRefreshFallback,
   SpaRefreshSettings,
   SupportedLanguage,
@@ -73,7 +73,7 @@ type SiteAdminFormProps = {
   canEditProfile: boolean;
   webhookUrl: string | null;
   webhookSecret: string | null;
-  webhookEvents: NotifyWebhookEventType[];
+  webhookEvents: KnownWebhookEventType[];
   canEditWebhooks: boolean;
   clientRuntimeCopy: {
     title: string;
@@ -183,7 +183,7 @@ export function SiteAdminForm({
   );
   const [webhookUrl, setWebhookUrl] = useState<string>(initialWebhookUrl ?? "");
   const [webhookSecret, setWebhookSecret] = useState<string>(initialWebhookSecret ?? "");
-  const [webhookEvents, setWebhookEvents] = useState<NotifyWebhookEventType[]>(
+  const [webhookEvents, setWebhookEvents] = useState<KnownWebhookEventType[]>(
     () => initialWebhookEvents,
   );
 

--- a/app/dashboard/sites/[id]/admin/site-admin-form.tsx
+++ b/app/dashboard/sites/[id]/admin/site-admin-form.tsx
@@ -24,10 +24,12 @@ import { useActionToast } from "@internal/dashboard/use-action-toast";
 import { REQUIRED_FIELDS_MESSAGE } from "@internal/dashboard/site-settings";
 import type {
   CrawlCaptureMode,
+  NotifyWebhookEventType,
   SpaRefreshFallback,
   SpaRefreshSettings,
   SupportedLanguage,
 } from "@internal/dashboard/webhooks";
+import { WebhookSettingsFields } from "../../webhook-settings-fields";
 
 // Avoid SSR for the combobox to prevent Radix Popover ID hydration mismatches.
 const LanguageTagCombobox = dynamic(
@@ -69,6 +71,10 @@ type SiteAdminFormProps = {
   translatableAttributes: string[] | null;
   canEditTranslatableAttributes: boolean;
   canEditProfile: boolean;
+  webhookUrl: string | null;
+  webhookSecret: string | null;
+  webhookEvents: NotifyWebhookEventType[];
+  canEditWebhooks: boolean;
   clientRuntimeCopy: {
     title: string;
     description: string;
@@ -126,6 +132,10 @@ export function SiteAdminForm({
   translatableAttributes: initialTranslatableAttributes,
   canEditTranslatableAttributes,
   canEditProfile,
+  webhookUrl: initialWebhookUrl,
+  webhookSecret: initialWebhookSecret,
+  webhookEvents: initialWebhookEvents,
+  canEditWebhooks,
   clientRuntimeCopy,
   spaRefreshCopy,
   translatableAttributesCopy,
@@ -170,6 +180,11 @@ export function SiteAdminForm({
   );
   const [translatableAttributes, setTranslatableAttributes] = useState<string>(() =>
     (initialTranslatableAttributes ?? []).join(", "),
+  );
+  const [webhookUrl, setWebhookUrl] = useState<string>(initialWebhookUrl ?? "");
+  const [webhookSecret, setWebhookSecret] = useState<string>(initialWebhookSecret ?? "");
+  const [webhookEvents, setWebhookEvents] = useState<NotifyWebhookEventType[]>(
+    () => initialWebhookEvents,
   );
 
   const parsedSourceUrl = useMemo(() => parseSourceUrl(sourceUrl), [sourceUrl]);
@@ -257,7 +272,8 @@ export function SiteAdminForm({
     canEditClientRuntime ||
     canEditSpaRefresh ||
     canEditTranslatableAttributes ||
-    canEditProfile;
+    canEditProfile ||
+    canEditWebhooks;
   const basicsInvalid =
     canEditBasics && (!patternIsValid || !sourceUrlValid || resetConfirmationError);
   const localesInvalid = canEditLocales && (targets.length === 0 || hasInvalidAlias);
@@ -278,6 +294,9 @@ export function SiteAdminForm({
   const translatableAttributesHelpText = canEditTranslatableAttributes
     ? translatableAttributesCopy.help
     : `${translatableAttributesCopy.help} ${lockedHelp}`;
+  const webhookHelpText = canEditWebhooks
+    ? "Configure where WebLingo should POST signed events for this site."
+    : `Configure where WebLingo should POST signed events for this site. ${lockedHelp}`;
 
   return (
     <Card>
@@ -778,6 +797,26 @@ export function SiteAdminForm({
               />
             </Field>
           </section>
+
+          <WebhookSettingsFields
+            title="Webhook integrations"
+            description="Send signed lifecycle events to your systems. Clear all events to disable delivery for this site."
+            urlLabel="Webhook URL"
+            urlHelp={webhookHelpText}
+            secretLabel="Signing secret"
+            secretHelp="Use the same shared secret in your receiver to verify WebLingo signatures."
+            eventsLabel="Events"
+            eventsHelp="Choose which event types this site should emit."
+            selectAllLabel="Select all"
+            disableAllLabel="Disable all"
+            webhookUrl={webhookUrl}
+            onWebhookUrlChange={setWebhookUrl}
+            webhookSecret={webhookSecret}
+            onWebhookSecretChange={setWebhookSecret}
+            webhookEvents={webhookEvents}
+            onWebhookEventsChange={setWebhookEvents}
+            canEdit={canEditWebhooks}
+          />
 
           <section className="space-y-3 border-t border-border/60 pt-6">
             <div className="flex items-center justify-between gap-3 border-b border-border/60 pb-3">

--- a/app/dashboard/sites/new/onboarding-form.tsx
+++ b/app/dashboard/sites/new/onboarding-form.tsx
@@ -25,7 +25,12 @@ import { Input } from "@/components/ui/input";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { cn } from "@/lib/utils";
 import { useActionToast } from "@internal/dashboard/use-action-toast";
-import type { SupportedLanguage } from "@internal/dashboard/webhooks";
+import {
+  WEBHOOK_EVENT_TYPES,
+  type NotifyWebhookEventType,
+  type SupportedLanguage,
+} from "@internal/dashboard/webhooks";
+import { WebhookSettingsFields } from "../webhook-settings-fields";
 
 // Avoid SSR for the combobox to prevent Radix Popover ID hydration mismatches.
 const LanguageTagCombobox = dynamic(
@@ -53,6 +58,11 @@ export function OnboardingForm(props: {
   const [sourceUrl, setSourceUrl] = useState("");
   const [subdomainToken, setSubdomainToken] = useState("{lang}");
   const [patternEditing, setPatternEditing] = useState(false);
+  const [webhookUrl, setWebhookUrl] = useState("");
+  const [webhookSecret, setWebhookSecret] = useState("");
+  const [webhookEvents, setWebhookEvents] = useState<NotifyWebhookEventType[]>([
+    ...WEBHOOK_EVENT_TYPES,
+  ]);
 
   useEffect(() => {
     const siteIdRaw = state.meta?.siteId;
@@ -254,6 +264,27 @@ export function OnboardingForm(props: {
                 </Field>
               </div>
             </section>
+
+            <WebhookSettingsFields
+              title="Webhook integrations"
+              description="Optional. Configure a destination to receive signed lifecycle events when translations complete or fail."
+              urlLabel="Webhook URL"
+              urlHelp="Use a publicly reachable HTTPS endpoint that can verify WebLingo signatures."
+              secretLabel="Signing secret"
+              secretHelp="Create a shared secret now or replace it later from site settings."
+              eventsLabel="Events"
+              eventsHelp="Select the lifecycle events this site should emit."
+              selectAllLabel="Select all"
+              disableAllLabel="Disable all"
+              webhookUrl={webhookUrl}
+              onWebhookUrlChange={setWebhookUrl}
+              webhookSecret={webhookSecret}
+              onWebhookSecretChange={setWebhookSecret}
+              webhookEvents={webhookEvents}
+              onWebhookEventsChange={setWebhookEvents}
+              canEdit
+            />
+
             {state.message && !state.ok ? (
               <div
                 className={cn(

--- a/app/dashboard/sites/webhook-settings-fields.tsx
+++ b/app/dashboard/sites/webhook-settings-fields.tsx
@@ -4,9 +4,9 @@ import { Button } from "@/components/ui/button";
 import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { WEBHOOK_EVENT_TYPES, type NotifyWebhookEventType } from "@internal/dashboard/webhooks";
+import { WEBHOOK_EVENT_TYPES, type KnownWebhookEventType } from "@internal/dashboard/webhooks";
 
-const WEBHOOK_EVENT_LABELS: Record<NotifyWebhookEventType, string> = {
+const WEBHOOK_EVENT_LABELS: Record<KnownWebhookEventType, string> = {
   "translation.completed": "Translation completed",
   "translation.failed": "Translation failed",
   "translation.summary": "Translation summary",
@@ -27,8 +27,8 @@ type WebhookSettingsFieldsProps = {
   onWebhookUrlChange: (value: string) => void;
   webhookSecret: string;
   onWebhookSecretChange: (value: string) => void;
-  webhookEvents: NotifyWebhookEventType[];
-  onWebhookEventsChange: (value: NotifyWebhookEventType[]) => void;
+  webhookEvents: KnownWebhookEventType[];
+  onWebhookEventsChange: (value: KnownWebhookEventType[]) => void;
   canEdit: boolean;
 };
 
@@ -55,7 +55,7 @@ export function WebhookSettingsFields({
   const anySelected = webhookEvents.length > 0;
   const webhookEventsJson = JSON.stringify(webhookEvents);
 
-  function toggleEvent(eventType: NotifyWebhookEventType): void {
+  function toggleEvent(eventType: KnownWebhookEventType): void {
     if (webhookEvents.includes(eventType)) {
       onWebhookEventsChange(webhookEvents.filter((entry) => entry !== eventType));
       return;

--- a/app/dashboard/sites/webhook-settings-fields.tsx
+++ b/app/dashboard/sites/webhook-settings-fields.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Field } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { WEBHOOK_EVENT_TYPES, type NotifyWebhookEventType } from "@internal/dashboard/webhooks";
+
+const WEBHOOK_EVENT_LABELS: Record<NotifyWebhookEventType, string> = {
+  "translation.completed": "Translation completed",
+  "translation.failed": "Translation failed",
+  "translation.summary": "Translation summary",
+};
+
+type WebhookSettingsFieldsProps = {
+  title: string;
+  description: string;
+  urlLabel: string;
+  urlHelp: string;
+  secretLabel: string;
+  secretHelp: string;
+  eventsLabel: string;
+  eventsHelp: string;
+  selectAllLabel: string;
+  disableAllLabel: string;
+  webhookUrl: string;
+  onWebhookUrlChange: (value: string) => void;
+  webhookSecret: string;
+  onWebhookSecretChange: (value: string) => void;
+  webhookEvents: NotifyWebhookEventType[];
+  onWebhookEventsChange: (value: NotifyWebhookEventType[]) => void;
+  canEdit: boolean;
+};
+
+export function WebhookSettingsFields({
+  title,
+  description,
+  urlLabel,
+  urlHelp,
+  secretLabel,
+  secretHelp,
+  eventsLabel,
+  eventsHelp,
+  selectAllLabel,
+  disableAllLabel,
+  webhookUrl,
+  onWebhookUrlChange,
+  webhookSecret,
+  onWebhookSecretChange,
+  webhookEvents,
+  onWebhookEventsChange,
+  canEdit,
+}: WebhookSettingsFieldsProps) {
+  const allSelected = webhookEvents.length === WEBHOOK_EVENT_TYPES.length;
+  const anySelected = webhookEvents.length > 0;
+  const webhookEventsJson = JSON.stringify(webhookEvents);
+
+  function toggleEvent(eventType: NotifyWebhookEventType): void {
+    if (webhookEvents.includes(eventType)) {
+      onWebhookEventsChange(webhookEvents.filter((entry) => entry !== eventType));
+      return;
+    }
+    onWebhookEventsChange([...webhookEvents, eventType]);
+  }
+
+  return (
+    <section className="space-y-5 border-t border-border/60 pt-6">
+      <div className="border-b border-border/60 pb-3">
+        <div className="flex items-start gap-3">
+          <span className="mt-1 h-5 w-1 rounded-full bg-primary/50" aria-hidden="true" />
+          <div className="space-y-1">
+            <h3 className="text-base font-semibold">{title}</h3>
+            <p className="text-sm text-muted-foreground">{description}</p>
+          </div>
+        </div>
+      </div>
+
+      <input name="webhookEvents" type="hidden" value={webhookEventsJson} />
+
+      <Field label={urlLabel} htmlFor="webhookUrl" description={urlHelp}>
+        <Input
+          id="webhookUrl"
+          name="webhookUrl"
+          type="url"
+          value={webhookUrl}
+          onChange={(event) => onWebhookUrlChange(event.target.value)}
+          placeholder="https://hooks.example.com/weblingo"
+          disabled={!canEdit}
+          autoComplete="off"
+        />
+      </Field>
+
+      <Field label={secretLabel} htmlFor="webhookSecret" description={secretHelp}>
+        <Input
+          id="webhookSecret"
+          name="webhookSecret"
+          type="password"
+          value={webhookSecret}
+          onChange={(event) => onWebhookSecretChange(event.target.value)}
+          placeholder="whsec_..."
+          disabled={!canEdit}
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </Field>
+
+      <Field
+        label={eventsLabel}
+        description={
+          <span className="block">
+            {eventsHelp}
+            {!anySelected
+              ? " Webhook delivery is disabled until at least one event is selected."
+              : ""}
+          </span>
+        }
+      >
+        <div className="space-y-3 rounded-md border border-border/60 bg-muted/20 px-4 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={!canEdit || allSelected}
+              onClick={() => onWebhookEventsChange([...WEBHOOK_EVENT_TYPES])}
+            >
+              {selectAllLabel}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              disabled={!canEdit || !anySelected}
+              onClick={() => onWebhookEventsChange([])}
+            >
+              {disableAllLabel}
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              {webhookEvents.length}/{WEBHOOK_EVENT_TYPES.length} selected
+            </span>
+          </div>
+
+          <div className="grid gap-2 md:grid-cols-3">
+            {WEBHOOK_EVENT_TYPES.map((eventType) => {
+              const checked = webhookEvents.includes(eventType);
+              return (
+                <label
+                  key={eventType}
+                  className={cn(
+                    "flex items-center gap-3 rounded-md border px-3 py-2 text-sm transition-colors",
+                    checked ? "border-primary/30 bg-primary/5" : "border-border/60 bg-background",
+                    !canEdit ? "cursor-not-allowed opacity-70" : "cursor-pointer",
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleEvent(eventType)}
+                    disabled={!canEdit}
+                    className="h-4 w-4 rounded border-border text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  />
+                  <span className="flex flex-col">
+                    <span className="font-medium text-foreground">
+                      {WEBHOOK_EVENT_LABELS[eventType]}
+                    </span>
+                    <span className="text-xs text-muted-foreground">{eventType}</span>
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      </Field>
+    </section>
+  );
+}

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -1876,6 +1876,19 @@
             ],
             "type": "string"
           },
+          "webhookEvents": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/NotifyWebhookEventType"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "webhookSecret": {
             "type": [
               "string",
@@ -3846,6 +3859,14 @@
         ],
         "type": "object"
       },
+      "NotifyWebhookEventType": {
+        "enum": [
+          "translation.completed",
+          "translation.failed",
+          "translation.summary"
+        ],
+        "type": "string"
+      },
       "PipelineStage": {
         "enum": [
           "crawl",
@@ -4818,6 +4839,12 @@
             ],
             "type": "string"
           },
+          "webhookEvents": {
+            "items": {
+              "$ref": "#/components/schemas/NotifyWebhookEventType"
+            },
+            "type": "array"
+          },
           "webhookSecret": {
             "type": [
               "string",
@@ -4838,6 +4865,7 @@
           "status",
           "servingMode",
           "maxLocales",
+          "webhookEvents",
           "locales",
           "domains"
         ],
@@ -5468,6 +5496,12 @@
             ],
             "type": "string"
           },
+          "webhookEvents": {
+            "items": {
+              "$ref": "#/components/schemas/NotifyWebhookEventType"
+            },
+            "type": "array"
+          },
           "webhookSecret": {
             "type": [
               "string",
@@ -5490,7 +5524,8 @@
           "maxLocales",
           "servingMode",
           "sourceUrl",
-          "status"
+          "status",
+          "webhookEvents"
         ],
         "type": "object"
       },
@@ -6006,6 +6041,19 @@
               "translated"
             ],
             "type": "string"
+          },
+          "webhookEvents": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/NotifyWebhookEventType"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "webhookSecret": {
             "type": [
@@ -6863,7 +6911,10 @@
                     "maxLocales": 1,
                     "servingMode": "strict",
                     "sourceUrl": "string",
-                    "status": "active"
+                    "status": "active",
+                    "webhookEvents": [
+                      "translation.completed"
+                    ]
                   }
                 },
                 "schema": {
@@ -8642,7 +8693,10 @@
                   "maxLocales": 1,
                   "servingMode": "strict",
                   "sourceUrl": "string",
-                  "status": "active"
+                  "status": "active",
+                  "webhookEvents": [
+                    "translation.completed"
+                  ]
                 },
                 "schema": {
                   "$ref": "#/components/schemas/SiteWithCrawlStatus"
@@ -8740,7 +8794,10 @@
                   "maxLocales": 1,
                   "servingMode": "strict",
                   "sourceUrl": "string",
-                  "status": "active"
+                  "status": "active",
+                  "webhookEvents": [
+                    "translation.completed"
+                  ]
                 },
                 "schema": {
                   "$ref": "#/components/schemas/Site"
@@ -8854,7 +8911,10 @@
                   "maxLocales": 1,
                   "servingMode": "strict",
                   "sourceUrl": "string",
-                  "status": "active"
+                  "status": "active",
+                  "webhookEvents": [
+                    "translation.completed"
+                  ]
                 },
                 "schema": {
                   "$ref": "#/components/schemas/Site"
@@ -9967,7 +10027,10 @@
                     "maxLocales": 1,
                     "servingMode": "strict",
                     "sourceUrl": "string",
-                    "status": "active"
+                    "status": "active",
+                    "webhookEvents": [
+                      "translation.completed"
+                    ]
                   }
                 },
                 "schema": {

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -1877,17 +1877,10 @@
             "type": "string"
           },
           "webhookEvents": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/NotifyWebhookEventType"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "items": {
+              "$ref": "#/components/schemas/NotifyWebhookEventType"
+            },
+            "type": "array"
           },
           "webhookSecret": {
             "type": [
@@ -6043,17 +6036,10 @@
             "type": "string"
           },
           "webhookEvents": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/NotifyWebhookEventType"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "items": {
+              "$ref": "#/components/schemas/NotifyWebhookEventType"
+            },
+            "type": "array"
           },
           "webhookSecret": {
             "type": [

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -6,8 +6,8 @@
       "sha256": "ae709eeb6bb93559601e672fd883bf40cf01050b5ab66c2c96eb5b7a90b2e471"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 343517,
-      "sha256": "8bb92edfde1611ca6a7ace4b311a0f9d1d2f4fdcb6234b9e13472c564c9b2bf6"
+      "bytes": 343219,
+      "sha256": "380bb863dc324674d9fda8290cc18f8f6358f6d04c6c4bd11344d2f4bb789c3a"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
       "bytes": 7095,
@@ -28,8 +28,8 @@
       "sha256": "0fe451fc26f0964c79ba679a0432cd8eaa132cc56132606d7493ccbced996571"
     },
     "docs/reference/openapi.json": {
-      "bytes": 269937,
-      "sha256": "d1b9b67c39a32d4ac6b6b363f75eec99579df0f8b0a6461c1840d628ac06f639"
+      "bytes": 269715,
+      "sha256": "f284c9127ddc86baf025d204b5bdbd4d70cf3024d21618f4cb2eba445cbc1880"
     }
   },
   "sourceRepoCommitTimestamp": "2026-04-20T13:55:27+09:00",

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-04-16T23:06:56+09:00",
+  "generatedAt": "2026-04-20T11:44:18+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
       "sha256": "ae709eeb6bb93559601e672fd883bf40cf01050b5ab66c2c96eb5b7a90b2e471"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 341743,
-      "sha256": "2b5c52aa10d3ca4be4ee8fa9bf3077b235953a271f89f844c3f935de76969598"
+      "bytes": 343517,
+      "sha256": "8bb92edfde1611ca6a7ace4b311a0f9d1d2f4fdcb6234b9e13472c564c9b2bf6"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
       "bytes": 7095,
@@ -28,11 +28,11 @@
       "sha256": "0fe451fc26f0964c79ba679a0432cd8eaa132cc56132606d7493ccbced996571"
     },
     "docs/reference/openapi.json": {
-      "bytes": 268591,
-      "sha256": "10c803d62ecd517c2bba6af7ad3fb69183388620e7037509f2c70b31411bd133"
+      "bytes": 269937,
+      "sha256": "d1b9b67c39a32d4ac6b6b363f75eec99579df0f8b0a6461c1840d628ac06f639"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-16T23:06:56+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-20T11:44:18+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "f3c2131cd3cfb86056a08d5517e1cf7a59f686f8"
+  "sourceRepoSha": "c5797cc08ce20d2e48aed440193e0dcc1efee366"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-20T11:44:18+09:00",
+  "generatedAt": "2026-04-20T13:55:27+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
@@ -32,7 +32,7 @@
       "sha256": "d1b9b67c39a32d4ac6b6b363f75eec99579df0f8b0a6461c1840d628ac06f639"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-20T11:44:18+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-20T13:55:27+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "c5797cc08ce20d2e48aed440193e0dcc1efee366"
+  "sourceRepoSha": "9cc9faa491091c7c28a6c1cb192e7b286dfd7acf"
 }

--- a/content/docs/api-reference.mdx
+++ b/content/docs/api-reference.mdx
@@ -46,6 +46,10 @@ Additional dashboard-oriented endpoints that are commonly used during rollout:
 - `GET /api/sites/{siteId}/translation-summaries` (`sites.translationSummaries.list`)
 - `GET /api/sites/{siteId}/switcher-snippets` (`sites.switcherSnippets.get`)
 
+Webhook settings are managed from the site admin screen and are documented separately:
+
+- [Webhooks](../webhooks)
+
 ## OpenAPI Explorer
 
 <RedocApiReference />

--- a/content/docs/index.ts
+++ b/content/docs/index.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from "react";
 
 import GettingStarted, { metadata as gettingStartedMeta } from "./getting-started.mdx";
 import SiteSetup, { metadata as siteSetupMeta } from "./site-setup.mdx";
+import Webhooks, { metadata as webhooksMeta } from "./webhooks.mdx";
 import TranslationPipeline, {
   metadata as translationPipelineMeta,
 } from "./translation-pipeline.mdx";
@@ -32,6 +33,14 @@ const docEntries: DocEntry[] = [
     section: siteSetupMeta.section ?? "Basics",
     order: siteSetupMeta.order ?? 0,
     component: SiteSetup,
+  },
+  {
+    slug: ["webhooks"],
+    title: webhooksMeta.title,
+    description: webhooksMeta.description ?? "",
+    section: webhooksMeta.section ?? "Pipeline",
+    order: webhooksMeta.order ?? 0,
+    component: Webhooks,
   },
   {
     slug: ["translation-pipeline"],

--- a/content/docs/site-setup.mdx
+++ b/content/docs/site-setup.mdx
@@ -57,4 +57,5 @@ existing host.
 
 - [Getting Started](../getting-started)
 - [Translation Pipeline](../translation-pipeline)
+- [Webhooks](../webhooks)
 - [API Reference](../api-reference)

--- a/content/docs/translation-pipeline.mdx
+++ b/content/docs/translation-pipeline.mdx
@@ -51,6 +51,8 @@ Every rollout follows the same deterministic flow so you can re-run safely and t
     (`sites.locales.translationSummary.put`)
 - Read range summaries:
   - `GET /api/sites/{siteId}/translation-summaries` (`sites.translationSummaries.list`)
+- Webhook notifications for run completion/failure:
+  - [Webhooks](../webhooks)
 
 ## Dashboard automation controls
 
@@ -65,4 +67,5 @@ Every rollout follows the same deterministic flow so you can re-run safely and t
 
 - [Getting Started](../getting-started)
 - [Domain + CNAME Setup](../site-setup)
+- [Webhooks](../webhooks)
 - [API Reference](../api-reference)

--- a/content/docs/webhooks.mdx
+++ b/content/docs/webhooks.mdx
@@ -8,7 +8,7 @@ export const metadata = {
 Webhooks let WebLingo notify your system when a site emits important translation events.
 They are site-scoped, signed, and intentionally simple: one destination per site for now.
 
-## Supported events
+## Currently supported events
 
 - `translation.completed`
 - `translation.failed`
@@ -24,9 +24,9 @@ From the site admin page, set:
 
 Behavior to know:
 
-- If `webhookEvents` is omitted, WebLingo enables all supported events.
+- If `webhookEvents` is omitted, WebLingo enables all currently supported events.
 - If `webhookEvents` is an empty array, delivery is disabled for that site.
-- The dashboard uses the same shape for new site setup and later edits.
+- Only currently supported events are configurable in the UI.
 
 ## Delivery contract
 

--- a/content/docs/webhooks.mdx
+++ b/content/docs/webhooks.mdx
@@ -1,0 +1,94 @@
+export const metadata = {
+  title: "Webhooks",
+  description: "Configure signed webhook delivery for translation events.",
+  section: "Pipeline",
+  order: 2,
+};
+
+Webhooks let WebLingo notify your system when a site emits important translation events.
+They are site-scoped, signed, and intentionally simple: one destination per site for now.
+
+## Supported events
+
+- `translation.completed`
+- `translation.failed`
+- `translation.summary`
+
+## Configuration
+
+From the site admin page, set:
+
+- Webhook URL
+- Signing secret
+- Event allowlist
+
+Behavior to know:
+
+- If `webhookEvents` is omitted, WebLingo enables all supported events.
+- If `webhookEvents` is an empty array, delivery is disabled for that site.
+- The dashboard uses the same shape for new site setup and later edits.
+
+## Delivery contract
+
+Every delivery is a signed `POST` to your endpoint.
+
+Headers include:
+
+- `X-WebLingo-Delivery-Id`
+- `X-WebLingo-Timestamp`
+- `X-WebLingo-Signature`
+- `X-WebLingo-Signature-V2`
+
+Use the signature headers to verify the payload and reject replays outside your allowed time
+window. WebLingo delivers events at least once, so your receiver should be idempotent.
+
+## What the payload looks like
+
+The exact JSON body depends on the event, but the receiver should expect:
+
+- an event name
+- a delivery id
+- a timestamp
+- site context
+- event-specific data
+
+Example shape:
+
+```json
+{
+  "event": "translation.completed",
+  "deliveryId": "del_123",
+  "timestamp": "2026-04-20T10:00:00.000Z",
+  "siteId": "site_123",
+  "payload": {
+    "targetLang": "fr",
+    "runId": "run_123"
+  }
+}
+```
+
+## Setup checklist
+
+1. Create or edit the site.
+2. Enter the webhook URL.
+3. Set a signing secret.
+4. Select the events you want.
+5. Verify your receiver checks the signature headers.
+6. Make the receiver idempotent.
+
+## Troubleshooting
+
+- No events arrive:
+  - confirm the URL is HTTPS and publicly reachable
+  - confirm at least one event is selected
+  - confirm the site is active
+- Duplicate deliveries:
+  - this is expected with at-least-once delivery; dedupe by delivery id
+- Signature mismatch:
+  - confirm the shared secret matches the site setting
+
+## Related docs
+
+- [Site Setup](../site-setup)
+- [Translation Pipeline](../translation-pipeline)
+- [API Reference](../api-reference)

--- a/docs/backend/DASHBOARD_SPECS.md
+++ b/docs/backend/DASHBOARD_SPECS.md
@@ -58,6 +58,7 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
   - `servingMode`: `"strict" | "tolerant"`.
   - `maxLocales`: number or `null` (null = no cap).
   - `webhookUrl`, `webhookSecret`: string or `null`.
+  - `webhookEvents`: `["translation.completed", "translation.failed", "translation.summary"]` or an empty array when delivery is disabled.
   - `routeConfig`: `RouteConfig` or `null`.
   - `locales`: `[{ sourceLang, targetLang, alias?, serveEnabled }]`.
   - `domains`: `[{ domain, status, verificationToken, verifiedAt?, lastCheckedAt?, dnsInstructions?, cloudflare? }]`.
@@ -173,7 +174,7 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
 - Payload (required): `{ sourceUrl, sourceLang, targetLangs: [...], subdomainPattern, servingMode, maxLocales }`.
   - `subdomainPattern` must contain `{lang}`; it can be a bare host (`{lang}.example.com`) or include scheme/path (`https://www.example.com/{lang}/docs`). Hostnames derived from this pattern seed `site_domains`; path segments become `routePrefix` per locale.
   - Optional: `siteProfile` (object or `null`), `localeAliases` map of `{ [targetLang]: "alias" | null }` to override the `{lang}` token per locale (lowercase letters/numbers/hyphens only).
-  - Optional: `crawlCaptureMode`, `clientRuntimeEnabled`, `translatableAttributes`, `spaRefresh`, `webhookUrl`, `webhookSecret`.
+  - Optional: `crawlCaptureMode`, `clientRuntimeEnabled`, `translatableAttributes`, `spaRefresh`, `webhookUrl`, `webhookSecret`, `webhookEvents`.
   - `maxLocales` is a positive integer per site or `null` (no cap). `targetLangs` cannot exceed `maxLocales` when provided.
 - Behavior: validates `sourceUrl` (HTTP 200), reads robots/sitemaps to seed initial pages, creates site + locales + route config, inserts domain records with verification tokens, and sets the site to `inactive` until activation.
 - Response `201`: `{ ...site, crawlStatus }` (typically `{ enqueued: false }` until activation).
@@ -209,12 +210,15 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
 
 `PATCH /api/sites/:id`
 
-- Payload (any subset): `{ sourceUrl?, targetLangs?, subdomainPattern?, localeAliases?, status? ("active"|"inactive"), siteProfile? (object|null), servingMode?, maxLocales?, crawlCaptureMode?, clientRuntimeEnabled?, translatableAttributes?, spaRefresh?, webhookUrl?, webhookSecret? }`.
+- Payload (any subset): `{ sourceUrl?, targetLangs?, subdomainPattern?, localeAliases?, status? ("active"|"inactive"), siteProfile? (object|null), servingMode?, maxLocales?, crawlCaptureMode?, clientRuntimeEnabled?, translatableAttributes?, spaRefresh?, webhookUrl?, webhookSecret?, webhookEvents? }`.
 - Behavior: updates site fields; upserts locales (removes absent target langs), rebuilds route config/domains from the pattern (new domains get fresh verification tokens; removed hosts are deleted), updates siteProfile (set to `null` to clear).
   - Enforces `targetLangs.length <= maxLocales` when `maxLocales` is set.
   - **Warning:** changing `sourceUrl` is destructive. It wipes pages/translations/deployments, resets status to `inactive`, seeds pages from robots/sitemaps, and requires reactivation before crawling. UI should require explicit confirmation.
   - Activating a site (`status: "active"`) requires at least one verified domain and triggers a crawl.
 - Response `200`: updated `Site`.
+
+- Website mapping:
+  - `/dashboard/sites/:id/admin` and the onboarding form should expose `webhookUrl`, `webhookSecret`, and the event allowlist together as one integrations block.
 
 `POST /api/sites/:id/crawl`
 

--- a/docs/backend/DASHBOARD_SPECS.md
+++ b/docs/backend/DASHBOARD_SPECS.md
@@ -58,7 +58,7 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
   - `servingMode`: `"strict" | "tolerant"`.
   - `maxLocales`: number or `null` (null = no cap).
   - `webhookUrl`, `webhookSecret`: string or `null`.
-  - `webhookEvents`: `["translation.completed", "translation.failed", "translation.summary"]` or an empty array when delivery is disabled.
+  - `webhookEvents`: array of currently supported event names, or an empty array when delivery is disabled.
   - `routeConfig`: `RouteConfig` or `null`.
   - `locales`: `[{ sourceLang, targetLang, alias?, serveEnabled }]`.
   - `domains`: `[{ domain, status, verificationToken, verifiedAt?, lastCheckedAt?, dnsInstructions?, cloudflare? }]`.
@@ -219,6 +219,7 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
 
 - Website mapping:
   - `/dashboard/sites/:id/admin` and the onboarding form should expose `webhookUrl`, `webhookSecret`, and the event allowlist together as one integrations block.
+  - The dashboard should preserve raw webhook event values from the API, even if the current UI cannot label them yet.
 
 `POST /api/sites/:id/crawl`
 

--- a/internal/dashboard/data.test.ts
+++ b/internal/dashboard/data.test.ts
@@ -41,6 +41,7 @@ function makeDashboardPayload(): SiteDashboardResponse {
       servingMode: "strict",
       maxLocales: null,
       siteProfile: null,
+      webhookEvents: ["translation.completed", "translation.failed", "translation.summary"],
       locales: [],
       domains: [],
       latestCrawlRun: null,

--- a/internal/dashboard/site-settings.test.ts
+++ b/internal/dashboard/site-settings.test.ts
@@ -1,4 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test_123";
+  process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
+  process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://posthog.example.com";
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.example.com";
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "sb_anon_key";
+  process.env.NEXT_PUBLIC_WEBHOOKS_API_BASE = "https://api.weblingo.example/api";
+  process.env.NEXT_PUBLIC_WEBHOOKS_API_TIMEOUT_MS = "15000";
+  return null;
+});
 
 import {
   REQUIRED_FIELDS_MESSAGE,
@@ -33,6 +45,7 @@ function makeAccess(overrides: Partial<SiteSettingsAccess> = {}): SiteSettingsAc
     canEditSpaRefresh: false,
     canEditTranslatableAttributes: false,
     canEditProfile: false,
+    canEditWebhooks: false,
     ...overrides,
   };
 }
@@ -47,6 +60,7 @@ describe("deriveSiteSettingsAccess", () => {
         "crawl_capture_mode",
         "client_runtime_toggle",
         "translatable_attributes",
+        "edit",
       ]),
       mutationsAllowed: false,
     });
@@ -58,6 +72,7 @@ describe("deriveSiteSettingsAccess", () => {
     expect(access.canEditClientRuntime).toBe(false);
     expect(access.canEditSpaRefresh).toBe(false);
     expect(access.canEditTranslatableAttributes).toBe(false);
+    expect(access.canEditWebhooks).toBe(false);
   });
 
   it("enables section access per feature when billing is ok", () => {
@@ -69,6 +84,7 @@ describe("deriveSiteSettingsAccess", () => {
         "crawl_capture_mode",
         "client_runtime_toggle",
         "translatable_attributes",
+        "edit",
       ]),
       mutationsAllowed: true,
     });
@@ -79,6 +95,7 @@ describe("deriveSiteSettingsAccess", () => {
     expect(access.canEditClientRuntime).toBe(true);
     expect(access.canEditSpaRefresh).toBe(true);
     expect(access.canEditTranslatableAttributes).toBe(true);
+    expect(access.canEditWebhooks).toBe(true);
   });
 });
 
@@ -179,6 +196,34 @@ describe("buildSiteSettingsUpdatePayload", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toMatch(/data-\* and aria-\*/i);
+    }
+  });
+
+  it("parses webhook settings and allows clearing the allowlist", () => {
+    const formData = new FormData();
+    formData.set("webhookUrl", "https://hooks.example.com/weblingo");
+    formData.set("webhookSecret", "secret-123");
+    formData.set("webhookEvents", JSON.stringify(["translation.completed", "translation.summary"]));
+    const result = buildSiteSettingsUpdatePayload(formData, makeAccess({ canEditWebhooks: true }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload).toEqual({
+        webhookUrl: "https://hooks.example.com/weblingo",
+        webhookSecret: "secret-123",
+        webhookEvents: ["translation.completed", "translation.summary"],
+      });
+    }
+  });
+
+  it("treats an empty webhook allowlist as explicit disable", () => {
+    const formData = new FormData();
+    formData.set("webhookUrl", "https://hooks.example.com/weblingo");
+    formData.set("webhookSecret", "secret-123");
+    formData.set("webhookEvents", JSON.stringify([]));
+    const result = buildSiteSettingsUpdatePayload(formData, makeAccess({ canEditWebhooks: true }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.webhookEvents).toEqual([]);
     }
   });
 });

--- a/internal/dashboard/site-settings.test.ts
+++ b/internal/dashboard/site-settings.test.ts
@@ -215,6 +215,18 @@ describe("buildSiteSettingsUpdatePayload", () => {
     }
   });
 
+  it("rejects unrecognized webhook events when parsing updates", () => {
+    const formData = new FormData();
+    formData.set("webhookUrl", "https://hooks.example.com/weblingo");
+    formData.set("webhookSecret", "secret-123");
+    formData.set("webhookEvents", JSON.stringify(["translation.completed", "translation.beta"]));
+    const result = buildSiteSettingsUpdatePayload(formData, makeAccess({ canEditWebhooks: true }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/unsupported event/i);
+    }
+  });
+
   it("treats an empty webhook allowlist as explicit disable", () => {
     const formData = new FormData();
     formData.set("webhookUrl", "https://hooks.example.com/weblingo");

--- a/internal/dashboard/site-settings.ts
+++ b/internal/dashboard/site-settings.ts
@@ -1,3 +1,5 @@
+import { WEBHOOK_EVENT_TYPES, type NotifyWebhookEventType } from "./webhooks";
+
 export type SiteSettingsFeature =
   | "edit"
   | "locale_update"
@@ -34,6 +36,7 @@ export type SiteSettingsAccess = {
   canEditSpaRefresh: boolean;
   canEditTranslatableAttributes: boolean;
   canEditProfile: boolean;
+  canEditWebhooks: boolean;
 };
 
 export type SiteSettingsUpdatePayload = Partial<{
@@ -52,6 +55,9 @@ export type SiteSettingsUpdatePayload = Partial<{
     errorFallback?: SpaRefreshFallback;
     enableSectionScope?: boolean;
   };
+  webhookUrl: string | null;
+  webhookSecret: string | null;
+  webhookEvents: NotifyWebhookEventType[];
 }>;
 
 export type SiteSettingsUpdateResult =
@@ -81,6 +87,7 @@ export function deriveSiteSettingsAccess(options: {
   const canEditTranslatableAttributes =
     options.has({ allFeatures: ["edit", "translatable_attributes"] }) && !billingBlocked;
   const canEditProfile = options.has({ feature: "edit" }) && !billingBlocked;
+  const canEditWebhooks = options.has({ feature: "edit" }) && !billingBlocked;
   return {
     billingBlocked,
     canEditBasics,
@@ -91,7 +98,37 @@ export function deriveSiteSettingsAccess(options: {
     canEditSpaRefresh,
     canEditTranslatableAttributes,
     canEditProfile,
+    canEditWebhooks,
   };
+}
+
+export function parseWebhookEvents(
+  raw: string | null | undefined,
+): NotifyWebhookEventType[] | string {
+  const normalized = typeof raw === "string" ? raw.trim() : "";
+  if (!normalized) {
+    return [...WEBHOOK_EVENT_TYPES];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(normalized);
+  } catch {
+    return "Webhook events must be valid JSON.";
+  }
+  if (!Array.isArray(parsed)) {
+    return "Webhook events must be a JSON array.";
+  }
+  const events: NotifyWebhookEventType[] = [];
+  for (const entry of parsed) {
+    if (
+      typeof entry !== "string" ||
+      !WEBHOOK_EVENT_TYPES.includes(entry as NotifyWebhookEventType)
+    ) {
+      return "Webhook events must only include supported events.";
+    }
+    events.push(entry as NotifyWebhookEventType);
+  }
+  return Array.from(new Set(events));
 }
 
 export function buildSiteSettingsUpdatePayload(
@@ -112,6 +149,8 @@ export function buildSiteSettingsUpdatePayload(
   const hasSpaRefresh = formData.has("spaRefreshEnabled");
   const hasTranslatableAttributes = formData.has("translatableAttributes");
   const hasProfile = formData.has("siteProfile");
+  const hasWebhooks =
+    formData.has("webhookUrl") || formData.has("webhookSecret") || formData.has("webhookEvents");
 
   if (hasBasics && !access.canEditBasics) {
     return { ok: false, error: "Source URL and routing are locked for this account." };
@@ -136,6 +175,9 @@ export function buildSiteSettingsUpdatePayload(
   }
   if (hasProfile && !access.canEditProfile) {
     return { ok: false, error: "Site profile updates are locked for this account." };
+  }
+  if (hasWebhooks && !access.canEditWebhooks) {
+    return { ok: false, error: "Webhook settings are locked for this account." };
   }
 
   if (hasBasics) {
@@ -262,6 +304,32 @@ export function buildSiteSettingsUpdatePayload(
       return { ok: false, error: "Site profile must be a non-empty JSON object." };
     }
     payload.siteProfile = siteProfile;
+  }
+
+  if (hasWebhooks) {
+    const webhookUrlRaw = formData.get("webhookUrl")?.toString().trim() ?? "";
+    if (webhookUrlRaw) {
+      try {
+        const url = new URL(webhookUrlRaw);
+        if (url.protocol !== "https:") {
+          return { ok: false, error: "Webhook URL must use https://." };
+        }
+        payload.webhookUrl = url.toString();
+      } catch {
+        return { ok: false, error: "Webhook URL must be a valid HTTPS URL." };
+      }
+    } else {
+      payload.webhookUrl = null;
+    }
+
+    const webhookSecretRaw = formData.get("webhookSecret")?.toString().trim() ?? "";
+    payload.webhookSecret = webhookSecretRaw.length > 0 ? webhookSecretRaw : null;
+
+    const webhookEvents = parseWebhookEvents(formData.get("webhookEvents")?.toString());
+    if (typeof webhookEvents === "string") {
+      return { ok: false, error: webhookEvents };
+    }
+    payload.webhookEvents = webhookEvents;
   }
 
   if (Object.keys(payload).length === 0) {

--- a/internal/dashboard/site-settings.ts
+++ b/internal/dashboard/site-settings.ts
@@ -107,7 +107,7 @@ export function parseWebhookEvents(
 ): NotifyWebhookEventType[] | string {
   const normalized = typeof raw === "string" ? raw.trim() : "";
   if (!normalized) {
-    return [...WEBHOOK_EVENT_TYPES];
+    return [];
   }
   let parsed: unknown;
   try {
@@ -120,15 +120,21 @@ export function parseWebhookEvents(
   }
   const events: NotifyWebhookEventType[] = [];
   for (const entry of parsed) {
-    if (
-      typeof entry !== "string" ||
-      !WEBHOOK_EVENT_TYPES.includes(entry as NotifyWebhookEventType)
-    ) {
-      return "Webhook events must only include supported events.";
+    if (typeof entry !== "string") {
+      return "Webhook events must be an array of strings.";
     }
-    events.push(entry as NotifyWebhookEventType);
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      return "Webhook events must not contain empty strings.";
+    }
+    if (!WEBHOOK_EVENT_TYPES.includes(trimmed as NotifyWebhookEventType)) {
+      return `Webhook events contains an unsupported event: ${trimmed}.`;
+    }
+    if (!events.includes(trimmed as NotifyWebhookEventType)) {
+      events.push(trimmed as NotifyWebhookEventType);
+    }
   }
-  return Array.from(new Set(events));
+  return events;
 }
 
 export function buildSiteSettingsUpdatePayload(

--- a/internal/dashboard/webhooks.openapi-contract.test.ts
+++ b/internal/dashboard/webhooks.openapi-contract.test.ts
@@ -563,6 +563,7 @@ describe("webhooks OpenAPI contract (dashboard client)", () => {
         siteProfile: null,
         webhookUrl: null,
         webhookSecret: null,
+        webhookEvents: ["translation.completed", "translation.failed", "translation.summary"],
         locales: [
           {
             sourceLang: "en",

--- a/internal/dashboard/webhooks.timeout.test.ts
+++ b/internal/dashboard/webhooks.timeout.test.ts
@@ -45,6 +45,7 @@ describe("webhooks request wrapper", () => {
         servingMode: "strict",
         maxLocales: null,
         siteProfile: null,
+        webhookEvents: ["translation.completed", "translation.failed", "translation.summary"],
         locales: [],
         domains: [],
         latestCrawlRun: null,
@@ -106,6 +107,7 @@ describe("webhooks request wrapper", () => {
             servingMode: "strict",
             maxLocales: null,
             siteProfile: null,
+            webhookEvents: ["translation.completed", "translation.failed", "translation.summary"],
             locales: [
               {
                 sourceLang: "en",
@@ -174,6 +176,7 @@ describe("webhooks request wrapper", () => {
             servingMode: "strict",
             maxLocales: null,
             siteProfile: null,
+            webhookEvents: ["translation.completed", "translation.failed", "translation.summary"],
             locales: [],
             domains: [],
             latestCrawlRun: null,
@@ -236,6 +239,7 @@ describe("webhooks request wrapper", () => {
             servingMode: "strict",
             maxLocales: null,
             siteProfile: null,
+            webhookEvents: ["translation.completed", "translation.failed", "translation.summary"],
             locales: [],
             domains: [],
             latestCrawlRun: null,
@@ -492,6 +496,7 @@ describe("webhooks request wrapper", () => {
         subdomainPattern: "https://{lang}.autotrim.com",
         servingMode: "strict",
         maxLocales: null,
+        webhookEvents: ["translation.completed", "translation.failed", "translation.summary"],
       },
       showcase: {
         defaultLang: "fr",

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -25,6 +25,7 @@ export const WEBHOOK_EVENT_TYPES = [
   "translation.failed",
   "translation.summary",
 ] as const;
+export type KnownWebhookEventType = (typeof WEBHOOK_EVENT_TYPES)[number];
 
 type RequestTimeoutProfile = keyof typeof REQUEST_TIMEOUT_MS;
 

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -20,6 +20,11 @@ const REQUEST_TIMEOUT_MS = {
 const DASHBOARD_E2E_MOCK_SITE_ID = "site-smoke-1";
 const DASHBOARD_E2E_MOCK_ACCOUNT_ID = "acct-e2e-smoke";
 const DASHBOARD_E2E_MOCK_SOURCE_URL = "https://source.example.test";
+export const WEBHOOK_EVENT_TYPES = [
+  "translation.completed",
+  "translation.failed",
+  "translation.summary",
+] as const;
 
 type RequestTimeoutProfile = keyof typeof REQUEST_TIMEOUT_MS;
 
@@ -72,6 +77,8 @@ const supportedLanguagesResponseSchema = z
     languages: z.array(supportedLanguageSchema),
   })
   .strict();
+
+const webhookEventTypeSchema = z.enum(WEBHOOK_EVENT_TYPES);
 
 const dnsInstructionsSchema = z
   .object({
@@ -164,6 +171,7 @@ const siteSchema = z.object({
   siteProfile: siteProfileSchema,
   webhookUrl: z.string().nullable().optional(),
   webhookSecret: z.string().nullable().optional(),
+  webhookEvents: z.array(webhookEventTypeSchema),
   locales: z.array(
     z.object({
       sourceLang: z.string(),
@@ -1054,6 +1062,7 @@ export type CrawlCaptureMode = z.infer<typeof crawlCaptureModeSchema>;
 export type SpaRefreshSettings = z.infer<typeof spaRefreshSchema>;
 export type SpaRefreshFallback = z.infer<typeof spaRefreshFallbackSchema>;
 export type CrawlStatus = z.infer<typeof crawlStatusSchema>;
+export type NotifyWebhookEventType = z.infer<typeof webhookEventTypeSchema>;
 export type Deployment = z.infer<typeof deploymentSchema>;
 export type DeploymentCompleteness = z.infer<typeof deploymentCompletenessSchema>;
 export type DeploymentHistoryEntry = z.infer<typeof deploymentHistoryEntrySchema>;
@@ -1251,6 +1260,7 @@ function createDashboardE2eMockSite(siteId: string) {
     servingMode: "strict" as const,
     maxLocales: null,
     siteProfile: null,
+    webhookEvents: ["translation.completed", "translation.failed", "translation.summary"],
     locales: [
       { sourceLang: "en", targetLang: "fr", alias: null, serveEnabled: true },
       { sourceLang: "en", targetLang: "ja", alias: null, serveEnabled: true },
@@ -2574,6 +2584,9 @@ export type CreateSitePayload = {
   clientRuntimeEnabled?: boolean;
   translatableAttributes?: string[] | null;
   spaRefresh?: SpaRefreshSettings | null;
+  webhookUrl?: string | null;
+  webhookSecret?: string | null;
+  webhookEvents?: NotifyWebhookEventType[];
 };
 
 export async function createSite(auth: AuthInput, payload: CreateSitePayload) {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -1,0 +1,16 @@
+const defaults: Record<string, string> = {
+  NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test_123",
+  NEXT_PUBLIC_POSTHOG_KEY: "phc_test",
+  NEXT_PUBLIC_POSTHOG_HOST: "https://posthog.example.com",
+  NEXT_PUBLIC_SUPABASE_URL: "https://supabase.example.com",
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_anon_key",
+  NEXT_PUBLIC_WEBHOOKS_API_BASE: "https://api.weblingo.example/api",
+  NEXT_PUBLIC_WEBHOOKS_API_TIMEOUT_MS: "15000",
+};
+
+for (const [key, value] of Object.entries(defaults)) {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ const config: ViteUserConfig = {
   test: {
     environment: "node",
     include: ["**/*.test.ts", "**/*.test.tsx"],
+    setupFiles: ["./tests/vitest.setup.ts"],
   },
 };
 


### PR DESCRIPTION
## Summary

- Add webhook settings to the dashboard site admin page and onboarding flow, including URL, secret, and event allowlist inputs.
- Add the public webhook docs page and synchronize the dashboard/backend docs contract.
- Teach the dashboard client contracts and tests to carry `webhookEvents` end to end.

## Testing

- [x] `corepack pnpm exec vitest --run internal/dashboard/site-settings.test.ts internal/dashboard/data.test.ts internal/dashboard/webhooks.openapi-contract.test.ts internal/dashboard/webhooks.timeout.test.ts app/dashboard/actions.capabilities.test.ts 'app/dashboard/sites/[id]/admin/page.test.tsx' 'app/api/dashboard/sites/[siteId]/status/route.test.ts'`
- [x] `corepack pnpm run check`
- [x] `corepack pnpm test`
- [x] `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm docs:sync`
- [x] `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm docs:sync:check`
- [x] `corepack pnpm test:contracts`

## Docs sync and capability matrix

- [x] Updated `docs/backend/DASHBOARD_SPECS.md` for the new webhook site settings contract.
- [x] Ran `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm docs:sync` and committed the refreshed `content/docs/_generated/*` snapshots.
