### PR TITLE
Refine preview proxy flows and sync backend docs

### DIFF
--- a/app/api/previews/[id]/route.ts
+++ b/app/api/previews/[id]/route.ts
@@ -1,94 +1,61 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { envServer } from "@internal/core/env-server";
-import { buildErrorLogFields } from "@internal/core/error-log";
-import { redis } from "@internal/core/redis";
-import { getClientIp } from "@internal/core/request-ip";
-import { rateLimitFixedWindow } from "@internal/core/rate-limit";
-import { fetchWithTimeout, FetchTimeoutError } from "@internal/core/fetch-timeout";
 import {
-  readJsonBodyLimited,
-  RequestBodyTooLargeError,
-  RequestBodyInvalidJsonError,
-} from "@internal/core/body";
+  buildPreviewIpRateLimitKey,
+  createPreviewFetchErrorResponse,
+  enforcePreviewRateLimit,
+  getPreviewProxyConfig,
+  readPreviewJsonBodyLimited,
+  readPreviewStatusToken,
+  validatePreviewId,
+} from "@internal/api/previews-proxy";
+import { fetchWithTimeout } from "@internal/core/fetch-timeout";
 
 export const runtime = "nodejs";
-
-function isUuid(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
-}
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
 
-  const apiBase = envServer.NEXT_PUBLIC_WEBHOOKS_API_BASE.replace(/\/$/, "");
-  const previewToken = envServer.TRY_NOW_TOKEN;
-  if (!apiBase || !previewToken) {
-    return NextResponse.json({ error: "Preview service is not configured." }, { status: 500 });
+  const configResult = getPreviewProxyConfig("json");
+  if (!configResult.ok) {
+    return configResult.response;
+  }
+  const { config } = configResult;
+
+  const invalidIdResponse = validatePreviewId(id, "json");
+  if (invalidIdResponse) {
+    return invalidIdResponse;
   }
 
-  if (!id || !isUuid(id)) {
-    return NextResponse.json({ error: "Invalid preview id" }, { status: 400 });
+  const tokenResult = readPreviewStatusToken(request, "json");
+  if (!tokenResult.ok) {
+    return tokenResult.response;
   }
 
-  const statusToken = request.nextUrl.searchParams.get("token")?.trim() ?? "";
-  if (!statusToken) {
-    return NextResponse.json({ error: "Missing preview status token" }, { status: 400 });
+  const rateLimitResponse = await enforcePreviewRateLimit({
+    key: buildPreviewIpRateLimitKey(request, "status"),
+    limit: config.statusMaxPerWindow,
+    windowMs: config.rateLimitWindowMs,
+    responseKind: "json",
+    limitedMessage: "Too many status requests. Please try again shortly.",
+    backendFailureLogMessage: "Rate limit backend failed (preview status ip)",
+  });
+  if (rateLimitResponse) {
+    return rateLimitResponse;
   }
 
   try {
-    const windowMs = Number(envServer.WEBSITE_PREVIEW_RATE_LIMIT_WINDOW_MS);
-    const maxPerWindow = Number(envServer.WEBSITE_PREVIEW_STATUS_MAX_PER_WINDOW);
-    const upstreamTimeoutMs = Number(envServer.WEBSITE_PREVIEW_UPSTREAM_STATUS_TIMEOUT_MS);
-
-    const ip = getClientIp(request);
-    try {
-      const ipLimit = await rateLimitFixedWindow(redis, {
-        key: `rl:v1:preview:status:ip:${encodeURIComponent(ip)}`,
-        limit: maxPerWindow,
-        windowMs,
-      });
-      if (!ipLimit.allowed) {
-        const retryAfterSeconds = Math.max(1, Math.ceil((ipLimit.resetAtMs - Date.now()) / 1000));
-        return NextResponse.json(
-          { error: "Too many status requests. Please try again shortly." },
-          {
-            status: 429,
-            headers: {
-              "Retry-After": String(retryAfterSeconds),
-            },
-          },
-        );
-      }
-    } catch (error) {
-      console.error(
-        JSON.stringify(
-          {
-            level: "error",
-            message: "Rate limit backend failed (preview status ip)",
-            ...buildErrorLogFields(error),
-          },
-          null,
-          0,
-        ),
-      );
-      return NextResponse.json(
-        { error: "Service temporarily unavailable. Please try again shortly." },
-        { status: 503 },
-      );
-    }
-
     const upstream = await fetchWithTimeout(
-      `${apiBase}/previews/${encodeURIComponent(id)}`,
+      `${config.apiBase}/previews/${encodeURIComponent(id)}`,
       {
         method: "GET",
         headers: {
-          "x-preview-token": previewToken,
-          "x-preview-status-token": statusToken,
+          "x-preview-token": config.previewToken,
+          "x-preview-status-token": tokenResult.statusToken,
         },
         cache: "no-store",
       },
-      { timeoutMs: upstreamTimeoutMs, signal: request.signal },
+      { timeoutMs: config.upstreamStatusTimeoutMs, signal: request.signal },
     );
 
     const text = await upstream.text();
@@ -98,97 +65,60 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       headers: { "Content-Type": contentType },
     });
   } catch (error) {
-    if (error instanceof FetchTimeoutError) {
-      return NextResponse.json({ error: "Preview service timed out" }, { status: 504 });
-    }
-    return NextResponse.json({ error: "Unable to reach preview service." }, { status: 502 });
+    return createPreviewFetchErrorResponse(error, "json");
   }
 }
 
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
 
-  const apiBase = envServer.NEXT_PUBLIC_WEBHOOKS_API_BASE.replace(/\/$/, "");
-  const previewToken = envServer.TRY_NOW_TOKEN;
-  if (!apiBase || !previewToken) {
-    return NextResponse.json({ error: "Preview service is not configured." }, { status: 500 });
+  const configResult = getPreviewProxyConfig("json");
+  if (!configResult.ok) {
+    return configResult.response;
+  }
+  const { config } = configResult;
+
+  const invalidIdResponse = validatePreviewId(id, "json");
+  if (invalidIdResponse) {
+    return invalidIdResponse;
   }
 
-  if (!id || !isUuid(id)) {
-    return NextResponse.json({ error: "Invalid preview id" }, { status: 400 });
+  const tokenResult = readPreviewStatusToken(request, "json");
+  if (!tokenResult.ok) {
+    return tokenResult.response;
   }
 
-  const statusToken = request.nextUrl.searchParams.get("token")?.trim() ?? "";
-  if (!statusToken) {
-    return NextResponse.json({ error: "Missing preview status token" }, { status: 400 });
+  const bodyResult = await readPreviewJsonBodyLimited(request, 200);
+  if (!bodyResult.ok) {
+    return bodyResult.response;
   }
 
-  let payload: unknown;
-  try {
-    payload = await readJsonBodyLimited(request, { maxBytes: 200 });
-  } catch (error) {
-    if (error instanceof RequestBodyTooLargeError) {
-      return NextResponse.json({ error: "Request body too large" }, { status: 413 });
-    }
-    if (error instanceof RequestBodyInvalidJsonError) {
-      return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
-    }
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
-  }
-
-  const windowMs = Number(envServer.WEBSITE_PREVIEW_RATE_LIMIT_WINDOW_MS);
-  const maxPerWindow = Number(envServer.WEBSITE_PREVIEW_STATUS_MAX_PER_WINDOW);
-  const upstreamTimeoutMs = Number(envServer.WEBSITE_PREVIEW_UPSTREAM_STATUS_TIMEOUT_MS);
-
-  const ip = getClientIp(request);
-  try {
-    const ipLimit = await rateLimitFixedWindow(redis, {
-      key: `rl:v1:preview:status:ip:${encodeURIComponent(ip)}`,
-      limit: maxPerWindow,
-      windowMs,
-    });
-    if (!ipLimit.allowed) {
-      const retryAfterSeconds = Math.max(1, Math.ceil((ipLimit.resetAtMs - Date.now()) / 1000));
-      return NextResponse.json(
-        { error: "Too many requests. Please try again shortly." },
-        {
-          status: 429,
-          headers: { "Retry-After": String(retryAfterSeconds) },
-        },
-      );
-    }
-  } catch (error) {
-    console.error(
-      JSON.stringify(
-        {
-          level: "error",
-          message: "Rate limit backend failed (preview update-email ip)",
-          ...buildErrorLogFields(error),
-        },
-        null,
-        0,
-      ),
-    );
-    return NextResponse.json(
-      { error: "Service temporarily unavailable. Please try again shortly." },
-      { status: 503 },
-    );
+  const rateLimitResponse = await enforcePreviewRateLimit({
+    key: buildPreviewIpRateLimitKey(request, "status"),
+    limit: config.statusMaxPerWindow,
+    windowMs: config.rateLimitWindowMs,
+    responseKind: "json",
+    limitedMessage: "Too many requests. Please try again shortly.",
+    backendFailureLogMessage: "Rate limit backend failed (preview update-email ip)",
+  });
+  if (rateLimitResponse) {
+    return rateLimitResponse;
   }
 
   try {
     const upstream = await fetchWithTimeout(
-      `${apiBase}/previews/${encodeURIComponent(id)}`,
+      `${config.apiBase}/previews/${encodeURIComponent(id)}`,
       {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
-          "x-preview-token": previewToken,
-          "x-preview-status-token": statusToken,
+          "x-preview-token": config.previewToken,
+          "x-preview-status-token": tokenResult.statusToken,
         },
-        body: JSON.stringify(payload),
+        body: JSON.stringify(bodyResult.payload),
         cache: "no-store",
       },
-      { timeoutMs: upstreamTimeoutMs, signal: request.signal },
+      { timeoutMs: config.upstreamStatusTimeoutMs, signal: request.signal },
     );
 
     const text = await upstream.text();
@@ -198,9 +128,6 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       headers: { "Content-Type": contentType },
     });
   } catch (error) {
-    if (error instanceof FetchTimeoutError) {
-      return NextResponse.json({ error: "Preview service timed out" }, { status: 504 });
-    }
-    return NextResponse.json({ error: "Unable to reach preview service." }, { status: 502 });
+    return createPreviewFetchErrorResponse(error, "json");
   }
 }

