### PR TITLE
Keep stale preview restores from hijacking Try form

### DIFF
--- a/components/try-form.test.tsx
+++ b/components/try-form.test.tsx
@@ -201,6 +201,8 @@ function storeRestoredActiveJob(
   const sourceUrl = overrides.sourceUrl ?? "https://restore.example.com";
   const sourceLang = overrides.sourceLang ?? "en";
   const targetLang = overrides.targetLang ?? "fr";
+  const createdAt = typeof overrides.createdAt === "number" ? overrides.createdAt : now - 2_000;
+  const updatedAt = typeof overrides.updatedAt === "number" ? overrides.updatedAt : now - 1_000;
   window.localStorage.setItem(
     PREVIEW_STATUS_CENTER_STORAGE_KEY,
     JSON.stringify([
@@ -223,8 +225,8 @@ function storeRestoredActiveJob(
         error: null,
         errorCode: null,
         errorStage: null,
-        createdAt: now - 2_000,
-        updatedAt: now - 1_000,
+        createdAt,
+        updatedAt,
         expiresAt: null,
         retryCount: 0,
         nextPollAt: now + 5_000,
@@ -238,6 +240,7 @@ const originalEventSource = globalThis.EventSource;
 beforeEach(() => {
   resetPreviewStatusCenterStoreForTests();
   window.localStorage.clear();
+  window.sessionStorage.clear();
   MockEventSource.instances = [];
   globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
   captureAnalyticsEvent.mockReset();
@@ -248,6 +251,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
   window.localStorage.clear();
+  window.sessionStorage.clear();
   resetPreviewStatusCenterStoreForTests();
   globalThis.EventSource = originalEventSource;
 });
@@ -731,6 +735,102 @@ describe("TryForm preview status", () => {
       expect(screen.getByPlaceholderText("https://example.com")).toBeTruthy();
       expect(screen.queryByRole("button", { name: "Start another preview" })).toBeNull();
     });
+  });
+
+  it("prefers the tab-pinned fresh preview over an older active preview on refresh", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ status: "processing", stage: "fetching_page" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const now = Date.now();
+    const staleRequestKey = buildPreviewStatusCenterRequestKey({
+      sourceUrl: "https://stale.example.com",
+      sourceLang: "en",
+      targetLang: "fr",
+    });
+    const freshRequestKey = buildPreviewStatusCenterRequestKey({
+      sourceUrl: "https://fresh.example.com",
+      sourceLang: "en",
+      targetLang: "fr",
+    });
+    window.localStorage.setItem(
+      PREVIEW_STATUS_CENTER_STORAGE_KEY,
+      JSON.stringify([
+        {
+          previewId: "stale-4444-4444-4444-444444444444",
+          requestKey: staleRequestKey,
+          statusToken: "stale-token",
+          sourceUrl: "https://stale.example.com",
+          sourceLang: "en",
+          targetLang: "fr",
+          status: "processing",
+          stage: "translating",
+          previewUrl: null,
+          error: null,
+          errorCode: null,
+          errorStage: null,
+          createdAt: now - 60 * 60 * 1000,
+          updatedAt: now + 1_000,
+          expiresAt: null,
+          retryCount: 0,
+          nextPollAt: now + 5_000,
+        },
+        {
+          previewId: "fresh-5555-5555-5555-555555555555",
+          requestKey: freshRequestKey,
+          statusToken: "fresh-token",
+          sourceUrl: "https://fresh.example.com",
+          sourceLang: "en",
+          targetLang: "fr",
+          status: "processing",
+          stage: "fetching_page",
+          previewUrl: null,
+          error: null,
+          errorCode: null,
+          errorStage: null,
+          createdAt: now - 5_000,
+          updatedAt: now - 4_000,
+          expiresAt: null,
+          retryCount: 0,
+          nextPollAt: now + 5_000,
+        },
+      ]),
+    );
+    window.sessionStorage.setItem(
+      "weblingo:try-form:active-preview-id:v1",
+      "fresh-5555-5555-5555-555555555555",
+    );
+
+    renderTryForm();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/previews/fresh-5555-5555-5555-555555555555?token=fresh-token",
+      );
+      expect(screen.getByText("fresh.example.com • English -> French")).toBeTruthy();
+      expect(screen.queryByText("stale.example.com • English -> French")).toBeNull();
+    });
+  });
+
+  it("does not let an old active preview take over an empty form on refresh", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ status: "processing" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const now = Date.now();
+    storeRestoredActiveJob({
+      previewId: "old-6666-6666-6666-666666666666",
+      sourceUrl: "https://old.example.com",
+      createdAt: now - 60 * 60 * 1000,
+      updatedAt: now,
+    });
+
+    renderTryForm();
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("https://example.com")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Generate preview" })).toBeTruthy();
+      expect(screen.queryByText("old.example.com • English -> French")).toBeNull();
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("shows retry and escape actions when restored status fetch fails", async () => {

--- a/components/try-form.tsx
+++ b/components/try-form.tsx
@@ -51,9 +51,8 @@ import {
   markPreviewStatusCenterJobTerminal,
   parsePreviewStatusCenterRequestKey,
   removePreviewStatusCenterJob,
-  selectLatestActivePreviewStatusCenterJob,
   selectLatestJobByRequestKey,
-  selectPreferredPreviewStatusCenterJob,
+  selectRestorablePreviewStatusCenterJob,
   subscribePreviewStatusCenterStore,
   upsertPreviewStatusCenterJob,
   updatePreviewStatusCenterJob,
@@ -86,12 +85,55 @@ type ConnectStatusUpdatesOptions = {
 };
 
 const emailSchema = z.email();
+const ACTIVE_PREVIEW_SESSION_STORAGE_KEY = "weblingo:try-form:active-preview-id:v1";
 
 function isAbortLikeError(error: unknown): boolean {
   return (
     (error instanceof DOMException && error.name === "AbortError") ||
     (error instanceof Error && error.name === "AbortError")
   );
+}
+
+function canUseSessionStorage() {
+  return typeof window !== "undefined" && typeof window.sessionStorage !== "undefined";
+}
+
+function readActivePreviewIdFromSession(): string | null {
+  if (!canUseSessionStorage()) {
+    return null;
+  }
+  try {
+    return window.sessionStorage.getItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeActivePreviewIdToSession(previewId: string) {
+  if (!canUseSessionStorage()) {
+    return;
+  }
+  try {
+    window.sessionStorage.setItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY, previewId);
+  } catch {
+    // Ignore storage failures; local preview status still works without tab pinning.
+  }
+}
+
+function clearActivePreviewIdFromSession(previewId?: string | null) {
+  if (!canUseSessionStorage()) {
+    return;
+  }
+  try {
+    if (
+      !previewId ||
+      window.sessionStorage.getItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY) === previewId
+    ) {
+      window.sessionStorage.removeItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore storage failures.
+  }
 }
 
 function buildPreviewAnalyticsSignature(job: PreviewStatusCenterJob): string {
@@ -428,11 +470,15 @@ export function TryForm({
     }
     restoreAttemptedRef.current = true;
 
-    const restoredJob =
-      selectLatestActivePreviewStatusCenterJob(jobs) ?? selectPreferredPreviewStatusCenterJob(jobs);
+    const restoredJob = selectRestorablePreviewStatusCenterJob({
+      jobs,
+      currentRequestKey: trimmedUrl ? currentRequestKey : null,
+      pinnedPreviewId: readActivePreviewIdFromSession(),
+    });
     if (!restoredJob) {
       return;
     }
+    writeActivePreviewIdToSession(restoredJob.previewId);
 
     trackedPreviewIdsRef.current.add(restoredJob.previewId);
     if (
@@ -464,7 +510,7 @@ export function TryForm({
     setUrl((current) => (current ? current : parsedRequest.sourceUrl));
     setSourceLang((current) => (current ? current : parsedRequest.sourceLang));
     setTargetLang((current) => (current ? current : parsedRequest.targetLang));
-  }, [jobs, lastRequestKey]);
+  }, [currentRequestKey, jobs, lastRequestKey, trimmedUrl]);
 
   useEffect(() => {
     if (
@@ -692,6 +738,7 @@ export function TryForm({
       removePreviewStatusCenterJob(trackedJob.previewId);
       clearRestoredStatusCheckRetry(trackedJob.previewId);
       restoredStatusCheckStartedRef.current.delete(trackedJob.previewId);
+      clearActivePreviewIdFromSession(trackedJob.previewId);
     }
     setLastRequestKey(null);
     setSubmissionError(null);
@@ -978,6 +1025,7 @@ export function TryForm({
       remoteStatusVerified: true,
       retryCount: 0,
     });
+    writeActivePreviewIdToSession(previewId);
 
     if (typeof window === "undefined" || typeof window.EventSource !== "function") {
       void handleCheckStatus(previewId, statusToken);

--- a/components/try-form.tsx
+++ b/components/try-form.tsx
@@ -45,17 +45,20 @@ import {
 } from "@internal/previews/status-center-i18n";
 import {
   buildPreviewStatusCenterRequestKey,
+  clearActivePreviewIdFromSession,
   getPreviewStatusCenterJobsSnapshot,
   getPreviewStatusCenterServerJobsSnapshot,
   hydratePreviewStatusCenterStore,
   markPreviewStatusCenterJobTerminal,
   parsePreviewStatusCenterRequestKey,
+  readActivePreviewIdFromSession,
   removePreviewStatusCenterJob,
   selectLatestJobByRequestKey,
   selectRestorablePreviewStatusCenterJob,
   subscribePreviewStatusCenterStore,
   upsertPreviewStatusCenterJob,
   updatePreviewStatusCenterJob,
+  writeActivePreviewIdToSession,
   type PreviewStatusCenterJob,
 } from "@internal/previews/status-center-store";
 import type { SupportedLanguage } from "@internal/dashboard/webhooks";
@@ -85,55 +88,12 @@ type ConnectStatusUpdatesOptions = {
 };
 
 const emailSchema = z.email();
-const ACTIVE_PREVIEW_SESSION_STORAGE_KEY = "weblingo:try-form:active-preview-id:v1";
 
 function isAbortLikeError(error: unknown): boolean {
   return (
     (error instanceof DOMException && error.name === "AbortError") ||
     (error instanceof Error && error.name === "AbortError")
   );
-}
-
-function canUseSessionStorage() {
-  return typeof window !== "undefined" && typeof window.sessionStorage !== "undefined";
-}
-
-function readActivePreviewIdFromSession(): string | null {
-  if (!canUseSessionStorage()) {
-    return null;
-  }
-  try {
-    return window.sessionStorage.getItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY);
-  } catch {
-    return null;
-  }
-}
-
-function writeActivePreviewIdToSession(previewId: string) {
-  if (!canUseSessionStorage()) {
-    return;
-  }
-  try {
-    window.sessionStorage.setItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY, previewId);
-  } catch {
-    // Ignore storage failures; local preview status still works without tab pinning.
-  }
-}
-
-function clearActivePreviewIdFromSession(previewId?: string | null) {
-  if (!canUseSessionStorage()) {
-    return;
-  }
-  try {
-    if (
-      !previewId ||
-      window.sessionStorage.getItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY) === previewId
-    ) {
-      window.sessionStorage.removeItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY);
-    }
-  } catch {
-    // Ignore storage failures.
-  }
 }
 
 function buildPreviewAnalyticsSignature(job: PreviewStatusCenterJob): string {

--- a/components/try-panel-header.test.tsx
+++ b/components/try-panel-header.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildPreviewStatusCenterRequestKey,
+  PREVIEW_STATUS_CENTER_STORAGE_KEY,
+  resetPreviewStatusCenterStoreForTests,
+  upsertPreviewStatusCenterJob,
+} from "@internal/previews/status-center-store";
+import { TryPanelHeader } from "./try-panel-header";
+
+const messages = {
+  "try.header.title": "Try WebLingo",
+  "try.header.description": "Create a preview",
+  "try.status.processingHint": "Processing hint",
+  "try.status.processing": "Processing",
+  "try.status.pending": "Pending",
+  "try.status.restoring": "Checking preview status...",
+  "try.stage.translating": "Translating",
+} as const;
+
+beforeEach(() => {
+  resetPreviewStatusCenterStoreForTests();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+  resetPreviewStatusCenterStoreForTests();
+});
+
+describe("TryPanelHeader", () => {
+  it("shows running copy for a fresh active preview", async () => {
+    upsertPreviewStatusCenterJob({
+      previewId: "fresh-1111-1111-1111-111111111111",
+      requestKey: buildPreviewStatusCenterRequestKey({
+        sourceUrl: "https://fresh.example.com",
+        sourceLang: "en",
+        targetLang: "fr",
+      }),
+      statusToken: "fresh-token",
+      sourceUrl: "https://fresh.example.com",
+      sourceLang: "en",
+      targetLang: "fr",
+      status: "processing",
+      stage: "translating",
+      remoteStatusVerified: true,
+    });
+
+    render(<TryPanelHeader messages={messages} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Translating" })).toBeTruthy();
+      expect(screen.getByText("Processing hint")).toBeTruthy();
+    });
+  });
+
+  it("ignores stale active previews when choosing header copy", async () => {
+    const now = Date.now();
+    window.localStorage.setItem(
+      PREVIEW_STATUS_CENTER_STORAGE_KEY,
+      JSON.stringify([
+        {
+          previewId: "stale-2222-2222-2222-222222222222",
+          requestKey: buildPreviewStatusCenterRequestKey({
+            sourceUrl: "https://stale.example.com",
+            sourceLang: "en",
+            targetLang: "fr",
+          }),
+          statusToken: "stale-token",
+          sourceUrl: "https://stale.example.com",
+          sourceLang: "en",
+          targetLang: "fr",
+          status: "processing",
+          stage: "translating",
+          previewUrl: null,
+          error: null,
+          errorCode: null,
+          errorStage: null,
+          createdAt: now - 60 * 60 * 1000,
+          updatedAt: now,
+          expiresAt: null,
+          retryCount: 0,
+          nextPollAt: now + 5_000,
+        },
+      ]),
+    );
+
+    render(<TryPanelHeader messages={messages} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Try WebLingo" })).toBeTruthy();
+      expect(screen.getByText("Create a preview")).toBeTruthy();
+    });
+    expect(screen.queryByRole("heading", { name: "Translating" })).toBeNull();
+  });
+});

--- a/components/try-panel-header.test.tsx
+++ b/components/try-panel-header.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  ACTIVE_PREVIEW_SESSION_STORAGE_KEY,
   buildPreviewStatusCenterRequestKey,
   PREVIEW_STATUS_CENTER_STORAGE_KEY,
   resetPreviewStatusCenterStoreForTests,
@@ -23,11 +24,13 @@ const messages = {
 beforeEach(() => {
   resetPreviewStatusCenterStoreForTests();
   window.localStorage.clear();
+  window.sessionStorage.clear();
 });
 
 afterEach(() => {
   cleanup();
   window.localStorage.clear();
+  window.sessionStorage.clear();
   resetPreviewStatusCenterStoreForTests();
 });
 
@@ -79,6 +82,7 @@ describe("TryPanelHeader", () => {
           error: null,
           errorCode: null,
           errorStage: null,
+          remoteStatusVerified: true,
           createdAt: now - 60 * 60 * 1000,
           updatedAt: now,
           expiresAt: null,
@@ -95,5 +99,47 @@ describe("TryPanelHeader", () => {
       expect(screen.getByText("Create a preview")).toBeTruthy();
     });
     expect(screen.queryByRole("heading", { name: "Translating" })).toBeNull();
+  });
+
+  it("keeps showing stale active previews when they are pinned to the current tab", async () => {
+    const now = Date.now();
+    const previewId = "pinned-3333-3333-3333-333333333333";
+    window.sessionStorage.setItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY, previewId);
+    window.localStorage.setItem(
+      PREVIEW_STATUS_CENTER_STORAGE_KEY,
+      JSON.stringify([
+        {
+          previewId,
+          requestKey: buildPreviewStatusCenterRequestKey({
+            sourceUrl: "https://pinned.example.com",
+            sourceLang: "en",
+            targetLang: "fr",
+          }),
+          statusToken: "pinned-token",
+          sourceUrl: "https://pinned.example.com",
+          sourceLang: "en",
+          targetLang: "fr",
+          status: "processing",
+          stage: "translating",
+          previewUrl: null,
+          error: null,
+          errorCode: null,
+          errorStage: null,
+          createdAt: now - 60 * 60 * 1000,
+          updatedAt: now,
+          expiresAt: null,
+          retryCount: 0,
+          nextPollAt: now + 5_000,
+        },
+      ]),
+    );
+
+    render(<TryPanelHeader messages={messages} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Checking preview status..." })).toBeTruthy();
+      expect(screen.getByText("Processing hint")).toBeTruthy();
+    });
+    expect(screen.queryByRole("heading", { name: "Try WebLingo" })).toBeNull();
   });
 });

--- a/components/try-panel-header.tsx
+++ b/components/try-panel-header.tsx
@@ -8,6 +8,7 @@ import {
   getPreviewStatusCenterJobsSnapshot,
   getPreviewStatusCenterServerJobsSnapshot,
   hydratePreviewStatusCenterStore,
+  readActivePreviewIdFromSession,
   selectRestorablePreviewStatusCenterJob,
   subscribePreviewStatusCenterStore,
 } from "@internal/previews/status-center-store";
@@ -28,7 +29,14 @@ export function TryPanelHeader({ messages }: TryPanelHeaderProps) {
     hydratePreviewStatusCenterStore();
   }, []);
 
-  const activeJob = useMemo(() => selectRestorablePreviewStatusCenterJob({ jobs }), [jobs]);
+  const activeJob = useMemo(
+    () =>
+      selectRestorablePreviewStatusCenterJob({
+        jobs,
+        pinnedPreviewId: readActivePreviewIdFromSession(),
+      }),
+    [jobs],
+  );
   const isRunning = activeJob?.status === "pending" || activeJob?.status === "processing";
   const title = isRunning ? resolvePreviewStatusCenterMessage(activeJob, t) : t("try.header.title");
   const description = isRunning ? t("try.status.processingHint") : t("try.header.description");

--- a/components/try-panel-header.tsx
+++ b/components/try-panel-header.tsx
@@ -8,7 +8,7 @@ import {
   getPreviewStatusCenterJobsSnapshot,
   getPreviewStatusCenterServerJobsSnapshot,
   hydratePreviewStatusCenterStore,
-  selectLatestActivePreviewStatusCenterJob,
+  selectRestorablePreviewStatusCenterJob,
   subscribePreviewStatusCenterStore,
 } from "@internal/previews/status-center-store";
 
@@ -28,7 +28,7 @@ export function TryPanelHeader({ messages }: TryPanelHeaderProps) {
     hydratePreviewStatusCenterStore();
   }, []);
 
