### PR TITLE
[codex] Verify restored preview status before resuming

### DIFF
--- a/components/preview-status-center.test.tsx
+++ b/components/preview-status-center.test.tsx
@@ -39,6 +39,7 @@ const messages = {
   "try.stage.saving": "Saving",
   "try.status.pending": "Pending",
   "try.status.processing": "Processing",
+  "try.status.restoring": "Checking preview status...",
   "try.status.ready": "Ready",
 } as const;
 

--- a/components/try-form.test.tsx
+++ b/components/try-form.test.tsx
@@ -733,8 +733,11 @@ describe("TryForm preview status", () => {
     });
   });
 
-  it("keeps restored sessions in checking state for transient status failures", async () => {
-    const fetchMock = vi.fn(async () => jsonResponse({ error: "Unavailable" }, 503));
+  it("shows retry and escape actions when restored status fetch fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network unavailable"))
+      .mockResolvedValueOnce(jsonResponse({ status: "processing", stage: "translating" }));
     vi.stubGlobal("fetch", fetchMock);
     storeRestoredActiveJob({
       previewId: "transient-3333-3333-3333-333333333333",
@@ -749,8 +752,16 @@ describe("TryForm preview status", () => {
       );
       expect(screen.getByText("Checking preview status...")).toBeTruthy();
       expect(screen.queryByRole("list", { name: "Preview progress" })).toBeNull();
-      expect(screen.queryByRole("button", { name: "Start another preview" })).toBeNull();
-      expect(screen.queryByRole("button", { name: "Retry preview" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Check status" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Start another preview" })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Check status" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(screen.getByRole("list", { name: "Preview progress" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Start another preview" })).toBeTruthy();
     });
   });
 

--- a/components/try-form.test.tsx
+++ b/components/try-form.test.tsx
@@ -74,6 +74,7 @@ const messages = {
   "try.status.capacityEmailHint": "Capacity email hint",
   "try.status.pending": "Pending",
   "try.status.processing": "Processing preview...",
+  "try.status.restoring": "Checking preview status...",
   "try.status.processingHint": "Processing hint",
   "try.status.ready": "Ready",
   "try.progress.label": "Preview progress",
@@ -182,6 +183,54 @@ function upsertDefaultJob(
     status,
     ...overrides,
   });
+}
+
+function storeRestoredActiveJob(
+  overrides: Partial<Record<string, unknown>> & {
+    previewId?: string;
+    requestKey?: string;
+    statusToken?: string;
+    sourceUrl?: string;
+    sourceLang?: string;
+    targetLang?: string;
+    status?: "pending" | "processing";
+    stage?: string | null;
+  } = {},
+) {
+  const now = Date.now();
+  const sourceUrl = overrides.sourceUrl ?? "https://restore.example.com";
+  const sourceLang = overrides.sourceLang ?? "en";
+  const targetLang = overrides.targetLang ?? "fr";
+  window.localStorage.setItem(
+    PREVIEW_STATUS_CENTER_STORAGE_KEY,
+    JSON.stringify([
+      {
+        previewId: overrides.previewId ?? "restore-1111-1111-1111-111111111111",
+        requestKey:
+          overrides.requestKey ??
+          buildPreviewStatusCenterRequestKey({
+            sourceUrl,
+            sourceLang,
+            targetLang,
+          }),
+        statusToken: overrides.statusToken ?? "restore-token",
+        sourceUrl,
+        sourceLang,
+        targetLang,
+        status: overrides.status ?? "processing",
+        stage: overrides.stage ?? "translating",
+        previewUrl: null,
+        error: null,
+        errorCode: null,
+        errorStage: null,
+        createdAt: now - 2_000,
+        updatedAt: now - 1_000,
+        expiresAt: null,
+        retryCount: 0,
+        nextPollAt: now + 5_000,
+      },
+    ]),
+  );
 }
 
 const originalEventSource = globalThis.EventSource;
