### PR TITLE
[codex] Add preview resume reset action

### DIFF
--- a/components/try-form.test.tsx
+++ b/components/try-form.test.tsx
@@ -84,6 +84,7 @@ const messages = {
   "try.progress.ready": "Ready",
   "try.status.timedOutNoEmail": "Processing is taking longer than expected.",
   "try.action.retry": "Retry preview",
+  "try.action.startAnother": "Start another preview",
   "try.action.checkStatus": "Check status",
   "try.action.checkingStatus": "Checking status...",
   "try.pending.emailPrompt": "Get notified when your preview is ready",
@@ -631,6 +632,14 @@ describe("TryForm preview status", () => {
       expect(screen.queryByRole("button", { name: "Generate preview" })).toBeNull();
       expect(screen.queryAllByTestId("mock-language-combobox")).toHaveLength(0);
       expect(screen.getByText("restore.example.com • English -> French")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Start another preview" }));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("https://example.com")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Generate preview" })).toBeTruthy();
+      expect(screen.queryByRole("list", { name: "Preview progress" })).toBeNull();
     });
   });
 

--- a/components/try-form.tsx
+++ b/components/try-form.tsx
@@ -644,6 +644,16 @@ export function TryForm({
     });
   }
 
+  function handleStartAnotherPreview() {
+    closeEventSource();
+    setLastRequestKey(null);
+    setSubmissionError(null);
+    timedOutRef.current = false;
+    setTimedOut(false);
+    setTimedOutWithEmail(false);
+    setPendingEmailStatus("idle");
+  }
+
   async function handleCheckStatus(
     previewIdOverride?: string,
     statusTokenOverride?: string,
@@ -1499,6 +1509,16 @@ export function TryForm({
                   )}
                 </div>
               ) : null}
+
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={handleStartAnotherPreview}
+                className="w-fit"
+              >
+                {t("try.action.startAnother")}
+              </Button>
             </div>
           </div>
         </div>

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-27T09:56:32+09:00",
+  "generatedAt": "2026-04-28T15:35:10+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
@@ -32,7 +32,7 @@
       "sha256": "d6881801fd18dfa5028b05879c860f92f395af6f6da14c2f6fd7d8efc567f67a"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-27T09:56:32+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-28T15:35:10+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "42852fc512c1634486751a052253b91bf08130b5"
+  "sourceRepoSha": "b4198df2e55f565b8b840c063f22822de4c50287"
 }

--- a/internal/i18n/messages/en.json
+++ b/internal/i18n/messages/en.json
@@ -171,6 +171,7 @@
   "try.center.retryHint": "Retry from the Try form.",
   "try.center.capacityHint": "Rendering capacity is temporarily full. We'll keep retrying automatically.",
   "try.action.retry": "Retry preview",
+  "try.action.startAnother": "Start another preview",
   "try.action.checkStatus": "Check status",
   "try.action.checkingStatus": "Checking...",
   "try.pending.emailPrompt": "Get notified when your preview is ready",

--- a/internal/i18n/messages/fr.json
+++ b/internal/i18n/messages/fr.json
@@ -662,6 +662,7 @@
   "try.center.retryHint": "Relancez depuis le formulaire d'aperçu.",
   "try.center.capacityHint": "La capacité de rendu est temporairement saturée. Nous continuons à réessayer automatiquement.",
   "try.action.retry": "Relancer l'aperçu",
+  "try.action.startAnother": "Lancer un autre aperçu",
   "try.action.checkStatus": "Vérifier le statut",
   "try.action.checkingStatus": "Vérification...",
   "try.pending.emailPrompt": "Recevez une notification quand votre aperçu est prêt",

--- a/internal/i18n/messages/ja.json
+++ b/internal/i18n/messages/ja.json
@@ -662,6 +662,7 @@
   "try.center.retryHint": "プレビューフォームから再試行してください。",
   "try.center.capacityHint": "レンダリング容量が一時的にいっぱいです。自動で再試行を続けます。",
   "try.action.retry": "プレビューを再試行",
+  "try.action.startAnother": "別のプレビューを開始",
   "try.action.checkStatus": "ステータスを確認",
   "try.action.checkingStatus": "確認中...",
   "try.pending.emailPrompt": "プレビューの準備ができたら通知を受け取る",

--- a/internal/previews/status-center-store.test.ts
+++ b/internal/previews/status-center-store.test.ts
@@ -77,6 +77,7 @@ describe("status-center-store", () => {
     const afterHydrate = getPreviewStatusCenterSnapshot();
     expect(afterHydrate.jobs).toHaveLength(1);
     expect(afterHydrate.jobs[0].sourceUrl).toBe("https://example.com");
+    expect(afterHydrate.jobs[0].nextPollAt).toBeLessThanOrEqual(Date.now());
   });
 
   it("marks a job terminal and supports dismissing it", () => {

--- a/internal/previews/status-center-store.ts
+++ b/internal/previews/status-center-store.ts
@@ -346,9 +346,7 @@ function parseStoredV2Job(value: unknown): PreviewStatusCenterJob | null {
     updatedAt: value.updatedAt,
     expiresAt: isFiniteNumber(value.expiresAt) ? value.expiresAt : null,
     retryCount: isFiniteNumber(value.retryCount) ? value.retryCount : 0,
-    nextPollAt: isFiniteNumber(value.nextPollAt)
-      ? value.nextPollAt
-      : Date.now() + DEFAULT_PREVIEW_STATUS_CENTER_POLL_INTERVAL_MS,
+    nextPollAt: isPreviewStatusCenterJobTerminal(status) ? Number.POSITIVE_INFINITY : Date.now(),
   });
 }
 
@@ -394,9 +392,7 @@ function parseStoredLegacyV1Job(value: unknown): PreviewStatusCenterJob | null {
     updatedAt: value.updatedAt,
     expiresAt: isFiniteNumber(value.expiresAt) ? value.expiresAt : null,
     retryCount: isFiniteNumber(value.retryCount) ? value.retryCount : 0,
-    nextPollAt: isFiniteNumber(value.nextPollAt)
-      ? value.nextPollAt
-      : Date.now() + DEFAULT_PREVIEW_STATUS_CENTER_POLL_INTERVAL_MS,
+    nextPollAt: isPreviewStatusCenterJobTerminal(status) ? Number.POSITIVE_INFINITY : Date.now(),
   });
 }
 


### PR DESCRIPTION
## Summary

- Why: Restored or resumed preview sessions left users without a direct way to abandon the current status panel and start a fresh preview.
- What: Adds a localized "Start another preview" action that resets preview status state, and hydrates non-terminal saved preview jobs for immediate polling while leaving terminal jobs idle.

## Testing

- [x] `corepack pnpm test -- components/try-form.test.tsx internal/previews/status-center-store.test.ts`
- [x] `corepack pnpm check`
- [x] `corepack pnpm test:contracts`
- [ ] `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check` (required when CI cross-repo token is unavailable)

## Docs sync and capability matrix

- [ ] Updated `docs/backend/DASHBOARD_SPECS.md` if user-facing backend capability coverage changed.
- [ ] Ran `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync` and committed `content/docs/_generated/*` when backend HEAD advanced.