-  const activeJob = useMemo(() => selectLatestActivePreviewStatusCenterJob(jobs), [jobs]);
+  const activeJob = useMemo(() => selectRestorablePreviewStatusCenterJob({ jobs }), [jobs]);
   const isRunning = activeJob?.status === "pending" || activeJob?.status === "processing";
   const title = isRunning ? resolvePreviewStatusCenterMessage(activeJob, t) : t("try.header.title");
   const description = isRunning ? t("try.status.processingHint") : t("try.header.description");

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-28T18:57:56+09:00",
+  "generatedAt": "2026-04-29T14:28:54+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 74945,
@@ -32,7 +32,7 @@
       "sha256": "d6881801fd18dfa5028b05879c860f92f395af6f6da14c2f6fd7d8efc567f67a"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-04-28T18:57:56+09:00",
+  "sourceRepoCommitTimestamp": "2026-04-29T14:28:54+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "a16e8887717bd9cbd7cfe6c813240989cc60653c"
+  "sourceRepoSha": "e8c69a5ddb8bcde0c2d23708bf4ece7f49b4ff7c"
 }

--- a/docs/plans/preview-status-runtime-architecture.md
+++ b/docs/plans/preview-status-runtime-architecture.md
@@ -18,6 +18,7 @@ Retention and bounds:
 
 - max 20 jobs
 - TTL 24h from `updatedAt`