--- a/app/api/previews/[id]/stream/route.ts
+++ b/app/api/previews/[id]/stream/route.ts
@@ -1,101 +1,66 @@
 import type { NextRequest } from "next/server";
 
-import { envServer } from "@internal/core/env-server";
-import { buildErrorLogFields } from "@internal/core/error-log";
-import { redis } from "@internal/core/redis";
-import { getClientIp } from "@internal/core/request-ip";
-import { rateLimitFixedWindow } from "@internal/core/rate-limit";
-import { fetchWithTimeout, FetchTimeoutError } from "@internal/core/fetch-timeout";
+import {
+  buildPreviewIpRateLimitKey,
+  createPreviewFetchErrorResponse,
+  enforcePreviewRateLimit,
+  getPreviewProxyConfig,
+  readPreviewStatusToken,
+  validatePreviewId,
+} from "@internal/api/previews-proxy";
+import { fetchWithTimeout } from "@internal/core/fetch-timeout";
 
 export const runtime = "nodejs";
-
-function isUuid(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
-}
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
 
-  const apiBase = envServer.NEXT_PUBLIC_WEBHOOKS_API_BASE.replace(/\/$/, "");
-  const previewToken = envServer.TRY_NOW_TOKEN;
-  if (!apiBase || !previewToken) {
-    return new Response("Preview service is not configured.", { status: 500 });
+  const configResult = getPreviewProxyConfig("text");
+  if (!configResult.ok) {
+    return configResult.response;
+  }
+  const { config } = configResult;
+
+  const invalidIdResponse = validatePreviewId(id, "text");
+  if (invalidIdResponse) {
+    return invalidIdResponse;
   }
 
-  if (!id || !isUuid(id)) {
-    return new Response("Invalid preview id", { status: 400 });
+  const tokenResult = readPreviewStatusToken(request, "text");
+  if (!tokenResult.ok) {
+    return tokenResult.response;
   }
 
-  const statusToken = request.nextUrl.searchParams.get("token")?.trim() ?? "";
-  if (!statusToken) {
-    return new Response("Missing preview status token", { status: 400 });
-  }
-
-  const windowMs = Number(envServer.WEBSITE_PREVIEW_RATE_LIMIT_WINDOW_MS);
-  const maxPerWindow = Number(envServer.WEBSITE_PREVIEW_STREAM_MAX_PER_WINDOW);
-  const upstreamConnectTimeoutMs = Number(
-    envServer.WEBSITE_PREVIEW_UPSTREAM_STREAM_CONNECT_TIMEOUT_MS,
-  );
-
-  const ip = getClientIp(request);
-  try {
-    const ipLimit = await rateLimitFixedWindow(redis, {
-      key: `rl:v1:preview:stream:ip:${encodeURIComponent(ip)}`,
-      limit: maxPerWindow,
-      windowMs,
-    });
-    if (!ipLimit.allowed) {
-      const retryAfterSeconds = Math.max(1, Math.ceil((ipLimit.resetAtMs - Date.now()) / 1000));
-      return new Response("Too many stream requests. Please try again shortly.", {
-        status: 429,
-        headers: {
-          "Retry-After": String(retryAfterSeconds),
-          "Content-Type": "text/plain",
-        },
-      });
-    }
-  } catch (error) {
-    console.error(
-      JSON.stringify(
-        {
-          level: "error",
-          message: "Rate limit backend failed (preview stream ip)",
-          ...buildErrorLogFields(error),
-        },
-        null,
-        0,
-      ),
-    );
-    return new Response("Service temporarily unavailable. Please try again shortly.", {
-      status: 503,
-      headers: { "Content-Type": "text/plain" },
-    });
+  const rateLimitResponse = await enforcePreviewRateLimit({
+    key: buildPreviewIpRateLimitKey(request, "stream"),
+    limit: config.streamMaxPerWindow,
+    windowMs: config.rateLimitWindowMs,
+    responseKind: "text",
+    limitedMessage: "Too many stream requests. Please try again shortly.",
+    backendFailureLogMessage: "Rate limit backend failed (preview stream ip)",
+  });
+  if (rateLimitResponse) {
+    return rateLimitResponse;
   }
 
   let upstream: Response;
   try {
     upstream = await fetchWithTimeout(
-      `${apiBase}/previews/${encodeURIComponent(id)}/stream`,
+      `${config.apiBase}/previews/${encodeURIComponent(id)}/stream`,
       {
         method: "GET",
         redirect: "manual",
         headers: {
           Accept: "text/event-stream",
-          "x-preview-token": previewToken,
-          "x-preview-status-token": statusToken,
+          "x-preview-token": config.previewToken,
+          "x-preview-status-token": tokenResult.statusToken,
         },
         cache: "no-store",
       },
-      { timeoutMs: upstreamConnectTimeoutMs, signal: request.signal },
+      { timeoutMs: config.upstreamStreamConnectTimeoutMs, signal: request.signal },
     );
   } catch (error) {
-    if (error instanceof FetchTimeoutError) {
-      return new Response("Preview service timed out", {
-        status: 504,
-        headers: { "Content-Type": "text/plain" },
-      });
-    }
-    return new Response("Unable to reach preview service.", { status: 502 });
+    return createPreviewFetchErrorResponse(error, "text");
   }
 
   if (!upstream.ok) {

--- a/app/api/previews/route.ts
+++ b/app/api/previews/route.ts
@@ -1,16 +1,14 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-import { envServer } from "@internal/core/env-server";
-import { buildErrorLogFields } from "@internal/core/error-log";
-import { redis } from "@internal/core/redis";
-import { getClientIp } from "@internal/core/request-ip";
-import { rateLimitFixedWindow } from "@internal/core/rate-limit";
 import {
-  readJsonBodyLimited,
-  RequestBodyInvalidJsonError,
-  RequestBodyTooLargeError,
-} from "@internal/core/body";
-import { fetchWithTimeout, FetchTimeoutError } from "@internal/core/fetch-timeout";
+  buildPreviewHostRateLimitKey,
+  buildPreviewIpRateLimitKey,
+  createPreviewFetchErrorResponse,
+  enforcePreviewRateLimit,
+  getPreviewProxyConfig,
+  readPreviewJsonBodyLimited,
+} from "@internal/api/previews-proxy";
+import { fetchWithTimeout } from "@internal/core/fetch-timeout";
 
 export const runtime = "nodejs";
 
@@ -34,124 +32,60 @@ function tryExtractSourceHost(payload: unknown): string | null {
 }
 
 export async function POST(request: NextRequest) {
-  const apiBase = envServer.NEXT_PUBLIC_WEBHOOKS_API_BASE.replace(/\/$/, "");
-  const previewToken = envServer.TRY_NOW_TOKEN;
-  if (!apiBase || !previewToken) {
-    return NextResponse.json({ error: "Preview service is not configured." }, { status: 500 });
+  const configResult = getPreviewProxyConfig("json");
+  if (!configResult.ok) {
+    return configResult.response;
+  }
+  const { config } = configResult;
+
+  const ipLimitResponse = await enforcePreviewRateLimit({
+    key: buildPreviewIpRateLimitKey(request, "create"),
+    limit: config.createMaxPerWindow,
+    windowMs: config.rateLimitWindowMs,
+    responseKind: "json",
+    limitedMessage: "Too many preview requests. Please try again shortly.",
+    backendFailureLogMessage: "Rate limit backend failed (preview create ip)",
+  });
+  if (ipLimitResponse) {
+    return ipLimitResponse;
   }
 
-  const windowMs = Number(envServer.WEBSITE_PREVIEW_RATE_LIMIT_WINDOW_MS);
-  const maxPerWindow = Number(envServer.WEBSITE_PREVIEW_CREATE_MAX_PER_WINDOW);
-  const maxPerHostPerWindow = Number(
-    envServer.WEBSITE_PREVIEW_CREATE_MAX_PER_SOURCE_HOST_PER_WINDOW,
-  );
-  const maxBodyBytes = Number(envServer.WEBSITE_PREVIEW_MAX_BODY_BYTES);
-  const upstreamTimeoutMs = Number(envServer.WEBSITE_PREVIEW_UPSTREAM_CREATE_TIMEOUT_MS);
-
-  const ip = getClientIp(request);
-  try {
-    const ipLimit = await rateLimitFixedWindow(redis, {
-      key: `rl:v1:preview:create:ip:${encodeURIComponent(ip)}`,
-      limit: maxPerWindow,
-      windowMs,
-    });
-    if (!ipLimit.allowed) {
-      const retryAfterSeconds = Math.max(1, Math.ceil((ipLimit.resetAtMs - Date.now()) / 1000));
-      return NextResponse.json(
-        { error: "Too many preview requests. Please try again shortly." },
-        {
-          status: 429,
-          headers: {
-            "Retry-After": String(retryAfterSeconds),
-          },
-        },
-      );
-    }
-  } catch (error) {
-    console.error(
-      JSON.stringify(
-        {
-          level: "error",
-          message: "Rate limit backend failed (preview create ip)",
-          ...buildErrorLogFields(error),
-        },
-        null,
-        0,
-      ),
-    );
-    return NextResponse.json(
-      { error: "Service temporarily unavailable. Please try again shortly." },
-      { status: 503 },
-    );
+  const bodyResult = await readPreviewJsonBodyLimited(request, config.maxBodyBytes);
+  if (!bodyResult.ok) {
+    return bodyResult.response;
   }
-
-  let payload: unknown;
-  try {
-    payload = await readJsonBodyLimited(request, { maxBytes: maxBodyBytes });
-  } catch (error) {
-    if (error instanceof RequestBodyTooLargeError) {
-      return NextResponse.json({ error: "Request body too large" }, { status: 413 });
-    }
-    if (error instanceof RequestBodyInvalidJsonError) {
-      return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
-    }
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
-  }
+  const { payload } = bodyResult;
 
   const sourceHost = tryExtractSourceHost(payload);
   if (sourceHost) {
-    try {
-      const hostLimit = await rateLimitFixedWindow(redis, {
-        key: `rl:v1:preview:create:host:${encodeURIComponent(sourceHost)}`,
-        limit: maxPerHostPerWindow,
-        windowMs,
-      });
-      if (!hostLimit.allowed) {
-        const retryAfterSeconds = Math.max(1, Math.ceil((hostLimit.resetAtMs - Date.now()) / 1000));
-        return NextResponse.json(
-          { error: "Too many preview requests for this site. Please try again shortly." },
-          {
-            status: 429,
-            headers: {
-              "Retry-After": String(retryAfterSeconds),
-            },
-          },
-        );
-      }
-    } catch (error) {
-      console.error(
-        JSON.stringify(
-          {
-            level: "error",
-            message: "Rate limit backend failed (preview create host)",
-            ...buildErrorLogFields(error),
-          },
-          null,
-          0,
-        ),
-      );
-      return NextResponse.json(
-        { error: "Service temporarily unavailable. Please try again shortly." },
-        { status: 503 },
-      );
+    const hostLimitResponse = await enforcePreviewRateLimit({
+      key: buildPreviewHostRateLimitKey(sourceHost),
+      limit: config.createMaxPerSourceHostPerWindow,
+      windowMs: config.rateLimitWindowMs,
+      responseKind: "json",
+      limitedMessage: "Too many preview requests for this site. Please try again shortly.",
+      backendFailureLogMessage: "Rate limit backend failed (preview create host)",
+    });
+    if (hostLimitResponse) {
+      return hostLimitResponse;
     }
   }
 
   try {
     const upstream = await fetchWithTimeout(
-      `${apiBase}/previews`,
+      `${config.apiBase}/previews`,
       {
         method: "POST",
         redirect: "manual",
         headers: {
           "Content-Type": "application/json",
-          "x-preview-token": previewToken,
+          "x-preview-token": config.previewToken,
           Accept: "application/json",
         },
         body: JSON.stringify(payload),
         cache: "no-store",
       },
-      { timeoutMs: upstreamTimeoutMs, signal: request.signal },
+      { timeoutMs: config.upstreamCreateTimeoutMs, signal: request.signal },
     );
 
     const contentType = upstream.headers.get("content-type") ?? "";
@@ -172,9 +106,6 @@ export async function POST(request: NextRequest) {
       headers: { "Content-Type": contentType || "application/json" },
     });
   } catch (error) {
-    if (error instanceof FetchTimeoutError) {
-      return NextResponse.json({ error: "Preview service timed out" }, { status: 504 });
-    }
-    return NextResponse.json({ error: "Unable to reach preview service." }, { status: 502 });
+    return createPreviewFetchErrorResponse(error, "json");
   }
 }

--- a/app/dashboard/actions.ts
+++ b/app/dashboard/actions.ts
@@ -211,6 +211,39 @@ async function invalidateDashboardCaches(
   }
 }
 
+async function runSiteMutation<T>(options: {
+  siteId: string;
+  invalidateSitesList: boolean;
+  revalidatePaths: string[];
+  logLabel: string;
+  fallbackError: string;
+  mutate: (auth: WebhooksAuthContext) => Promise<T>;
+  onSuccess: (result: T) => ActionResponse;
+  formatError?: (error: unknown, fallback: string) => string;
+}): Promise<ActionResponse> {
+  try {
+    const result = await withWebhooksAuth(async (auth) => {
+      const response = await options.mutate(auth);
+      await invalidateDashboardCaches(auth, options.siteId, {
+        invalidateSitesList: options.invalidateSitesList,
+      });
+      return response;
+    });
+    for (const path of options.revalidatePaths) {
+      revalidatePath(path);
+    }
+    return options.onSuccess(result);
+  } catch (error) {
+    if (isNextRedirectError(error)) {
+      throw error;
+    }
+    console.error(`[dashboard] ${options.logLabel} failed:`, error);
+    return failed(
+      (options.formatError ?? toFriendlyDashboardActionError)(error, options.fallbackError),
+    );
+  }
+}
+
 async function requireInternalAdminWorkspaceAuth(): Promise<WebhooksAuthContext> {
   const auth = await requireDashboardAuth();
   if (!hasActorInternalOps(auth)) {
@@ -649,27 +682,23 @@ export async function triggerCrawlAction(
     return failed("Site ID is required.");
   }
 
-  try {
-    const status = await withWebhooksAuth(async (auth) => {
-      const response = await triggerCrawl(auth, siteId, force ? { force } : undefined);
-      await invalidateDashboardCaches(auth, siteId, { invalidateSitesList: false });
-      return response;
-    });
-    revalidatePath(`/dashboard/sites/${siteId}`);
-    if (status.enqueued) {
-      return succeeded("Crawl enqueued.");
-    }
-    if (status.error) {
-      return failed(status.error);
-    }
-    return succeeded("Crawl is already queued.");
-  } catch (error) {
-    if (isNextRedirectError(error)) {
-      throw error;
-    }
-    console.error("[dashboard] triggerCrawlAction failed:", error);
-    return failed(toFriendlyDashboardActionError(error, "Unable to enqueue a crawl right now."));
-  }
+  return runSiteMutation({
+    siteId,
+    invalidateSitesList: false,
+    revalidatePaths: [`/dashboard/sites/${siteId}`],
+    logLabel: "triggerCrawlAction",
+    fallbackError: "Unable to enqueue a crawl right now.",
+    mutate: (auth) => triggerCrawl(auth, siteId, force ? { force } : undefined),
+    onSuccess: (status) => {
+      if (status.enqueued) {
+        return succeeded("Crawl enqueued.");
+      }
+      if (status.error) {
+        return failed(status.error);
+      }
+      return succeeded("Crawl is already queued.");
+    },
+  });
 }
 
 export async function triggerManagedDemoForceCrawlAction(
@@ -731,36 +760,29 @@ export async function triggerCrawlTranslateAction(
     return failed("At least one target language is required.");
   }
 
-  try {
-    const result = await withWebhooksAuth(async (auth) => {
-      const response = await triggerCrawlTranslate(auth, siteId, {
+  return runSiteMutation({
+    siteId,
+    invalidateSitesList: false,
+    revalidatePaths: [`/dashboard/sites/${siteId}`, `/dashboard/sites/${siteId}/pages`],
+    logLabel: "triggerCrawlTranslateAction",
+    fallbackError: "Unable to queue crawl + translate right now.",
+    mutate: (auth) =>
+      triggerCrawlTranslate(auth, siteId, {
         targetLangs,
         ...(pageIds.length ? { pageIds } : {}),
         ...(sourcePaths.length ? { sourcePaths } : {}),
         ...(force ? { force: true } : {}),
-      });
-      await invalidateDashboardCaches(auth, siteId, { invalidateSitesList: false });
-      return response;
-    });
-    revalidatePath(`/dashboard/sites/${siteId}`);
-    revalidatePath(`/dashboard/sites/${siteId}/pages`);
-    return succeeded(
-      `Crawl + translate queued (${result.enqueuedCount}/${result.selectedCount} pages).`,
-      {
-        crawlId: result.crawlId,
-        selectedCount: result.selectedCount,
-        enqueuedCount: result.enqueuedCount,
-      },
-    );
-  } catch (error) {
-    if (isNextRedirectError(error)) {
-      throw error;
-    }
-    console.error("[dashboard] triggerCrawlTranslateAction failed:", error);
-    return failed(
-      toFriendlyDashboardActionError(error, "Unable to queue crawl + translate right now."),
-    );
-  }
+      }),
+    onSuccess: (result) =>
+      succeeded(
+        `Crawl + translate queued (${result.enqueuedCount}/${result.selectedCount} pages).`,
+        {
+          crawlId: result.crawlId,
+          selectedCount: result.selectedCount,
+          enqueuedCount: result.enqueuedCount,
+        },
+      ),
+  });
 }
 
 export async function translateAndServeAction(
@@ -777,44 +799,37 @@ export async function translateAndServeAction(
 
   const shouldActivate = siteStatus === "inactive";
 
-  try {
-    const result = await withWebhooksAuth(async (auth) => {
+  return runSiteMutation({
+    siteId,
+    invalidateSitesList: shouldActivate,
+    revalidatePaths: shouldActivate
+      ? [`/dashboard/sites/${siteId}`, `/dashboard/sites/${siteId}/admin`, "/dashboard"]
+      : [`/dashboard/sites/${siteId}`],
+    logLabel: "translateAndServeAction",
+    fallbackError: "Unable to start translation and serving right now.",
+    formatError: toTranslateAndServeError,
+    mutate: async (auth) => {
       if (shouldActivate) {
         await updateSite(auth, siteId, { status: "active" });
       }
-      const response = await translateSite(auth, siteId, targetLang, {
+      return translateSite(auth, siteId, targetLang, {
         intent: "translate_and_serve",
       });
-      await invalidateDashboardCaches(auth, siteId, {
-        invalidateSitesList: shouldActivate,
-      });
-      return response;
-    });
-    revalidatePath(`/dashboard/sites/${siteId}`);
-    if (shouldActivate) {
-      revalidatePath(`/dashboard/sites/${siteId}/admin`);
-      revalidatePath("/dashboard");
-    }
-    const activationPrefix = shouldActivate ? "Localization enabled. " : "";
-    const crawlEnqueued = Boolean(result.crawlEnqueued);
-    const missingSnapshots = result.missingSnapshots ?? 0;
-    const runStarted = Boolean(result.run);
-    let toast = "Translation run started.";
-    if (!runStarted && crawlEnqueued) {
-      toast = "Crawl queued. Translation will start once snapshots are ready.";
-    } else if (runStarted && crawlEnqueued && missingSnapshots > 0) {
-      toast = "Translation started for available snapshots. Crawl queued for missing pages.";
-    }
-    return succeeded(`${activationPrefix}${toast}`);
-  } catch (error) {
-    if (isNextRedirectError(error)) {
-      throw error;
-    }
-    console.error("[dashboard] translateAndServeAction failed:", error);
-    return failed(
-      toTranslateAndServeError(error, "Unable to start translation and serving right now."),
-    );
-  }
+    },
+    onSuccess: (result) => {
+      const activationPrefix = shouldActivate ? "Localization enabled. " : "";
+      const crawlEnqueued = Boolean(result.crawlEnqueued);
+      const missingSnapshots = result.missingSnapshots ?? 0;
+      const runStarted = Boolean(result.run);
+      let toast = "Translation run started.";
+      if (!runStarted && crawlEnqueued) {
+        toast = "Crawl queued. Translation will start once snapshots are ready.";
+      } else if (runStarted && crawlEnqueued && missingSnapshots > 0) {
+        toast = "Translation started for available snapshots. Crawl queued for missing pages.";
+      }
+      return succeeded(`${activationPrefix}${toast}`);
+    },
+  });
 }
 
 export async function upsertDigestSubscriptionAction(
@@ -983,21 +998,15 @@ export async function cancelTranslationRunAction(
     return failed("Site ID and run ID are required.");
   }
 
-  try {
-    await withWebhooksAuth(async (auth) => {
-      await cancelTranslationRun(auth, siteId, runId);
-      await invalidateDashboardCaches(auth, siteId, { invalidateSitesList: false });
-    });
-    revalidatePath(`/dashboard/sites/${siteId}`);
-    revalidatePath(`/dashboard/sites/${siteId}/admin`);
-    return succeeded("Translation run cancelled.");
-  } catch (error) {
-    if (isNextRedirectError(error)) {
-      throw error;
-    }
-    console.error("[dashboard] cancelTranslationRunAction failed:", error);
-    return failed(toFriendlyDashboardActionError(error, "Unable to cancel the translation run."));
-  }
+  return runSiteMutation({
+    siteId,
+    invalidateSitesList: false,
+    revalidatePaths: [`/dashboard/sites/${siteId}`, `/dashboard/sites/${siteId}/admin`],
+    logLabel: "cancelTranslationRunAction",
+    fallbackError: "Unable to cancel the translation run.",
+    mutate: (auth) => cancelTranslationRun(auth, siteId, runId),
+    onSuccess: () => succeeded("Translation run cancelled."),
+  });
 }
 
 function buildResumeToast(
@@ -1033,23 +1042,15 @@ export async function resumeTranslationRunAction(
     return failed("Site ID and run ID are required.");
   }
 
-  try {
-    const result = await withWebhooksAuth(async (auth) => {
-      const response = await resumeTranslationRun(auth, siteId, runId);
-      await invalidateDashboardCaches(auth, siteId, { invalidateSitesList: false });
-      return response;
-    });
-    revalidatePath(`/dashboard/sites/${siteId}`);
-    revalidatePath(`/dashboard/sites/${siteId}/admin`);
-    const message = buildResumeToast("resume", result);
-    return succeeded(message);
-  } catch (error) {
-    if (isNextRedirectError(error)) {
-      throw error;
-    }
-    console.error("[dashboard] resumeTranslationRunAction failed:", error);
-    return failed(toFriendlyDashboardActionError(error, "Unable to resume the translation run."));
-  }
+  return runSiteMutation({
+    siteId,
+    invalidateSitesList: false,
+    revalidatePaths: [`/dashboard/sites/${siteId}`, `/dashboard/sites/${siteId}/admin`],
+    logLabel: "resumeTranslationRunAction",
+    fallbackError: "Unable to resume the translation run.",
+    mutate: (auth) => resumeTranslationRun(auth, siteId, runId),
+    onSuccess: (result) => succeeded(buildResumeToast("resume", result)),
+  });
 }
 
 export async function retryFailedTranslationRunAction(
@@ -1063,23 +1064,15 @@ export async function retryFailedTranslationRunAction(
     return failed("Site ID and run ID are required.");
   }
 
-  try {
-    const result = await withWebhooksAuth(async (auth) => {
-      const response = await resumeTranslationRun(auth, siteId, runId);
-      await invalidateDashboardCaches(auth, siteId, { invalidateSitesList: false });
-      return response;
-    });
-    revalidatePath(`/dashboard/sites/${siteId}`);
-    revalidatePath(`/dashboard/sites/${siteId}/admin`);
-    const message = buildResumeToast("retry", result);
-    return succeeded(message);
-  } catch (error) {
-    if (isNextRedirectError(error)) {
-      throw error;
-    }
-    console.error("[dashboard] retryFailedTranslationRunAction failed:", error);
-    return failed(toFriendlyDashboardActionError(error, "Unable to retry failed pages right now."));
-  }
+  return runSiteMutation({
+    siteId,
+    invalidateSitesList: false,
+    revalidatePaths: [`/dashboard/sites/${siteId}`, `/dashboard/sites/${siteId}/admin`],
+    logLabel: "retryFailedTranslationRunAction",
+    fallbackError: "Unable to retry failed pages right now.",
+    mutate: (auth) => resumeTranslationRun(auth, siteId, runId),
+    onSuccess: (result) => succeeded(buildResumeToast("retry", result)),
+  });
 }
 
 export async function triggerPageCrawlAction(
@@ -1093,29 +1086,23 @@ export async function triggerPageCrawlAction(
     return failed("Site ID and page ID are required.");
   }
 
-  try {
-    const status = await withWebhooksAuth(async (auth) => {
-      const response = await triggerPageCrawl(auth, siteId, pageId);
-      await invalidateDashboardCaches(auth, siteId, { invalidateSitesList: false });
-      return response;
-    });
-    revalidatePath(`/dashboard/sites/${siteId}`);
-    if (status.enqueued) {
-      return succeeded("Page crawl enqueued.");
-    }
-    if (status.error) {
-      return failed(status.error);
-    }
-    return succeeded("Page crawl is already queued.");
-  } catch (error) {
-    if (isNextRedirectError(error)) {
-      throw error;
-    }
-    console.error("[dashboard] triggerPageCrawlAction failed:", error);
-    return failed(
-      toFriendlyDashboardActionError(error, "Unable to enqueue a page crawl right now."),
-    );
-  }
+  return runSiteMutation({
+    siteId,
+    invalidateSitesList: false,
+    revalidatePaths: [`/dashboard/sites/${siteId}`],
+    logLabel: "triggerPageCrawlAction",
+    fallbackError: "Unable to enqueue a page crawl right now.",
+    mutate: (auth) => triggerPageCrawl(auth, siteId, pageId),
+    onSuccess: (status) => {
+      if (status.enqueued) {
+        return succeeded("Page crawl enqueued.");
+      }
+      if (status.error) {
+        return failed(status.error);
+      }
+      return succeeded("Page crawl is already queued.");
+    },
+  });
 }
 
 export async function verifyDomainAction(

--- a/app/dashboard/sites/webhook-settings-fields.test.tsx
+++ b/app/dashboard/sites/webhook-settings-fields.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { KnownWebhookEventType } from "@internal/dashboard/webhooks";
+
+import { WebhookSettingsFields } from "./webhook-settings-fields";
+
+const baseProps = {
+  title: "Webhook integrations",
+  description: "Send signed lifecycle events.",
+  urlLabel: "Webhook URL",
+  urlHelp: "Webhook URL help",
+  secretLabel: "Signing secret",
+  secretHelp: "Signing secret help",
+  eventsLabel: "Events",
+  eventsHelp: "Events help",
+  selectAllLabel: "Select all",
+  disableAllLabel: "Disable all",
+  webhookUrl: "https://hooks.example.com/weblingo",
+  onWebhookUrlChange: vi.fn(),
+  webhookSecret: "secret",
+  onWebhookSecretChange: vi.fn(),
+  webhookEvents: ["translation.completed", "translation.failed"] as KnownWebhookEventType[],
+  onWebhookEventsChange: vi.fn(),
+};
+
+describe("WebhookSettingsFields", () => {
+  it("does not submit webhook fields while rendered read-only", () => {
+    const { container } = render(<WebhookSettingsFields {...baseProps} canEdit={false} />);
+    expect(container.querySelector('input[name="webhookEvents"]')).toBeNull();
+  });
+
+  it("submits webhook events when editing is allowed", () => {
+    const { container } = render(<WebhookSettingsFields {...baseProps} canEdit />);
+    const hiddenInput = container.querySelector<HTMLInputElement>('input[name="webhookEvents"]');
+    expect(hiddenInput?.value).toBe('["translation.completed","translation.failed"]');
+  });
+});

--- a/app/dashboard/sites/webhook-settings-fields.tsx
+++ b/app/dashboard/sites/webhook-settings-fields.tsx
@@ -75,7 +75,7 @@ export function WebhookSettingsFields({
         </div>
       </div>
 
-      <input name="webhookEvents" type="hidden" value={webhookEventsJson} />
+      {canEdit ? <input name="webhookEvents" type="hidden" value={webhookEventsJson} /> : null}
 
       <Field label={urlLabel} htmlFor="webhookUrl" description={urlHelp}>
         <Input

--- a/components/try-form.test.tsx
+++ b/components/try-form.test.tsx
@@ -1197,6 +1197,38 @@ describe("TryForm preview status", () => {
     });
   });
 
+  it("maps status polling 404 responses to preview-not-found copy", async () => {
+    vi.stubGlobal("EventSource", undefined);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/previews") {
+        return jsonResponse({
+          previewId: "33333333-3333-3333-3333-333333333333",
+          statusToken: "poll-token",
+          status: "pending",
+        });
+      }
+      if (url === "/api/previews/33333333-3333-3333-3333-333333333333?token=poll-token") {
+        return jsonResponse({ error: "Not found" }, 404);
+      }
+      return jsonResponse({ status: "processing" });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderTryForm();
+    fireEvent.change(screen.getByPlaceholderText("https://example.com"), {
+      target: { value: "https://example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate preview" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/previews/33333333-3333-3333-3333-333333333333?token=poll-token",
+      );
+      expect(screen.getByText("Preview not found")).toBeTruthy();
+    });
+  });
+
   it("closes SSE and uses a single status check when stream errors", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/components/try-form.tsx
+++ b/components/try-form.tsx
@@ -25,13 +25,14 @@ import {
   type ClientMessages,
 } from "@internal/i18n";
 import {
-  hasExplicitFailure,
-  isPreviewErrorCode,
   isPreviewStage,
-  resolveStatusCheckFailure,
   type PreviewErrorCode,
   type PreviewStage,
 } from "@internal/previews/preview-sse";
+import {
+  resolvePreviewErrorPayload,
+  resolvePreviewStatusDecision,
+} from "@internal/previews/preview-status-decision";
 import {
   parsePreviewRetryHint,
   type PreviewRetryHint,
@@ -81,12 +82,6 @@ type ConnectStatusUpdatesOptions = {
   initialStage?: PreviewStage | null;
   initialPreviewUrl?: string;
   initialRetryHint?: PreviewRetryHint | null;
-};
-
-type ResolvedPreviewError = {
-  code: PreviewErrorCode | null;
-  stage: PreviewStage | null;
-  message: string;
 };
 
 const emailSchema = z.email();
@@ -607,36 +602,12 @@ export function TryForm({
     return t("try.error.default");
   }
 
-  function resolveErrorFromPayload(
-    data: Record<string, unknown>,
-    fallback?: string,
-  ): ResolvedPreviewError {
-    const details =
-      data.details && typeof data.details === "object"
-        ? (data.details as Record<string, unknown>)
-        : null;
-    const code = isPreviewErrorCode(data.errorCode)
-      ? data.errorCode
-      : details && isPreviewErrorCode(details.errorCode)
-        ? details.errorCode
-        : null;
-    const stage = isPreviewStage(data.errorStage)
-      ? data.errorStage
-      : details && isPreviewStage(details.errorStage)
-        ? details.errorStage
-        : null;
-    const message = resolveErrorMessage(
-      code,
-      (data.error as string | undefined) ??
-        (data.message as string | undefined) ??
-        fallback ??
-        null,
+  function resolveErrorFromPayload(data: Record<string, unknown>, fallback?: string) {
+    return resolvePreviewErrorPayload(
+      data,
+      fallback ?? t("try.error.default"),
+      resolveErrorMessage,
     );
-    return {
-      code,
-      stage,
-      message,
-    };
   }
 
   function syncStatusCenterActiveState(
@@ -702,47 +673,20 @@ export function TryForm({
         }
       }
 
-      if (!response.ok) {
-        const decision = resolveStatusCheckFailure(response.status, payload);
-        if (decision === "processing") {
-          syncStatusCenterActiveState(
-            previewId,
-            "processing",
-            null,
-            resolvePreviewRetryHint(payload),
-          );
-          return false;
-        }
-
-        const reason =
-          (payload && typeof payload.error === "string" ? payload.error : "") ||
-          (payload && typeof payload.message === "string" ? payload.message : "") ||
-          t("try.error.default");
-        const resolved = resolveErrorFromPayload(payload ?? {}, reason);
-        syncStatusCenterTerminalState(
-          previewId,
-          resolved.code === "preview_expired" ? "expired" : "failed",
-          {
-            error: resolved.message,
-            errorCode: resolved.code,
-            errorStage: resolved.stage,
-          },
-        );
-        setSubmissionError(null);
-        timedOutRef.current = false;
-        setTimedOut(false);
-        setTimedOutWithEmail(false);
-        return true;
-      }
-
-      if (!payload || typeof payload !== "object") {
-        syncStatusCenterActiveState(previewId, "processing", null);
-        return false;
-      }
-
-      if (payload.status === "ready") {
-        syncStatusCenterTerminalState(previewId, "ready", {
-          previewUrl: typeof payload.previewUrl === "string" ? payload.previewUrl : null,
+      const decision = resolvePreviewStatusDecision({
+        responseOk: response.ok,
+        responseStatus: response.status,
+        payload,
+        defaultErrorMessage: t("try.error.default"),
+        resolveErrorMessage,
+        mapNotFoundToErrorCode: true,
+      });
+      if (decision.kind === "terminal") {
+        syncStatusCenterTerminalState(previewId, decision.status, {
+          previewUrl: decision.previewUrl,
+          error: decision.error,
+          errorCode: decision.errorCode,
+          errorStage: decision.errorStage,
         });
         setSubmissionError(null);
         timedOutRef.current = false;
@@ -751,30 +695,7 @@ export function TryForm({
         return true;
       }
 
-      if (payload.status === "failed" || hasExplicitFailure(payload)) {
-        const resolved = resolveErrorFromPayload(payload, t("try.error.default"));
-        syncStatusCenterTerminalState(
-          previewId,
-          resolved.code === "preview_expired" ? "expired" : "failed",
-          {
-            error: resolved.message,
-            errorCode: resolved.code,
-            errorStage: resolved.stage,
-          },
-        );
-        setSubmissionError(null);
-        timedOutRef.current = false;
-        setTimedOut(false);
-        setTimedOutWithEmail(false);
-        return true;
-      }
-
-      syncStatusCenterActiveState(
-        previewId,
-        payload.status === "pending" ? "pending" : "processing",
-        isPreviewStage(payload.stage) ? payload.stage : null,
-        resolvePreviewRetryHint(payload),
-      );
+      syncStatusCenterActiveState(previewId, decision.status, decision.stage, decision.retryHint);
       return false;
     } catch {
       syncStatusCenterActiveState(previewId, "processing", null);
@@ -825,37 +746,25 @@ export function TryForm({
         });
       }
 
-      if (data.status === "ready") {
-        syncStatusCenterTerminalState(previewId, "ready", {
-          previewUrl: typeof data.previewUrl === "string" ? data.previewUrl : null,
+      const decision = resolvePreviewStatusDecision({
+        responseOk: true,
+        responseStatus: 200,
+        payload: data,
+        defaultErrorMessage: t("try.error.default"),
+        resolveErrorMessage,
+      });
+      if (decision.kind === "terminal") {
+        syncStatusCenterTerminalState(previewId, decision.status, {
+          previewUrl: decision.previewUrl,
+          error: decision.error,
+          errorCode: decision.errorCode,
+          errorStage: decision.errorStage,
         });
         closeEventSource();
         return;
       }
 
-      if (data.status === "failed" || hasExplicitFailure(data)) {
-        const resolved = resolveErrorFromPayload(data);
-        syncStatusCenterTerminalState(
-          previewId,
-          resolved.code === "preview_expired" ? "expired" : "failed",
-          {
-            error: resolved.message,
-            errorCode: resolved.code,
-            errorStage: resolved.stage,
-          },
-        );
-        closeEventSource();
-        return;
-      }
-
-      if (data.status === "pending" || data.status === "processing") {
-        syncStatusCenterActiveState(
-          previewId,
-          data.status,
-          isPreviewStage(data.stage) ? data.stage : null,
-          resolvePreviewRetryHint(data),
-        );
-      }
+      syncStatusCenterActiveState(previewId, decision.status, decision.stage, decision.retryHint);
     };
 
     const parseEventPayload = (event: MessageEvent | Event): Record<string, unknown> | null => {

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -1591,14 +1591,19 @@
       "CrawlTriggerRequest": {
         "additionalProperties": false,
         "example": {
+          "docsOnly": true,
           "force": true
         },
         "examples": [
           {
+            "docsOnly": true,
             "force": true
           }
         ],
         "properties": {
+          "docsOnly": {
+            "type": "boolean"
+          },
           "force": {
             "type": "boolean"
           }
@@ -7012,6 +7017,7 @@
           "content": {
             "application/json": {
               "example": {
+                "docsOnly": true,
                 "force": true
               },
               "schema": {
@@ -9732,6 +9738,7 @@
           "content": {
             "application/json": {
               "example": {
+                "docsOnly": true,
                 "force": true
               },
               "schema": {

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-04-20T13:55:27+09:00",
+  "generatedAt": "2026-04-27T07:13:45+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
       "sha256": "ae709eeb6bb93559601e672fd883bf40cf01050b5ab66c2c96eb5b7a90b2e471"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 343219,
-      "sha256": "380bb863dc324674d9fda8290cc18f8f6358f6d04c6c4bd11344d2f4bb789c3a"
+      "bytes": 343412,
+      "sha256": "171a4cec49ace7cb46261ac8e47955c86cd1d02dd4769c7075b392cd1bf0ae70"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
       "bytes": 7095,
@@ -28,11 +28,11 @@
       "sha256": "0fe451fc26f0964c79ba679a0432cd8eaa132cc56132606d7493ccbced996571"
     },
     "docs/reference/openapi.json": {
-      "bytes": 269715,
-      "sha256": "f284c9127ddc86baf025d204b5bdbd4d70cf3024d21618f4cb2eba445cbc1880"
+      "bytes": 269822,
+      "sha256": "d6881801fd18dfa5028b05879c860f92f395af6f6da14c2f6fd7d8efc567f67a"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-20T13:55:27+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-27T07:13:45+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "9cc9faa491091c7c28a6c1cb192e7b286dfd7acf"
+  "sourceRepoSha": "ab9ef2b84056682198e9fa92ed8a8a8f4a7fefd8"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-27T07:13:45+09:00",
+  "generatedAt": "2026-04-27T09:56:32+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
@@ -32,7 +32,7 @@
       "sha256": "d6881801fd18dfa5028b05879c860f92f395af6f6da14c2f6fd7d8efc567f67a"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-27T07:13:45+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-27T09:56:32+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "ab9ef2b84056682198e9fa92ed8a8a8f4a7fefd8"
+  "sourceRepoSha": "42852fc512c1634486751a052253b91bf08130b5"
 }

--- a/internal/api/previews-proxy.ts
+++ b/internal/api/previews-proxy.ts
@@ -1,0 +1,212 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import {
+  readJsonBodyLimited,
+  RequestBodyInvalidJsonError,
+  RequestBodyTooLargeError,
+} from "@internal/core/body";
+import { buildErrorLogFields } from "@internal/core/error-log";
+import { envServer } from "@internal/core/env-server";
+import { FetchTimeoutError } from "@internal/core/fetch-timeout";
+import { rateLimitFixedWindow } from "@internal/core/rate-limit";
+import { redis } from "@internal/core/redis";
+import { getClientIp } from "@internal/core/request-ip";
+
+export type PreviewProxyResponseKind = "json" | "text";
+
+export type PreviewProxyConfig = {
+  apiBase: string;
+  previewToken: string;
+  rateLimitWindowMs: number;
+  createMaxPerWindow: number;
+  createMaxPerSourceHostPerWindow: number;
+  statusMaxPerWindow: number;
+  streamMaxPerWindow: number;
+  maxBodyBytes: number;
+  upstreamCreateTimeoutMs: number;
+  upstreamStatusTimeoutMs: number;
+  upstreamStreamConnectTimeoutMs: number;
+};
+
+type PreviewProxyConfigResult =
+  | { ok: true; config: PreviewProxyConfig }
+  | { ok: false; response: Response };
+
+type PreviewRateLimitOptions = {
+  key: string;
+  limit: number;
+  windowMs: number;
+  responseKind: PreviewProxyResponseKind;
+  limitedMessage: string;
+  backendFailureLogMessage: string;
+};
+
+type PreviewBodyResult = { ok: true; payload: unknown } | { ok: false; response: Response };
+
+export function createPreviewProxyResponse(
+  kind: PreviewProxyResponseKind,
+  message: string,
+  status: number,
+  headers?: HeadersInit,
+): Response {
+  if (kind === "json") {
+    return NextResponse.json({ error: message }, { status, headers });
+  }
+  return new Response(message, {
+    status,
+    headers: {
+      "Content-Type": "text/plain",
+      ...headers,
+    },
+  });
+}
+
+export function getPreviewProxyConfig(
+  responseKind: PreviewProxyResponseKind,
+): PreviewProxyConfigResult {
+  const apiBase = envServer.NEXT_PUBLIC_WEBHOOKS_API_BASE.replace(/\/$/, "");
+  const previewToken = envServer.TRY_NOW_TOKEN;
+  if (!apiBase || !previewToken) {
+    return {
+      ok: false,
+      response: createPreviewProxyResponse(responseKind, "Preview service is not configured.", 500),
+    };
+  }
+
+  return {
+    ok: true,
+    config: {
+      apiBase,
+      previewToken,
+      rateLimitWindowMs: Number(envServer.WEBSITE_PREVIEW_RATE_LIMIT_WINDOW_MS),
+      createMaxPerWindow: Number(envServer.WEBSITE_PREVIEW_CREATE_MAX_PER_WINDOW),
+      createMaxPerSourceHostPerWindow: Number(
+        envServer.WEBSITE_PREVIEW_CREATE_MAX_PER_SOURCE_HOST_PER_WINDOW,
+      ),
+      statusMaxPerWindow: Number(envServer.WEBSITE_PREVIEW_STATUS_MAX_PER_WINDOW),
+      streamMaxPerWindow: Number(envServer.WEBSITE_PREVIEW_STREAM_MAX_PER_WINDOW),
+      maxBodyBytes: Number(envServer.WEBSITE_PREVIEW_MAX_BODY_BYTES),
+      upstreamCreateTimeoutMs: Number(envServer.WEBSITE_PREVIEW_UPSTREAM_CREATE_TIMEOUT_MS),
+      upstreamStatusTimeoutMs: Number(envServer.WEBSITE_PREVIEW_UPSTREAM_STATUS_TIMEOUT_MS),
+      upstreamStreamConnectTimeoutMs: Number(
+        envServer.WEBSITE_PREVIEW_UPSTREAM_STREAM_CONNECT_TIMEOUT_MS,
+      ),
+    },
+  };
+}
+
+export function isPreviewUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+export function validatePreviewId(
+  id: string,
+  responseKind: PreviewProxyResponseKind,
+): Response | null {
+  if (!id || !isPreviewUuid(id)) {
+    return createPreviewProxyResponse(responseKind, "Invalid preview id", 400);
+  }
+  return null;
+}
+
+export function readPreviewStatusToken(
+  request: NextRequest,
+  responseKind: PreviewProxyResponseKind,
+): { ok: true; statusToken: string } | { ok: false; response: Response } {
+  const statusToken = request.nextUrl.searchParams.get("token")?.trim() ?? "";
+  if (!statusToken) {
+    return {
+      ok: false,
+      response: createPreviewProxyResponse(responseKind, "Missing preview status token", 400),
+    };
+  }
+  return { ok: true, statusToken };
+}
+
+export async function enforcePreviewRateLimit({
+  key,
+  limit,
+  windowMs,
+  responseKind,
+  limitedMessage,
+  backendFailureLogMessage,
+}: PreviewRateLimitOptions): Promise<Response | null> {
+  try {
+    const rateLimit = await rateLimitFixedWindow(redis, {
+      key,
+      limit,
+      windowMs,
+    });
+    if (!rateLimit.allowed) {
+      const retryAfterSeconds = Math.max(1, Math.ceil((rateLimit.resetAtMs - Date.now()) / 1000));
+      return createPreviewProxyResponse(responseKind, limitedMessage, 429, {
+        "Retry-After": String(retryAfterSeconds),
+      });
+    }
+    return null;
+  } catch (error) {
+    console.error(
+      JSON.stringify(
+        {
+          level: "error",
+          message: backendFailureLogMessage,
+          ...buildErrorLogFields(error),
+        },
+        null,
+        0,
+      ),
+    );
+    return createPreviewProxyResponse(
+      responseKind,
+      "Service temporarily unavailable. Please try again shortly.",
+      503,
+    );
+  }
+}
+
+export function buildPreviewIpRateLimitKey(request: NextRequest, scope: string): string {
+  return `rl:v1:preview:${scope}:ip:${encodeURIComponent(getClientIp(request))}`;
+}
+
+export function buildPreviewHostRateLimitKey(sourceHost: string): string {
+  return `rl:v1:preview:create:host:${encodeURIComponent(sourceHost)}`;
+}
+
+export async function readPreviewJsonBodyLimited(
+  request: NextRequest,
+  maxBytes: number,
+): Promise<PreviewBodyResult> {
+  try {
+    return {
+      ok: true,
+      payload: await readJsonBodyLimited(request, { maxBytes }),
+    };
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      return {
+        ok: false,
+        response: NextResponse.json({ error: "Request body too large" }, { status: 413 }),
+      };
+    }
+    if (error instanceof RequestBodyInvalidJsonError) {
+      return {
+        ok: false,
+        response: NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 }),
+      };
+    }
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Invalid request body" }, { status: 400 }),
+    };
+  }
+}
+
+export function createPreviewFetchErrorResponse(
+  error: unknown,
+  responseKind: PreviewProxyResponseKind,
+): Response {
+  if (error instanceof FetchTimeoutError) {
+    return createPreviewProxyResponse(responseKind, "Preview service timed out", 504);
+  }
+  return createPreviewProxyResponse(responseKind, "Unable to reach preview service.", 502);
+}

--- a/internal/previews/preview-status-decision.ts
+++ b/internal/previews/preview-status-decision.ts
@@ -1,0 +1,167 @@
+import { parsePreviewRetryHint, type PreviewRetryHint } from "./preview-job-machine";
+import {
+  hasExplicitFailure,
+  isPreviewErrorCode,
+  isPreviewStage,
+  resolveStatusCheckFailure,
+  type PreviewErrorCode,
+  type PreviewStage,
+} from "./preview-sse";
+
+export type ResolvedPreviewStatusError = {
+  code: PreviewErrorCode | null;
+  stage: PreviewStage | null;
+  message: string;
+};
+
+export type PreviewStatusDecision =
+  | {
+      kind: "active";
+      status: "pending" | "processing";
+      stage: PreviewStage | null;
+      previewUrl?: string;
+      retryHint: PreviewRetryHint | null;
+    }
+  | {
+      kind: "terminal";
+      status: "ready" | "failed" | "expired";
+      previewUrl?: string | null;
+      error?: string | null;
+      errorCode?: PreviewErrorCode | null;
+      errorStage?: PreviewStage | null;
+    };
+
+export type PreviewErrorMessageResolver = (
+  code: PreviewErrorCode | null,
+  fallback?: string | null,
+) => string;
+
+type ResolvePreviewStatusDecisionInput = {
+  responseOk: boolean;
+  responseStatus: number;
+  payload: Record<string, unknown> | null;
+  defaultErrorMessage: string;
+  resolveErrorMessage?: PreviewErrorMessageResolver;
+  mapNotFoundToErrorCode?: boolean;
+};
+
+function readDetails(payload: Record<string, unknown> | null): Record<string, unknown> | null {
+  return payload && typeof payload.details === "object" && payload.details !== null
+    ? (payload.details as Record<string, unknown>)
+    : null;
+}
+
+export function resolvePreviewErrorPayload(
+  payload: Record<string, unknown> | null,
+  fallback: string,
+  resolveErrorMessage?: PreviewErrorMessageResolver,
+): ResolvedPreviewStatusError {
+  const details = readDetails(payload);
+  const code = isPreviewErrorCode(payload?.errorCode)
+    ? payload.errorCode
+    : details && isPreviewErrorCode(details.errorCode)
+      ? details.errorCode
+      : null;
+  const stage = isPreviewStage(payload?.errorStage)
+    ? payload.errorStage
+    : details && isPreviewStage(details.errorStage)
+      ? details.errorStage
+      : null;
+  const rawMessage =
+    (payload?.error as string | undefined) || (payload?.message as string | undefined) || fallback;
+
+  return {
+    code,
+    stage,
+    message: resolveErrorMessage ? resolveErrorMessage(code, rawMessage) : rawMessage,
+  };
+}
+
+export function resolvePreviewStatusDecision({
+  responseOk,
+  responseStatus,
+  payload,
+  defaultErrorMessage,
+  resolveErrorMessage,
+  mapNotFoundToErrorCode = false,
+}: ResolvePreviewStatusDecisionInput): PreviewStatusDecision {
+  if (!responseOk) {
+    if (responseStatus === 410) {
+      return {
+        kind: "terminal",
+        status: "expired",
+        error: null,
+        errorCode: "preview_expired",
+        errorStage: null,
+      };
+    }
+
+    if (responseStatus === 404 && mapNotFoundToErrorCode) {
+      return {
+        kind: "terminal",
+        status: "failed",
+        error: null,
+        errorCode: "preview_not_found",
+        errorStage: null,
+      };
+    }
+
+    const decision = resolveStatusCheckFailure(responseStatus, payload);
+    if (decision === "processing") {
+      return {
+        kind: "active",
+        status: "processing",
+        stage: null,
+        retryHint: null,
+      };
+    }
+
+    const resolved = resolvePreviewErrorPayload(payload, defaultErrorMessage, resolveErrorMessage);
+    return {
+      kind: "terminal",
+      status: resolved.code === "preview_expired" ? "expired" : "failed",
+      error: resolved.message,
+      errorCode: resolved.code,
+      errorStage: resolved.stage,
+    };
+  }
+
+  if (!payload) {
+    return {
+      kind: "active",
+      status: "processing",
+      stage: null,
+      retryHint: null,
+    };
+  }
+
+  if (payload.status === "ready") {
+    return {
+      kind: "terminal",
+      status: "ready",
+      previewUrl: typeof payload.previewUrl === "string" ? payload.previewUrl : null,
+      error: null,
+      errorCode: null,
+      errorStage: null,
+    };
+  }
+
+  if (payload.status === "failed" || hasExplicitFailure(payload)) {
+    const resolved = resolvePreviewErrorPayload(payload, defaultErrorMessage, resolveErrorMessage);
+    return {
+      kind: "terminal",
+      status: resolved.code === "preview_expired" ? "expired" : "failed",
+      error: resolved.message,
+      errorCode: resolved.code,
+      errorStage: resolved.stage,
+    };
+  }
+
+  return {
+    kind: "active",
+    status: payload.status === "pending" ? "pending" : "processing",
+    stage: isPreviewStage(payload.stage) ? payload.stage : null,
+    previewUrl: typeof payload.previewUrl === "string" ? payload.previewUrl : undefined,
+    retryHint: parsePreviewRetryHint(payload.retryHint),
+  };
+}

--- a/internal/previews/use-preview-status-runtime.ts
+++ b/internal/previews/use-preview-status-runtime.ts
@@ -2,15 +2,6 @@
 
 import { useEffect, useRef, useSyncExternalStore } from "react";
 import {
-  hasExplicitFailure,
-  isPreviewErrorCode,
-  isPreviewStage,
-  resolveStatusCheckFailure,
-  type PreviewErrorCode,
-  type PreviewStage,
-} from "./preview-sse";
-import { parsePreviewRetryHint, type PreviewRetryHint } from "./preview-job-machine";
-import {
   calculatePreviewStatusCenterRetryDelayMs,
   cleanupPreviewStatusCenterJobs,
   DEFAULT_PREVIEW_STATUS_CENTER_POLL_INTERVAL_MS,
@@ -25,50 +16,13 @@ import {
   updatePreviewStatusCenterJob,
   type PreviewStatusCenterJob,
 } from "./status-center-store";
+import { resolvePreviewStatusDecision } from "./preview-status-decision";
 
 const MAX_STATUS_RETRY_ATTEMPTS = 4;
 let previewStatusRuntimeOwner: symbol | null = null;
 
 export function resetPreviewStatusRuntimeOwnerForTests() {
   previewStatusRuntimeOwner = null;
-}
-
-function resolveErrorPayload(payload: Record<string, unknown> | null): {
-  code: PreviewErrorCode | null;
-  stage: PreviewStage | null;
-  message: string;
-} {
-  const details =
-    payload && typeof payload.details === "object" && payload.details !== null
-      ? (payload.details as Record<string, unknown>)
-      : null;
-
-  const code = isPreviewErrorCode(payload?.errorCode)
-    ? payload.errorCode
-    : details && isPreviewErrorCode(details.errorCode)
-      ? details.errorCode
-      : null;
-
-  const stage = isPreviewStage(payload?.errorStage)
-    ? payload.errorStage
-    : details && isPreviewStage(details.errorStage)
-      ? details.errorStage
-      : null;
-
-  const message =
-    (payload?.error as string | undefined) ||
-    (payload?.message as string | undefined) ||
-    "Unable to check preview status.";
-
-  return {
-    code,
-    stage,
-    message,
-  };
-}
-
-function resolveRetryHint(payload: Record<string, unknown> | null): PreviewRetryHint | null {
-  return parsePreviewRetryHint(payload?.retryHint);
 }
 
 export function usePreviewStatusRuntime() {
@@ -144,95 +98,31 @@ export function usePreviewStatusRuntime() {
           }
         }
 
-        if (!response.ok) {
-          if (response.status === 410) {
-            markPreviewStatusCenterJobTerminal(job.previewId, "expired", {
-              errorCode: "preview_expired",
-              error: null,
-              errorStage: null,
-            });
-            return;
-          }
-
-          if (response.status === 404) {
-            markPreviewStatusCenterJobTerminal(job.previewId, "failed", {
-              errorCode: "preview_not_found",
-              error: null,
-              errorStage: null,
-            });
-            return;
-          }
-
-          const decision = resolveStatusCheckFailure(response.status, payload);
-          if (decision === "processing") {
-            updatePreviewStatusCenterJob(job.previewId, {
-              status: "processing",
-              error: null,
-              errorCode: null,
-              errorStage: null,
-              retryHint: null,
-            });
-            resetPreviewStatusCenterJobRetry(job.previewId);
-            return;
-          }
-
-          const resolved = resolveErrorPayload(payload);
-          markPreviewStatusCenterJobTerminal(
-            job.previewId,
-            resolved.code === "preview_expired" ? "expired" : "failed",
-            {
-              error: resolved.message,
-              errorCode: resolved.code,
-              errorStage: resolved.stage,
-            },
-          );
-          return;
-        }
-
-        if (!payload) {
-          updatePreviewStatusCenterJob(job.previewId, {
-            status: "processing",
-            error: null,
-            errorCode: null,
-            errorStage: null,
-            retryHint: null,
+        const decision = resolvePreviewStatusDecision({
+          responseOk: response.ok,
+          responseStatus: response.status,
+          payload,
+          defaultErrorMessage: "Unable to check preview status.",
+          mapNotFoundToErrorCode: true,
+        });
+        if (decision.kind === "terminal") {
+          markPreviewStatusCenterJobTerminal(job.previewId, decision.status, {
+            previewUrl: decision.previewUrl,
+            error: decision.error,
+            errorCode: decision.errorCode,
+            errorStage: decision.errorStage,
           });
-          resetPreviewStatusCenterJobRetry(job.previewId);
-          return;
-        }
-
-        if (payload.status === "ready") {
-          markPreviewStatusCenterJobTerminal(job.previewId, "ready", {
-            previewUrl: typeof payload.previewUrl === "string" ? payload.previewUrl : null,
-            error: null,
-            errorCode: null,
-            errorStage: null,
-          });
-          return;
-        }
-
-        if (payload.status === "failed" || hasExplicitFailure(payload)) {
-          const resolved = resolveErrorPayload(payload);
-          markPreviewStatusCenterJobTerminal(
-            job.previewId,
-            resolved.code === "preview_expired" ? "expired" : "failed",
-            {
-              error: resolved.message,
-              errorCode: resolved.code,
-              errorStage: resolved.stage,
-            },
-          );
           return;
         }
 
         updatePreviewStatusCenterJob(job.previewId, {
-          status: payload.status === "pending" ? "pending" : "processing",
-          stage: isPreviewStage(payload.stage) ? payload.stage : undefined,
-          previewUrl: typeof payload.previewUrl === "string" ? payload.previewUrl : undefined,
+          status: decision.status,
+          stage: decision.stage ?? undefined,
+          previewUrl: decision.previewUrl,
           error: null,
           errorCode: null,
           errorStage: null,
-          retryHint: resolveRetryHint(payload),
+          retryHint: decision.retryHint,
         });
         resetPreviewStatusCenterJobRetry(job.previewId);
       } catch {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,10 +1,17 @@
 import createMDX from "@next/mdx";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   pageExtensions: ["ts", "tsx", "mdx"],
   allowedDevOrigins: ["localhost", "127.0.0.1"],
+  turbopack: {
+    root: projectRoot,
+  },
 };
 
 const withMDX = createMDX({


### PR DESCRIPTION
## Summary

- Why: keep the website preview/dashboard proxy flows and generated backend docs snapshots aligned with the backend branch.
- What: refines preview proxy/status handling, keeps webhook settings coverage, and syncs generated backend docs metadata to backend `42852fc5`.

## Testing

- [x] `corepack pnpm test`
- [x] `corepack pnpm check`
- [x] `corepack pnpm test:contracts`
- [x] `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm docs:sync:check` (required when CI cross-repo token is unavailable)

## Docs sync and capability matrix

- [x] Updated `docs/backend/DASHBOARD_SPECS.md` if user-facing backend capability coverage changed. (N/A; no dashboard capability change.)
- [x] Ran `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm docs:sync` and committed `content/docs/_generated/*` when backend HEAD advanced.