@@ -474,6 +523,7 @@ describe("TryForm preview status", () => {
         errorCode: null,
         errorStage: null,
         retryHint: null,
+        remoteStatusVerified: true,
         createdAt: 1,
         updatedAt: 1,
         expiresAt: null,
@@ -496,6 +546,7 @@ describe("TryForm preview status", () => {
         errorCode: null,
         errorStage: null,
         retryHint: null,
+        remoteStatusVerified: true,
         createdAt: 1,
         updatedAt: 1,
         expiresAt: null,
@@ -518,6 +569,7 @@ describe("TryForm preview status", () => {
         errorCode: null,
         errorStage: null,
         retryHint: null,
+        remoteStatusVerified: true,
         createdAt: 1,
         updatedAt: 1,
         expiresAt: null,
@@ -540,6 +592,7 @@ describe("TryForm preview status", () => {
         errorCode: null,
         errorStage: null,
         retryHint: null,
+        remoteStatusVerified: true,
         createdAt: 1,
         updatedAt: 1,
         expiresAt: null,
@@ -562,6 +615,7 @@ describe("TryForm preview status", () => {
         errorCode: null,
         errorStage: null,
         retryHint: null,
+        remoteStatusVerified: true,
         createdAt: 1,
         updatedAt: 1,
         expiresAt: null,
@@ -594,6 +648,13 @@ describe("TryForm preview status", () => {
   });
 
   it("shows summary while restoring a running job", async () => {
+    let resolveStatus: (value: Response) => void = () => undefined;
+    const statusPromise = new Promise<Response>((resolve) => {
+      resolveStatus = resolve;
+    });
+    const fetchMock = vi.fn(async () => statusPromise);
+    vi.stubGlobal("fetch", fetchMock);
+
     const now = Date.now();
     window.localStorage.setItem(
       PREVIEW_STATUS_CENTER_STORAGE_KEY,
@@ -627,11 +688,19 @@ describe("TryForm preview status", () => {
     renderTryForm();
 
     await waitFor(() => {
-      expect(screen.getByRole("list", { name: "Preview progress" })).toBeTruthy();
+      expect(screen.getByText("Checking preview status...")).toBeTruthy();
       expect(screen.queryByPlaceholderText("https://example.com")).toBeNull();
       expect(screen.queryByRole("button", { name: "Generate preview" })).toBeNull();
       expect(screen.queryAllByTestId("mock-language-combobox")).toHaveLength(0);
       expect(screen.getByText("restore.example.com • English -> French")).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Start another preview" })).toBeNull();
+    });
+
+    resolveStatus(jsonResponse({ status: "processing", stage: "translating" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("list", { name: "Preview progress" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Start another preview" })).toBeTruthy();
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Start another preview" }));
@@ -640,6 +709,48 @@ describe("TryForm preview status", () => {
       expect(screen.getByPlaceholderText("https://example.com")).toBeTruthy();
       expect(screen.getByRole("button", { name: "Generate preview" })).toBeTruthy();
       expect(screen.queryByRole("list", { name: "Preview progress" })).toBeNull();
+    });
+  });
+
+  it("renders a terminal restored-session error before allowing another preview", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ error: "Not found" }, 404));
+    vi.stubGlobal("fetch", fetchMock);
+    storeRestoredActiveJob({
+      previewId: "not-found-2222-2222-2222-222222222222",
+      sourceUrl: "https://missing.example.com",
+    });
+
+    renderTryForm();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/previews/not-found-2222-2222-2222-222222222222?token=restore-token",
+      );
+      expect(screen.getByText("Preview not found")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Retry preview" })).toBeTruthy();
+      expect(screen.getByPlaceholderText("https://example.com")).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Start another preview" })).toBeNull();
+    });
+  });
+
+  it("keeps restored sessions in checking state for transient status failures", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ error: "Unavailable" }, 503));
+    vi.stubGlobal("fetch", fetchMock);
+    storeRestoredActiveJob({
+      previewId: "transient-3333-3333-3333-333333333333",
+      sourceUrl: "https://transient.example.com",
+    });
+
+    renderTryForm();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/previews/transient-3333-3333-3333-333333333333?token=restore-token",
+      );
+      expect(screen.getByText("Checking preview status...")).toBeTruthy();
+      expect(screen.queryByRole("list", { name: "Preview progress" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Start another preview" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Retry preview" })).toBeNull();
     });
   });
 
@@ -805,6 +916,7 @@ describe("TryForm preview status", () => {
                 : null,
           errorStage: phase.status === "failed" ? "generating_preview" : null,
           retryHint: null,
+          remoteStatusVerified: true,
           createdAt: 1,
           updatedAt: 1,
           expiresAt: null,
@@ -903,6 +1015,11 @@ describe("TryForm preview status", () => {
   });
 
   it("tracks restored previews and later terminal transitions", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ status: "processing" })),
+    );
+
     window.localStorage.setItem(
       PREVIEW_STATUS_CENTER_STORAGE_KEY,
       JSON.stringify([
@@ -1004,6 +1121,11 @@ describe("TryForm preview status", () => {
   });
 
   it("shows a basic request summary while a request is in flight", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ status: "pending" })),
+    );
+
     window.localStorage.setItem(
       PREVIEW_STATUS_CENTER_STORAGE_KEY,
       JSON.stringify([
@@ -1042,6 +1164,11 @@ describe("TryForm preview status", () => {
   });
 
   it("renders a compact progress stepper for running previews", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ status: "processing", stage: "translating" })),
+    );
+
     window.localStorage.setItem(
       PREVIEW_STATUS_CENTER_STORAGE_KEY,
       JSON.stringify([

--- a/components/try-form.tsx
+++ b/components/try-form.tsx
@@ -214,6 +214,9 @@ export function TryForm({
   const [pendingEmailStatus, setPendingEmailStatus] = useState<
     "idle" | "submitting" | "saved" | "error"
   >("idle");
+  const [restoredStatusRetryPreviewIds, setRestoredStatusRetryPreviewIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const baseLocale = getBaseLangTag(locale) ?? locale.trim().toLowerCase();
   const defaultTargetLang = baseLocale === "en" ? "fr" : "en";
   const [sourceLang, setSourceLang] = useState<string>(locale);
@@ -285,6 +288,10 @@ export function TryForm({
   const isRequestInFlight = isPreviewRunning || isRestoredStatusChecking;
   const showInProgressCard = isPreviewRunning && !isRestoredStatusChecking && !timedOut;
   const showRestoredStatusCheckingCard = isRestoredStatusChecking && !timedOut;
+  const canRetryRestoredStatusCheck =
+    trackedJob !== null &&
+    isRestoredStatusChecking &&
+    restoredStatusRetryPreviewIds.has(trackedJob.previewId);
   const showGeneratingState = isSameRequest && mode === "creating";
   const showEditableControls = !isRequestInFlight;
   const isSameLanguage =
@@ -659,10 +666,32 @@ export function TryForm({
     });
   }
 
+  function markRestoredStatusCheckRetryAvailable(previewId: string) {
+    restoredStatusCheckStartedRef.current.delete(previewId);
+    setRestoredStatusRetryPreviewIds((current) => {
+      const next = new Set(current);
+      next.add(previewId);
+      return next;
+    });
+  }
+
+  function clearRestoredStatusCheckRetry(previewId: string) {
+    setRestoredStatusRetryPreviewIds((current) => {
+      if (!current.has(previewId)) {
+        return current;
+      }
+      const next = new Set(current);
+      next.delete(previewId);
+      return next;
+    });
+  }
+
   function handleStartAnotherPreview() {
     closeEventSource();
     if (trackedJob) {
       removePreviewStatusCenterJob(trackedJob.previewId);
+      clearRestoredStatusCheckRetry(trackedJob.previewId);
+      restoredStatusCheckStartedRef.current.delete(trackedJob.previewId);
     }
     setLastRequestKey(null);
     setSubmissionError(null);
@@ -720,6 +749,7 @@ export function TryForm({
         timedOutRef.current = false;
         setTimedOut(false);
         setTimedOutWithEmail(false);
+        clearRestoredStatusCheckRetry(previewId);
         return true;
       }
 
@@ -730,9 +760,15 @@ export function TryForm({
         decision.retryHint,
         decision.remoteStatusVerified,
       );
+      if (decision.remoteStatusVerified) {
+        clearRestoredStatusCheckRetry(previewId);
+      } else {
+        markRestoredStatusCheckRetryAvailable(previewId);
+      }
       return false;
     } catch {
       syncStatusCenterActiveState(previewId, "processing", null, null, false);
+      markRestoredStatusCheckRetryAvailable(previewId);
       return false;
     } finally {
       if (mountedRef.current) {
@@ -753,13 +789,26 @@ export function TryForm({
     if (checkingStatus) {
       return;
     }
+    if (restoredStatusRetryPreviewIds.has(trackedJob.previewId)) {
+      return;
+    }
     if (restoredStatusCheckStartedRef.current.has(trackedJob.previewId)) {
       return;
     }
 
     restoredStatusCheckStartedRef.current.add(trackedJob.previewId);
     void handleCheckStatusRef.current(trackedJob.previewId, trackedJob.statusToken);
-  }, [checkingStatus, trackedJob]);
+  }, [checkingStatus, restoredStatusRetryPreviewIds, trackedJob]);
+
+  function handleRetryRestoredStatusCheck() {
+    if (!trackedJob || !isRestoredStatusChecking) {
+      return;
+    }
+    const previewId = trackedJob.previewId;
+    clearRestoredStatusCheckRetry(previewId);
+    restoredStatusCheckStartedRef.current.add(previewId);
+    void handleCheckStatus(trackedJob.previewId, trackedJob.statusToken);
+  }
 
   function connectSSE(previewId: string, statusToken: string) {
     closeEventSource();
@@ -1438,6 +1487,22 @@ export function TryForm({
             <p className="max-w-md text-xs leading-5 text-muted-foreground/90">
               {processingHintMessage}
             </p>
+            {canRetryRestoredStatusCheck ? (
+              <div className="flex flex-wrap items-center gap-2 pt-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={handleRetryRestoredStatusCheck}
+                  disabled={checkingStatus}
+                >
+                  {checkingStatus ? t("try.action.checkingStatus") : t("try.action.checkStatus")}
+                </Button>
+                <Button type="button" size="sm" variant="ghost" onClick={handleStartAnotherPreview}>
+                  {t("try.action.startAnother")}
+                </Button>
+              </div>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/components/try-form.tsx
+++ b/components/try-form.tsx
@@ -50,6 +50,7 @@ import {
   hydratePreviewStatusCenterStore,
   markPreviewStatusCenterJobTerminal,
   parsePreviewStatusCenterRequestKey,
+  removePreviewStatusCenterJob,
   selectLatestActivePreviewStatusCenterJob,
   selectLatestJobByRequestKey,
   selectPreferredPreviewStatusCenterJob,
@@ -229,6 +230,10 @@ export function TryForm({
   const trackedPreviewIdsRef = useRef<Set<string>>(new Set());
   const trackedPreviewStatusSignaturesRef = useRef<Map<string, string>>(new Map());
   const trackedPreviewTerminalRef = useRef<Set<string>>(new Set());
+  const restoredStatusCheckStartedRef = useRef<Set<string>>(new Set());
+  const handleCheckStatusRef = useRef<
+    (previewIdOverride?: string, statusTokenOverride?: string) => Promise<boolean | null>
+  >(async () => null);
 
   const trimmedUrl = url.trim();
   const submittedEmail = submittedEmailRef.current;
@@ -273,8 +278,13 @@ export function TryForm({
   const isSameRequest = lastRequestKey !== null && currentRequestKey === lastRequestKey;
   const isPreviewRunning =
     mode === "creating" || mode === "running_pending" || mode === "running_processing";
-  const isRequestInFlight = isPreviewRunning;
-  const showInProgressCard = isPreviewRunning && !timedOut;
+  const isRestoredStatusChecking =
+    trackedJob !== null &&
+    (trackedJob.status === "pending" || trackedJob.status === "processing") &&
+    !trackedJob.remoteStatusVerified;
+  const isRequestInFlight = isPreviewRunning || isRestoredStatusChecking;
+  const showInProgressCard = isPreviewRunning && !isRestoredStatusChecking && !timedOut;
+  const showRestoredStatusCheckingCard = isRestoredStatusChecking && !timedOut;
   const showGeneratingState = isSameRequest && mode === "creating";
   const showEditableControls = !isRequestInFlight;
   const isSameLanguage =
@@ -491,6 +501,9 @@ export function TryForm({
     if (!trackedPreviewIdsRef.current.has(trackedJob.previewId)) {
       return;
     }
+    if (!trackedJob.remoteStatusVerified) {
+      return;
+    }
 
     const signature = buildPreviewAnalyticsSignature(trackedJob);
     const previousSignature = trackedPreviewStatusSignaturesRef.current.get(trackedJob.previewId);
@@ -615,6 +628,7 @@ export function TryForm({
     status: "pending" | "processing",
     stage: PreviewStage | null,
     retryHint?: PreviewRetryHint | null,
+    remoteStatusVerified = true,
   ) {
     updatePreviewStatusCenterJob(previewId, {
       status,
@@ -623,6 +637,7 @@ export function TryForm({
       errorCode: null,
       errorStage: null,
       retryHint: retryHint ?? null,
+      remoteStatusVerified,
     });
   }
 
@@ -646,6 +661,9 @@ export function TryForm({
 
   function handleStartAnotherPreview() {
     closeEventSource();
+    if (trackedJob) {
+      removePreviewStatusCenterJob(trackedJob.previewId);
+    }
     setLastRequestKey(null);
     setSubmissionError(null);
     timedOutRef.current = false;
@@ -705,10 +723,16 @@ export function TryForm({
         return true;
       }
 
-      syncStatusCenterActiveState(previewId, decision.status, decision.stage, decision.retryHint);
+      syncStatusCenterActiveState(
+        previewId,
+        decision.status,
+        decision.stage,
+        decision.retryHint,
+        decision.remoteStatusVerified,
+      );
       return false;
     } catch {
-      syncStatusCenterActiveState(previewId, "processing", null);
+      syncStatusCenterActiveState(previewId, "processing", null, null, false);
       return false;
     } finally {
       if (mountedRef.current) {
@@ -716,6 +740,26 @@ export function TryForm({
       }
     }
   }
+
+  handleCheckStatusRef.current = handleCheckStatus;
+
+  useEffect(() => {
+    if (!trackedJob || trackedJob.remoteStatusVerified) {
+      return;
+    }
+    if (trackedJob.status !== "pending" && trackedJob.status !== "processing") {
+      return;
+    }
+    if (checkingStatus) {
+      return;
+    }
+    if (restoredStatusCheckStartedRef.current.has(trackedJob.previewId)) {
+      return;
+    }
+
+    restoredStatusCheckStartedRef.current.add(trackedJob.previewId);
+    void handleCheckStatusRef.current(trackedJob.previewId, trackedJob.statusToken);
+  }, [checkingStatus, trackedJob]);
 
   function connectSSE(previewId: string, statusToken: string) {
     closeEventSource();
@@ -882,6 +926,7 @@ export function TryForm({
       errorStage: null,
       previewUrl: options.initialPreviewUrl,
       retryHint: options.initialRetryHint ?? null,
+      remoteStatusVerified: true,
       retryCount: 0,
     });
 
@@ -1379,6 +1424,21 @@ export function TryForm({
               </div>
             </>
           )}
+        </div>
+      ) : null}
+
+      {statusMessage && showRestoredStatusCheckingCard ? (
+        <div className="space-y-4 pt-1">
+          <p className="break-words text-sm font-medium text-foreground">{requestSummary}</p>
+          <div className="space-y-1 rounded-md border border-border/70 bg-muted/35 px-4 py-3">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <LoaderCircle className="h-4 w-4 animate-spin text-primary" />
+              <span>{statusMessage}</span>
+            </div>
+            <p className="max-w-md text-xs leading-5 text-muted-foreground/90">
+              {processingHintMessage}
+            </p>
+          </div>
         </div>
       ) : null}
 

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-28T15:58:53+09:00",
+  "generatedAt": "2026-04-28T18:57:56+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
@@ -32,7 +32,7 @@
       "sha256": "d6881801fd18dfa5028b05879c860f92f395af6f6da14c2f6fd7d8efc567f67a"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-28T15:58:53+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-28T18:57:56+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "acb7f3e199ccb3179c76d074af393318eb82ca92"
+  "sourceRepoSha": "a16e8887717bd9cbd7cfe6c813240989cc60653c"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-28T15:35:10+09:00",
+  "generatedAt": "2026-04-28T15:58:53+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
@@ -32,7 +32,7 @@
       "sha256": "d6881801fd18dfa5028b05879c860f92f395af6f6da14c2f6fd7d8efc567f67a"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-28T15:35:10+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-28T15:58:53+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "b4198df2e55f565b8b840c063f22822de4c50287"
+  "sourceRepoSha": "acb7f3e199ccb3179c76d074af393318eb82ca92"
 }

--- a/internal/i18n/messages/en.json
+++ b/internal/i18n/messages/en.json
@@ -129,6 +129,7 @@
   "try.status.capacityEmailHint": "Rendering capacity is temporarily full. We'll keep retrying automatically. Leave your email to be notified when it's ready.",
   "try.status.pending": "Queued for translation...",
   "try.status.processing": "Translating your page...",
+  "try.status.restoring": "Checking preview status...",
   "try.status.ready": "Preview ready. Open or copy the link below.",
   "try.progress.label": "Preview progress",
   "try.progress.queued": "Queued",

--- a/internal/i18n/messages/fr.json
+++ b/internal/i18n/messages/fr.json
@@ -115,6 +115,7 @@
   "try.status.creating": "Création de la prévisualisation...",
   "try.status.pending": "En file d'attente pour traduction...",
   "try.status.processing": "Traduction de votre page en cours...",
+  "try.status.restoring": "Vérification du statut de l'aperçu...",
   "try.status.ready": "Prévisualisation prête. Ouvrez ou copiez le lien ci-dessous.",
   "try.progress.label": "Progression de l'aperçu",
   "try.progress.queued": "En attente",

--- a/internal/i18n/messages/ja.json
+++ b/internal/i18n/messages/ja.json
@@ -115,6 +115,7 @@
   "try.status.creating": "プレビューを作成中...",
   "try.status.pending": "翻訳キューに追加されました...",
   "try.status.processing": "ページを翻訳中...",
+  "try.status.restoring": "プレビューのステータスを確認中...",
   "try.status.ready": "プレビューの準備ができました。以下のリンクを開くかコピーしてください。",
   "try.progress.label": "プレビューの進行状況",
   "try.progress.queued": "キュー待ち",

--- a/internal/previews/preview-job-machine.test.ts
+++ b/internal/previews/preview-job-machine.test.ts
@@ -22,6 +22,7 @@ function buildJob(overrides: Partial<PreviewJob> = {}): PreviewJob {
     errorCode: null,
     errorStage: null,
     retryHint: null,
+    remoteStatusVerified: true,
     createdAt: now,
     updatedAt: now,
     expiresAt: null,

--- a/internal/previews/preview-job-machine.ts
+++ b/internal/previews/preview-job-machine.ts
@@ -22,6 +22,7 @@ export type PreviewJob = {
   errorCode: PreviewErrorCode | null;
   errorStage: PreviewStage | null;
   retryHint: PreviewRetryHint | null;
+  remoteStatusVerified: boolean;
   createdAt: number;
   updatedAt: number;
   expiresAt: number | null;
@@ -43,6 +44,7 @@ export type PreviewJobUpsertInput = {
   errorCode?: PreviewErrorCode | null;
   errorStage?: PreviewStage | null;
   retryHint?: PreviewRetryHint | null;
+  remoteStatusVerified?: boolean;
   expiresAt?: number | null;
   retryCount?: number;
   nextPollAt?: number;
@@ -61,6 +63,7 @@ export type PreviewJobPatch = Partial<{
   errorCode: PreviewErrorCode | null;
   errorStage: PreviewStage | null;
   retryHint: PreviewRetryHint | null;
+  remoteStatusVerified: boolean;
   expiresAt: number | null;
   retryCount: number;
   nextPollAt: number;
@@ -231,6 +234,9 @@ function reduceUpsert(
       : input.retryHint === undefined
         ? (existing?.retryHint ?? null)
         : input.retryHint,
+    remoteStatusVerified: terminal
+      ? true
+      : (input.remoteStatusVerified ?? existing?.remoteStatusVerified ?? true),
     createdAt: existing?.createdAt ?? context.now,
     updatedAt: context.now,
     expiresAt: input.expiresAt ?? existing?.expiresAt ?? null,
@@ -277,6 +283,9 @@ function reducePatch(
       : patch.retryHint === undefined
         ? existing.retryHint
         : patch.retryHint,
+    remoteStatusVerified: terminal
+      ? true
+      : (patch.remoteStatusVerified ?? existing.remoteStatusVerified),
     expiresAt: patch.expiresAt === undefined ? existing.expiresAt : patch.expiresAt,
     updatedAt: context.now,
     retryCount: terminal
@@ -315,6 +324,7 @@ export function reducePreviewJob(
         retryCount: 0,
         nextPollAt: Number.POSITIVE_INFINITY,
         stage: null,
+        remoteStatusVerified: true,
       },
       context,
     );

--- a/internal/previews/preview-status-decision.ts
+++ b/internal/previews/preview-status-decision.ts
@@ -21,6 +21,7 @@ export type PreviewStatusDecision =
       stage: PreviewStage | null;
       previewUrl?: string;
       retryHint: PreviewRetryHint | null;
+      remoteStatusVerified: boolean;
     }
   | {
       kind: "terminal";
@@ -113,6 +114,7 @@ export function resolvePreviewStatusDecision({
         status: "processing",
         stage: null,
         retryHint: null,
+        remoteStatusVerified: false,
       };
     }
 
@@ -132,6 +134,7 @@ export function resolvePreviewStatusDecision({
       status: "processing",
       stage: null,
       retryHint: null,
+      remoteStatusVerified: false,
     };
   }
 
@@ -163,5 +166,6 @@ export function resolvePreviewStatusDecision({
     stage: isPreviewStage(payload.stage) ? payload.stage : null,
     previewUrl: typeof payload.previewUrl === "string" ? payload.previewUrl : undefined,
     retryHint: parsePreviewRetryHint(payload.retryHint),
+    remoteStatusVerified: true,
   };
 }

--- a/internal/previews/status-center-i18n.ts
+++ b/internal/previews/status-center-i18n.ts
@@ -61,6 +61,7 @@ export const PREVIEW_STATUS_CENTER_MESSAGE_KEYS: ReadonlyArray<string> = [
   "try.status.pending",
   "try.status.processing",
   "try.status.ready",
+  "try.status.restoring",
 ];
 
 type PreviewStatusCenterTranslator = (
@@ -93,6 +94,9 @@ export function resolvePreviewStatusCenterMessage(
   job: PreviewStatusCenterJob,
   t: PreviewStatusCenterTranslator,
 ): string {
+  if (!job.remoteStatusVerified && (job.status === "pending" || job.status === "processing")) {
+    return t("try.status.restoring");
+  }
   if (job.status === "pending") {
     return resolvePreviewStatusCenterStageMessage(job.stage, t) ?? t("try.status.pending");
   }

--- a/internal/previews/status-center-store.test.ts
+++ b/internal/previews/status-center-store.test.ts
@@ -78,6 +78,7 @@ describe("status-center-store", () => {
     expect(afterHydrate.jobs).toHaveLength(1);
     expect(afterHydrate.jobs[0].sourceUrl).toBe("https://example.com");
     expect(afterHydrate.jobs[0].nextPollAt).toBeLessThanOrEqual(Date.now());
+    expect(afterHydrate.jobs[0].remoteStatusVerified).toBe(false);
   });
 
   it("marks a job terminal and supports dismissing it", () => {
@@ -248,6 +249,7 @@ describe("status-center-store", () => {
       errorCode: null,
       errorStage: null,
       retryHint: null,
+      remoteStatusVerified: true,
       expiresAt: null,
       retryCount: 0,
       nextPollAt: Number.POSITIVE_INFINITY,
@@ -266,6 +268,7 @@ describe("status-center-store", () => {
       errorCode: null,
       errorStage: null,
       retryHint: null,
+      remoteStatusVerified: true,
       expiresAt: null,
       retryCount: 0,
       nextPollAt: Number.POSITIVE_INFINITY,

--- a/internal/previews/status-center-store.ts
+++ b/internal/previews/status-center-store.ts
@@ -240,6 +240,7 @@ function normalizeJob(job: PreviewStatusCenterJob): PreviewStatusCenterJob {
         : Date.now() + DEFAULT_PREVIEW_STATUS_CENTER_POLL_INTERVAL_MS,
     stage: terminal ? null : job.stage,
     retryHint: terminal ? null : job.retryHint,
+    remoteStatusVerified: terminal ? true : job.remoteStatusVerified,
   };
 }
 
@@ -342,6 +343,7 @@ function parseStoredV2Job(value: unknown): PreviewStatusCenterJob | null {
     errorCode: parseOptionalPreviewErrorCode(value.errorCode),
     errorStage,
     retryHint: parsePreviewRetryHint(value.retryHint),
+    remoteStatusVerified: isPreviewStatusCenterJobTerminal(status),
     createdAt: value.createdAt,
     updatedAt: value.updatedAt,
     expiresAt: isFiniteNumber(value.expiresAt) ? value.expiresAt : null,
@@ -388,6 +390,7 @@ function parseStoredLegacyV1Job(value: unknown): PreviewStatusCenterJob | null {
     errorCode: parseOptionalPreviewErrorCode(value.errorCode),
     errorStage: legacyStage,
     retryHint: null,
+    remoteStatusVerified: isPreviewStatusCenterJobTerminal(status),
     createdAt: value.createdAt,
     updatedAt: value.updatedAt,
     expiresAt: isFiniteNumber(value.expiresAt) ? value.expiresAt : null,
@@ -593,6 +596,7 @@ function migrateLegacyJobsFromStorage(now: number): {
         ? existing.status
         : resolveNextPreviewJobPhase(existing.status, "processing"),
       stage: terminal ? null : existing.stage,
+      remoteStatusVerified: terminal,
       updatedAt: Math.max(existing.updatedAt, pending.updatedAt),
       nextPollAt: terminal
         ? Number.POSITIVE_INFINITY
@@ -615,6 +619,7 @@ function migrateLegacyJobsFromStorage(now: number): {
         errorCode: null,
         errorStage: null,
         retryHint: null,
+        remoteStatusVerified: false,
         createdAt: pending.updatedAt,
         updatedAt: pending.updatedAt,
         expiresAt: null,

--- a/internal/previews/use-preview-status-runtime.test.tsx
+++ b/internal/previews/use-preview-status-runtime.test.tsx
@@ -222,4 +222,85 @@ describe("usePreviewStatusRuntime", () => {
       });
     });
   });
+
+  it("keeps empty successful status responses unverified and schedules a retry", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("", {
+            status: 200,
+          }),
+      ),
+    );
+
+    upsertPreviewStatusCenterJob({
+      previewId: "55555555-5555-5555-5555-555555555555",
+      requestKey: buildPreviewStatusCenterRequestKey({
+        sourceUrl: "https://example.com",
+        sourceLang: "en",
+        targetLang: "fr",
+      }),
+      statusToken: "token",
+      sourceUrl: "https://example.com",
+      sourceLang: "en",
+      targetLang: "fr",
+      status: "processing",
+      nextPollAt: 0,
+      remoteStatusVerified: false,
+    });
+
+    render(<RuntimeHarness />);
+
+    await waitFor(() => {
+      const job = getPreviewStatusCenterJobsSnapshot().find(
+        (entry) => entry.previewId === "55555555-5555-5555-5555-555555555555",
+      );
+      expect(job?.status).toBe("processing");
+      expect(job?.remoteStatusVerified).toBe(false);
+      expect(job?.retryCount).toBe(1);
+      expect(job?.nextPollAt).toBeGreaterThan(Date.now());
+    });
+  });
+
+  it("terminalizes restored jobs after repeated transient status failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ error: "Unavailable" }), {
+            status: 503,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+
+    upsertPreviewStatusCenterJob({
+      previewId: "66666666-6666-6666-6666-666666666666",
+      requestKey: buildPreviewStatusCenterRequestKey({
+        sourceUrl: "https://example.com",
+        sourceLang: "en",
+        targetLang: "fr",
+      }),
+      statusToken: "token",
+      sourceUrl: "https://example.com",
+      sourceLang: "en",
+      targetLang: "fr",
+      status: "processing",
+      retryCount: 4,
+      nextPollAt: 0,
+      remoteStatusVerified: false,
+    });
+
+    render(<RuntimeHarness />);
+
+    await waitFor(() => {
+      const job = getPreviewStatusCenterJobsSnapshot().find(
+        (entry) => entry.previewId === "66666666-6666-6666-6666-666666666666",
+      );
+      expect(job?.status).toBe("failed");
+      expect(job?.errorCode).toBe("unknown");
+      expect(job?.remoteStatusVerified).toBe(true);
+    });
+  });
 });

--- a/internal/previews/use-preview-status-runtime.ts
+++ b/internal/previews/use-preview-status-runtime.ts
@@ -115,6 +115,16 @@ export function usePreviewStatusRuntime() {
           return;
         }
 
+        const retryCount = decision.remoteStatusVerified ? 0 : job.retryCount + 1;
+        if (!decision.remoteStatusVerified && retryCount > MAX_STATUS_RETRY_ATTEMPTS) {
+          markPreviewStatusCenterJobTerminal(job.previewId, "failed", {
+            errorCode: "unknown",
+            error: "Unable to check preview status.",
+            errorStage: null,
+          });
+          return;
+        }
+
         updatePreviewStatusCenterJob(job.previewId, {
           status: decision.status,
           stage: decision.stage ?? undefined,
@@ -123,8 +133,15 @@ export function usePreviewStatusRuntime() {
           errorCode: null,
           errorStage: null,
           retryHint: decision.retryHint,
+          remoteStatusVerified: decision.remoteStatusVerified,
+          retryCount,
+          nextPollAt: decision.remoteStatusVerified
+            ? undefined
+            : Date.now() + calculatePreviewStatusCenterRetryDelayMs(retryCount),
         });
-        resetPreviewStatusCenterJobRetry(job.previewId);
+        if (decision.remoteStatusVerified) {
+          resetPreviewStatusCenterJobRetry(job.previewId);
+        }
       } catch {
         const retryCount = job.retryCount + 1;
         if (retryCount > MAX_STATUS_RETRY_ATTEMPTS) {


### PR DESCRIPTION
## Summary

- Why: Locally restored preview sessions were being treated as authoritative before the backend confirmed their current state, which could leave stale or missing previews stuck in the Try form with an always-visible new-preview action.
- What: Adds a shared `remoteStatusVerified` flag to preview jobs, marks hydrated active jobs as unverified, checks remote status before showing normal running UI, keeps transient status failures in retry flow, terminalizes definitive or exhausted failures, and removes the tracked stored job when starting another preview.

## Testing

- [x] `corepack pnpm test`
- [x] `corepack pnpm check`
- [x] `corepack pnpm test:contracts` (covered by `check:ci`)
- [x] `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm docs:sync:check` (via `check:ci`)
- [x] CI-env `corepack pnpm build`

## Docs sync and capability matrix

- [x] Updated `docs/backend/DASHBOARD_SPECS.md` if user-facing backend capability coverage changed. Not applicable; no dashboard capability coverage changed.
- [x] Ran `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm docs:sync` and committed `content/docs/_generated/*` when backend HEAD advanced.