+- active jobs older than 15 minutes from `createdAt` are kept in storage but are not auto-restored as the primary Try form state
 
 ## One-time migration behavior
 
@@ -77,6 +78,6 @@ All preview job state mutations must go through store events and reducer logic (
 
 - Status center list: `selectJobsForStatusCenter()`
 - Try form binding: `selectLatestJobByRequestKey(requestKey)`
-- Initial restore: `selectLatestActivePreviewStatusCenterJob()`
+- Initial Try form restore: `selectRestorablePreviewStatusCenterJob()`, which prefers the current tab's pinned preview id, then a matching current request key, then a fresh active job, then the latest terminal job.
 
 This keeps form and toast/status-center synchronized from the same source of truth.

--- a/internal/previews/status-center-store.test.ts
+++ b/internal/previews/status-center-store.test.ts
@@ -16,9 +16,11 @@ import {
   removePreviewStatusCenterJob,
   resetPreviewStatusCenterJobRetry,
   resetPreviewStatusCenterStoreForTests,
+  RESTORABLE_ACTIVE_PREVIEW_MAX_AGE_MS,
   selectPreferredPreviewStatusCenterJob,
   selectLatestActivePreviewStatusCenterJob,
   selectLatestJobByRequestKey,
+  selectRestorablePreviewStatusCenterJob,
   setPreviewStatusCenterJobRetry,
   upsertPreviewStatusCenterJob,
   type PreviewStatusCenterJob,
@@ -354,6 +356,82 @@ describe("status-center-store", () => {
     expect(selectPreferredPreviewStatusCenterJob()?.statusToken).toBe("first-token");
     expect(selectLatestActivePreviewStatusCenterJob()?.statusToken).toBe("first-token");
     expect(selectLatestJobByRequestKey(requestKey)?.statusToken).toBe("first-token");
+  });
+
+  it("selects the pinned restorable job before older active jobs", () => {
+    const now = Date.now();
+    const jobs: PreviewStatusCenterJob[] = [
+      {
+        ...buildJob({
+          previewId: "stale-1111-1111-1111-111111111111",
+          sourceUrl: "https://stale.example.com",
+        }),
+        stage: null,
+        previewUrl: null,
+        error: null,
+        errorCode: null,
+        errorStage: null,
+        remoteStatusVerified: false,
+        createdAt: now - RESTORABLE_ACTIVE_PREVIEW_MAX_AGE_MS - 1,
+        updatedAt: now + 1_000,
+        expiresAt: null,
+        retryCount: 0,
+        nextPollAt: now + 5_000,
+      },
+      {
+        ...buildJob({
+          previewId: "fresh-2222-2222-2222-222222222222",
+          sourceUrl: "https://fresh.example.com",
+        }),
+        stage: null,
+        previewUrl: null,
+        error: null,
+        errorCode: null,
+        errorStage: null,
+        remoteStatusVerified: false,
+        createdAt: now - 1_000,
+        updatedAt: now - 500,
+        expiresAt: null,
+        retryCount: 0,
+        nextPollAt: now + 5_000,
+      },
+    ];
+
+    expect(
+      selectRestorablePreviewStatusCenterJob({
+        jobs,
+        pinnedPreviewId: "fresh-2222-2222-2222-222222222222",
+        now,
+      })?.sourceUrl,
+    ).toBe("https://fresh.example.com");
+  });
+
+  it("does not restore old active jobs as the primary try-form job", () => {
+    const now = Date.now();
+    const stale: PreviewStatusCenterJob = {
+      ...buildJob({
+        previewId: "stale-3333-3333-3333-333333333333",
+        sourceUrl: "https://stale.example.com",
+      }),
+      stage: null,
+      previewUrl: null,
+      error: null,
+      errorCode: null,
+      errorStage: null,
+      remoteStatusVerified: false,
+      createdAt: now - RESTORABLE_ACTIVE_PREVIEW_MAX_AGE_MS - 1,
+      updatedAt: now,
+      expiresAt: null,
+      retryCount: 0,
+      nextPollAt: now + 5_000,
+    };
+
+    expect(
+      selectRestorablePreviewStatusCenterJob({
+        jobs: [stale],
+        now,
+      }),
+    ).toBeNull();
   });
 
   it("drops unknown phases from storage and warns once per hydration pass", () => {

--- a/internal/previews/status-center-store.test.ts
+++ b/internal/previews/status-center-store.test.ts
@@ -358,29 +358,12 @@ describe("status-center-store", () => {
     expect(selectLatestJobByRequestKey(requestKey)?.statusToken).toBe("first-token");
   });
 
-  it("selects the pinned restorable job before older active jobs", () => {
+  it("selects the pinned active job beyond the auto-restore age cutoff", () => {
     const now = Date.now();
     const jobs: PreviewStatusCenterJob[] = [
       {
         ...buildJob({
-          previewId: "stale-1111-1111-1111-111111111111",
-          sourceUrl: "https://stale.example.com",
-        }),
-        stage: null,
-        previewUrl: null,
-        error: null,
-        errorCode: null,
-        errorStage: null,
-        remoteStatusVerified: false,
-        createdAt: now - RESTORABLE_ACTIVE_PREVIEW_MAX_AGE_MS - 1,
-        updatedAt: now + 1_000,
-        expiresAt: null,
-        retryCount: 0,
-        nextPollAt: now + 5_000,
-      },
-      {
-        ...buildJob({
-          previewId: "fresh-2222-2222-2222-222222222222",
+          previewId: "fresh-1111-1111-1111-111111111111",
           sourceUrl: "https://fresh.example.com",
         }),
         stage: null,
@@ -395,15 +378,88 @@ describe("status-center-store", () => {
         retryCount: 0,
         nextPollAt: now + 5_000,
       },
+      {
+        ...buildJob({
+          previewId: "stale-2222-2222-2222-222222222222",
+          sourceUrl: "https://stale.example.com",
+        }),
+        stage: null,
+        previewUrl: null,
+        error: null,
+        errorCode: null,
+        errorStage: null,
+        remoteStatusVerified: false,
+        createdAt: now - RESTORABLE_ACTIVE_PREVIEW_MAX_AGE_MS - 1,
+        updatedAt: now - 250,
+        expiresAt: null,
+        retryCount: 0,
+        nextPollAt: now + 5_000,
+      },
     ];
 
     expect(
       selectRestorablePreviewStatusCenterJob({
         jobs,
-        pinnedPreviewId: "fresh-2222-2222-2222-222222222222",
+        pinnedPreviewId: "stale-2222-2222-2222-222222222222",
         now,
       })?.sourceUrl,
-    ).toBe("https://fresh.example.com");
+    ).toBe("https://stale.example.com");
+  });
+
+  it("falls back to a restorable terminal request-key match when a stale active job is newer", () => {
+    const now = Date.now();
+    const requestKey = buildPreviewStatusCenterRequestKey({
+      sourceUrl: "https://same.example.com",
+      sourceLang: "en",
+      targetLang: "fr",
+    });
+    const jobs: PreviewStatusCenterJob[] = [
+      {
+        ...buildJob({
+          previewId: "ready-3333-3333-3333-333333333333",
+          requestKey,
+          sourceUrl: "https://same.example.com",
+          status: "ready",
+        }),
+        stage: null,
+        previewUrl: "https://preview.example.com/ready",
+        error: null,
+        errorCode: null,
+        errorStage: null,
+        remoteStatusVerified: true,
+        createdAt: now - RESTORABLE_ACTIVE_PREVIEW_MAX_AGE_MS - 10_000,
+        updatedAt: now - 2_000,
+        expiresAt: now + 60_000,
+        retryCount: 0,
+        nextPollAt: Number.POSITIVE_INFINITY,
+      },
+      {
+        ...buildJob({
+          previewId: "stale-4444-4444-4444-444444444444",
+          requestKey,
+          sourceUrl: "https://same.example.com",
+        }),
+        stage: null,
+        previewUrl: null,
+        error: null,
+        errorCode: null,
+        errorStage: null,
+        remoteStatusVerified: false,
+        createdAt: now - RESTORABLE_ACTIVE_PREVIEW_MAX_AGE_MS - 1,
+        updatedAt: now,
+        expiresAt: null,
+        retryCount: 0,
+        nextPollAt: now + 5_000,
+      },
+    ];
+
+    expect(
+      selectRestorablePreviewStatusCenterJob({
+        jobs,
+        currentRequestKey: requestKey,
+        now,
+      })?.previewId,
+    ).toBe("ready-3333-3333-3333-333333333333");
   });
 
   it("does not restore old active jobs as the primary try-form job", () => {

--- a/internal/previews/status-center-store.ts
+++ b/internal/previews/status-center-store.ts
@@ -20,6 +20,7 @@ export const PREVIEW_STATUS_CENTER_STORAGE_KEY = "weblingo:preview-jobs:v2";
 export const LEGACY_PREVIEW_STATUS_CENTER_STORAGE_KEY = "weblingo:preview-status-center:v1";
 export const LEGACY_PENDING_PREVIEW_STORAGE_KEY = "weblingo:try-form:pending-preview:v1";
 export const DEFAULT_PREVIEW_STATUS_CENTER_POLL_INTERVAL_MS = 5_000;
+export const RESTORABLE_ACTIVE_PREVIEW_MAX_AGE_MS = 15 * 60 * 1000;
 const PREVIEW_STATUS_CENTER_REQUEST_KEY_PREFIX = "v2:";
 const MAX_PREVIEW_STATUS_CENTER_JOBS = 20;
 const STALE_PREVIEW_STATUS_CENTER_JOB_TTL_MS = 24 * 60 * 60 * 1000;
@@ -757,6 +758,68 @@ export function selectLatestActivePreviewStatusCenterJob(
     }
   }
   return best;
+}
+
+function isRestorableActivePreviewStatusCenterJob(
+  job: PreviewStatusCenterJob,
+  now: number,
+): boolean {
+  if (!isPreviewStatusCenterJobActive(job)) {
+    return false;
+  }
+  const createdAt = normalizeTimestamp(job.createdAt);
+  return (
+    createdAt !== Number.NEGATIVE_INFINITY &&
+    now - createdAt <= RESTORABLE_ACTIVE_PREVIEW_MAX_AGE_MS
+  );
+}
+
+function isRestorablePreviewStatusCenterJob(job: PreviewStatusCenterJob, now: number): boolean {
+  return (
+    isPreviewStatusCenterJobTerminal(job.status) ||
+    isRestorableActivePreviewStatusCenterJob(job, now)
+  );
+}
+
+export function selectRestorablePreviewStatusCenterJob(
+  options: {
+    jobs?: PreviewStatusCenterJob[];
+    currentRequestKey?: string | null;
+    pinnedPreviewId?: string | null;
+    now?: number;
+  } = {},
+): PreviewStatusCenterJob | null {
+  const jobs = options.jobs ?? state.jobs;
+  const now = options.now ?? Date.now();
+
+  if (options.pinnedPreviewId) {
+    const pinned = jobs.find((job) => job.previewId === options.pinnedPreviewId);
+    if (pinned && isRestorablePreviewStatusCenterJob(pinned, now)) {
+      return pinned;
+    }
+  }
+
+  if (options.currentRequestKey) {
+    const matching = selectLatestJobByRequestKey(options.currentRequestKey, jobs);
+    return matching && isRestorablePreviewStatusCenterJob(matching, now) ? matching : null;
+  }
+
+  let bestActive: PreviewStatusCenterJob | null = null;
+  let bestTerminal: PreviewStatusCenterJob | null = null;
+  for (const job of jobs) {
+    if (isRestorableActivePreviewStatusCenterJob(job, now)) {
+      if (!bestActive || comparePreviewStatusCenterJobs(job, bestActive) < 0) {
+        bestActive = job;
+      }
+      continue;
+    }
+    if (isPreviewStatusCenterJobTerminal(job.status)) {
+      if (!bestTerminal || comparePreviewStatusCenterJobs(job, bestTerminal) < 0) {
+        bestTerminal = job;
+      }
+    }
+  }
+  return bestActive ?? bestTerminal;
 }
 
 export function selectPreferredPreviewStatusCenterJob(

--- a/internal/previews/status-center-store.ts
+++ b/internal/previews/status-center-store.ts
@@ -19,6 +19,7 @@ import {
 export const PREVIEW_STATUS_CENTER_STORAGE_KEY = "weblingo:preview-jobs:v2";
 export const LEGACY_PREVIEW_STATUS_CENTER_STORAGE_KEY = "weblingo:preview-status-center:v1";
 export const LEGACY_PENDING_PREVIEW_STORAGE_KEY = "weblingo:try-form:pending-preview:v1";
+export const ACTIVE_PREVIEW_SESSION_STORAGE_KEY = "weblingo:try-form:active-preview-id:v1";
 export const DEFAULT_PREVIEW_STATUS_CENTER_POLL_INTERVAL_MS = 5_000;
 export const RESTORABLE_ACTIVE_PREVIEW_MAX_AGE_MS = 15 * 60 * 1000;
 const PREVIEW_STATUS_CENTER_REQUEST_KEY_PREFIX = "v2:";
@@ -110,6 +111,48 @@ function emit() {
 
 function canUseStorage() {
   return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function canUseSessionStorage() {
+  return typeof window !== "undefined" && typeof window.sessionStorage !== "undefined";
+}
+
+export function readActivePreviewIdFromSession(): string | null {
+  if (!canUseSessionStorage()) {
+    return null;
+  }
+  try {
+    return window.sessionStorage.getItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writeActivePreviewIdToSession(previewId: string) {
+  if (!canUseSessionStorage()) {
+    return;
+  }
+  try {
+    window.sessionStorage.setItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY, previewId);
+  } catch {
+    // Ignore storage failures; local preview status still works without tab pinning.
+  }
+}
+
+export function clearActivePreviewIdFromSession(previewId?: string | null) {
+  if (!canUseSessionStorage()) {
+    return;
+  }
+  try {
+    if (
+      !previewId ||
+      window.sessionStorage.getItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY) === previewId
+    ) {
+      window.sessionStorage.removeItem(ACTIVE_PREVIEW_SESSION_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore storage failures.
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -781,6 +824,10 @@ function isRestorablePreviewStatusCenterJob(job: PreviewStatusCenterJob, now: nu
   );
 }
 
+function isPinnedRestorablePreviewStatusCenterJob(job: PreviewStatusCenterJob): boolean {
+  return isPreviewStatusCenterJobTerminal(job.status) || isPreviewStatusCenterJobActive(job);
+}
+
 export function selectRestorablePreviewStatusCenterJob(
   options: {
     jobs?: PreviewStatusCenterJob[];
@@ -794,14 +841,25 @@ export function selectRestorablePreviewStatusCenterJob(
 
   if (options.pinnedPreviewId) {
     const pinned = jobs.find((job) => job.previewId === options.pinnedPreviewId);
-    if (pinned && isRestorablePreviewStatusCenterJob(pinned, now)) {
+    if (pinned && isPinnedRestorablePreviewStatusCenterJob(pinned)) {
       return pinned;
     }
   }
 
   if (options.currentRequestKey) {
-    const matching = selectLatestJobByRequestKey(options.currentRequestKey, jobs);
-    return matching && isRestorablePreviewStatusCenterJob(matching, now) ? matching : null;
+    let best: PreviewStatusCenterJob | null = null;
+    for (const job of jobs) {
+      if (job.requestKey !== options.currentRequestKey) {
+        continue;
+      }
+      if (!isRestorablePreviewStatusCenterJob(job, now)) {
+        continue;
+      }
+      if (!best || comparePreviewStatusCenterJobs(job, best) < 0) {
+        best = job;
+      }
+    }
+    return best;
   }
 
   let bestActive: PreviewStatusCenterJob | null = null;


### PR DESCRIPTION
## Summary

- Why: refreshing the Try form could restore an older active preview from local storage and replace the preview the user just started, leaving the form stuck on stale `translating` state.
- What: pin the active tab preview in `sessionStorage`, prefer that pin during restore, and stop auto-restoring active previews older than 15 minutes as the primary Try form state while keeping them in the status store.

## Testing

- [x] `corepack pnpm test`
- [x] `corepack pnpm check`
- [ ] `corepack pnpm test:contracts` (not required; frontend-only preview restore behavior)
- [ ] `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync:check` (not required; no backend docs snapshot changes)

## Docs sync and capability matrix

- [ ] Updated `docs/backend/DASHBOARD_SPECS.md` if user-facing backend capability coverage changed. (Not required; no backend capability change.)
- [ ] Ran `WEBLINGO_REPO_PATH=/absolute/path/to/weblingo corepack pnpm docs:sync` and committed `content/docs/_generated/*` when backend HEAD advanced. (Not required; no backend sync change.)
