### PR TITLE
Add runtime requests dashboard workflow

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,4 @@ types/database.ts
 
 # Backend-synced docs artifacts (deterministic generator output)
 content/docs/_generated/*.json
+content/docs/_generated/backend-playbooks.snapshot.md

--- a/app/api/dashboard/sites/[siteId]/runtime-request-policy/preview/route.test.ts
+++ b/app/api/dashboard/sites/[siteId]/runtime-request-policy/preview/route.test.ts
@@ -90,13 +90,10 @@ describe("POST /api/dashboard/sites/[siteId]/runtime-request-policy/preview", ()
 
     const payload = { runtimeRequestPolicy: makePolicy() };
     const response = await POST(
-      new Request(
-        "http://localhost/api/dashboard/sites/site-1/runtime-request-policy/preview",
-        {
-          method: "POST",
-          body: JSON.stringify(payload),
-        },
-      ),
+      new Request("http://localhost/api/dashboard/sites/site-1/runtime-request-policy/preview", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
       { params: Promise.resolve({ siteId: "site-1" }) },
     );
 
@@ -119,13 +116,10 @@ describe("POST /api/dashboard/sites/[siteId]/runtime-request-policy/preview", ()
     );
 
     const response = await POST(
-      new Request(
-        "http://localhost/api/dashboard/sites/site-1/runtime-request-policy/preview",
-        {
-          method: "POST",
-          body: JSON.stringify({ runtimeRequestPolicy: makePolicy() }),
-        },
-      ),
+      new Request("http://localhost/api/dashboard/sites/site-1/runtime-request-policy/preview", {
+        method: "POST",
+        body: JSON.stringify({ runtimeRequestPolicy: makePolicy() }),
+      }),
       { params: Promise.resolve({ siteId: "site-1" }) },
     );
 

--- a/app/api/dashboard/sites/[siteId]/runtime-request-policy/preview/route.test.ts
+++ b/app/api/dashboard/sites/[siteId]/runtime-request-policy/preview/route.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DashboardAuth } from "@internal/dashboard/auth";
+
+import { POST } from "./route";
+import { requireDashboardAuth } from "@internal/dashboard/auth";
+import { previewRuntimeRequestPolicy } from "@internal/dashboard/webhooks";
+
+vi.mock("@internal/dashboard/auth", () => ({
+  requireDashboardAuth: vi.fn(),
+}));
+
+vi.mock("@internal/dashboard/webhooks", () => {
+  class WebhooksApiError extends Error {
+    status: number;
+    details?: unknown;
+
+    constructor(message: string, status: number, details?: unknown) {
+      super(message);
+      this.status = status;
+      this.details = details;
+    }
+  }
+  return {
+    previewRuntimeRequestPolicy: vi.fn(),
+    WebhooksApiError,
+  };
+});
+
+const mockedRequireDashboardAuth = vi.mocked(requireDashboardAuth);
+const mockedPreviewRuntimeRequestPolicy = vi.mocked(previewRuntimeRequestPolicy);
+
+function makeAuth(): DashboardAuth {
+  return {
+    user: null,
+    session: null,
+    webhooksAuth: {
+      token: "subject-token",
+      expiresAt: "2026-01-01T00:00:00.000Z",
+      subjectAccountId: "acct-customer",
+      refresh: async () => "subject-token",
+    },
+    account: null,
+    actorAccount: null,
+    subjectAccount: null,
+    actorWebhooksAuth: null,
+    agencyCustomers: null,
+    actorAccountId: "acct-agency",
+    subjectAccountId: "acct-customer",
+    actingAsCustomer: true,
+    subjectFallbackToActor: false,
+    actorPlanActive: true,
+    subjectPlanActive: true,
+    mutationsAllowed: true,
+    billingIssue: null,
+    stripeBillingRuntime: null,
+    has: () => true,
+  };
+}
+
+function makePolicy() {
+  return {
+    schemaVersion: 1 as const,
+    mode: "standard" as const,
+    enabled: true,
+    rules: [],
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/dashboard/sites/[siteId]/runtime-request-policy/preview", () => {
+  it("uses the subject-scoped dashboard auth context", async () => {
+    const auth = makeAuth();
+    mockedRequireDashboardAuth.mockResolvedValue(auth);
+    mockedPreviewRuntimeRequestPolicy.mockResolvedValue({
+      runtimeRequestPolicy: makePolicy(),
+      validationErrors: [],
+      warnings: [],
+      collisions: [],
+      highRiskConfirmations: [],
+      sampleResults: [],
+      matchedObservationGroups: [],
+      propagation: {
+        currentRouteConfigUpdatedAt: "2026-05-04T00:00:00.000Z",
+        currentRuntimeRequestPolicyVersion: "site-config:2026-05-04T00:00:00.000Z",
+      },
+    });
+
+    const payload = { runtimeRequestPolicy: makePolicy() };
+    const response = await POST(
+      new Request(
+        "http://localhost/api/dashboard/sites/site-1/runtime-request-policy/preview",
+        {
+          method: "POST",
+          body: JSON.stringify(payload),
+        },
+      ),
+      { params: Promise.resolve({ siteId: "site-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockedPreviewRuntimeRequestPolicy).toHaveBeenCalledWith(
+      auth.webhooksAuth,
+      "site-1",
+      payload,
+    );
+  });
+
+  it("forwards stable backend validation codes", async () => {
+    mockedRequireDashboardAuth.mockResolvedValue(makeAuth());
+    const { WebhooksApiError } = await import("@internal/dashboard/webhooks");
+    mockedPreviewRuntimeRequestPolicy.mockRejectedValue(
+      new WebhooksApiError("runtimeRequestPolicy failed validation", 400, {
+        code: "runtime_request_policy_validation_failed",
+        validationErrors: [{ code: "confirmation_required_non_get_proxy", ruleId: "cart" }],
+      }),
+    );
+
+    const response = await POST(
+      new Request(
+        "http://localhost/api/dashboard/sites/site-1/runtime-request-policy/preview",
+        {
+          method: "POST",
+          body: JSON.stringify({ runtimeRequestPolicy: makePolicy() }),
+        },
+      ),
+      { params: Promise.resolve({ siteId: "site-1" }) },
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.details.validationErrors[0].code).toBe("confirmation_required_non_get_proxy");
+  });
+});

--- a/app/api/dashboard/sites/[siteId]/runtime-request-policy/preview/route.ts
+++ b/app/api/dashboard/sites/[siteId]/runtime-request-policy/preview/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+
+import { requireDashboardAuth } from "@internal/dashboard/auth";
+import { previewRuntimeRequestPolicy, WebhooksApiError } from "@internal/dashboard/webhooks";
+
+type RouteParams = {
+  params: Promise<{
+    siteId: string;
+  }>;
+};
+
+export async function POST(request: Request, { params }: RouteParams) {
+  const auth = await requireDashboardAuth();
+  if (!auth.webhooksAuth) {
+    return NextResponse.json({ error: "Missing credentials." }, { status: 401 });
+  }
+  if (!auth.subjectAccountId) {
+    return NextResponse.json({ error: "Missing account context." }, { status: 401 });
+  }
+
+  const { siteId } = await params;
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Request body must be valid JSON." }, { status: 400 });
+  }
+
+  try {
+    const preview = await previewRuntimeRequestPolicy(
+      auth.webhooksAuth,
+      siteId,
+      body as Parameters<typeof previewRuntimeRequestPolicy>[2],
+    );
+    return NextResponse.json(preview);
+  } catch (error) {
+    if (error instanceof WebhooksApiError) {
+      return NextResponse.json(
+        { error: error.message, details: error.details ?? null },
+        { status: error.status || 500 },
+      );
+    }
+    console.warn("[dashboard] runtime-request-policy preview failed", {
+      siteId,
+      error: error instanceof Error ? error.message : error,
+    });
+    return NextResponse.json(
+      { error: "Unable to preview runtime request policy." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/dashboard/_components/sites-nav.test.tsx
+++ b/app/dashboard/_components/sites-nav.test.tsx
@@ -85,6 +85,7 @@ describe("SitesNav", () => {
       "Workspace",
       "Pages & crawl",
       "Source selection",
+      "Runtime requests",
       "Translation rules",
       "Settings",
     ]) {

--- a/app/dashboard/_components/sites-nav.tsx
+++ b/app/dashboard/_components/sites-nav.tsx
@@ -59,6 +59,7 @@ function SiteNavItem({ site, pathname }: SiteNavItemProps) {
     { href: baseHref, label: "Workspace" },
     { href: `${baseHref}/pages`, label: "Pages & crawl" },
     { href: `${baseHref}/source-selection`, label: "Source selection" },
+    { href: `${baseHref}/runtime-requests`, label: "Runtime requests" },
     { href: `${baseHref}/overrides`, label: "Translation rules" },
     { href: `${baseHref}/admin`, label: "Settings" },
   ];

--- a/app/dashboard/actions.ts
+++ b/app/dashboard/actions.ts
@@ -22,6 +22,7 @@ import {
   setTranslationSummaryPreference,
   setLocaleServing,
   fetchSite,
+  updateRuntimeRequestObservationLifecycle,
   translateSite,
   triggerCrawl,
   triggerCrawlTranslate,
@@ -34,6 +35,9 @@ import {
   WebhooksApiError,
   type DigestFrequency,
   type GlossaryEntry,
+  type RuntimeRequestLifecycle,
+  type RuntimeRequestPolicyConfig,
+  type RuntimeRequestPolicyRule,
   type SourceSelectionConfig,
   type TranslationSummaryFrequency,
 } from "@internal/dashboard/webhooks";
@@ -83,9 +87,32 @@ const translationSummaryFrequencies = new Set<TranslationSummaryFrequency>([
 const consistencyStatuses = new Set(["proposed", "approved", "frozen"]);
 const consistencyBlockModes = new Set(["strict", "prefer"]);
 const sourceSelectionRuleActions = new Set(["include", "exclude"]);
+const runtimeRequestPolicyActions = new Set(["observe", "deny", "neutralize", "proxy"]);
+const runtimeRequestPolicyMethods = new Set([
+  "GET",
+  "HEAD",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "OPTIONS",
+]);
+const runtimeRequestPolicyCredentials = new Set(["omit", "same_origin", "include"]);
+const runtimeRequestPolicyCacheModes = new Set(["no-store", "edge"]);
+const runtimeRequestPolicyRedirectScopes = new Set(["same_origin", "same_registrable_domain"]);
+const runtimeRequestPolicyConfirmations = new Set([
+  "non_get_proxy",
+  "credential_forwarding",
+  "high_risk_path",
+]);
+const runtimeRequestLifecycles = new Set(["open", "reviewed", "dismissed", "ignored"]);
 
 function isEditableSourceSelectionAction(value: string): value is "include" | "exclude" {
   return sourceSelectionRuleActions.has(value);
+}
+
+function isRuntimeRequestLifecycle(value: string): value is RuntimeRequestLifecycle {
+  return runtimeRequestLifecycles.has(value);
 }
 
 function toFriendlyDashboardActionError(error: unknown, fallback: string): string {
@@ -369,6 +396,191 @@ function editableSourceSelectionConfigFromRules(
       return [{ action: rule.action, pattern: rule.pattern.trim() }];
     }),
   };
+}
+
+function parseRuntimeRequestPolicyConfig(
+  rawValue: FormDataEntryValue | null,
+): RuntimeRequestPolicyConfig | string {
+  if (typeof rawValue !== "string" || rawValue.trim().length === 0) {
+    return "Runtime request policy payload is required.";
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawValue);
+  } catch {
+    return "Runtime request policy payload must be valid JSON.";
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return "Runtime request policy payload must be an object.";
+  }
+  const record = parsed as Record<string, unknown>;
+  const rulesValue = record.rules;
+  if (!Array.isArray(rulesValue)) {
+    return "Runtime request policy rules must be an array.";
+  }
+  if (rulesValue.length > 200) {
+    return "Runtime request policy supports up to 200 rules.";
+  }
+
+  const rules: RuntimeRequestPolicyRule[] = [];
+  for (const [index, ruleValue] of rulesValue.entries()) {
+    const rule = parseRuntimeRequestPolicyRule(ruleValue, index);
+    if (typeof rule === "string") {
+      return rule;
+    }
+    rules.push(rule);
+  }
+
+  return {
+    schemaVersion: 1,
+    mode: "standard",
+    enabled: record.enabled !== false,
+    rules,
+  };
+}
+
+function parseRuntimeRequestPolicyRule(
+  value: unknown,
+  index: number,
+): RuntimeRequestPolicyRule | string {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return `Runtime request rule ${index + 1} must be an object.`;
+  }
+  const record = value as Record<string, unknown>;
+  const id = readRuntimePolicyString(record.id, `runtime request rule ${index + 1} id`, 64);
+  if (!id.ok) {
+    return id.error;
+  }
+  const name = readRuntimePolicyString(record.name, `runtime request rule ${index + 1} name`, 120);
+  if (!name.ok) {
+    return name.error;
+  }
+  const pattern = readRuntimePolicyString(
+    record.pattern,
+    `runtime request rule ${index + 1} pattern`,
+    300,
+  );
+  if (!pattern.ok) {
+    return pattern.error;
+  }
+  const action = typeof record.action === "string" ? record.action : "";
+  if (!runtimeRequestPolicyActions.has(action)) {
+    return `Runtime request rule ${index + 1} must use observe, deny, neutralize, or proxy.`;
+  }
+  const methods = parseRuntimePolicyStringSet(
+    record.methods,
+    runtimeRequestPolicyMethods,
+    action === "proxy" ? ["GET", "HEAD"] : ["GET", "HEAD", "POST", "OPTIONS"],
+  );
+  const confirmations = parseRuntimePolicyStringSet(
+    record.confirmations,
+    runtimeRequestPolicyConfirmations,
+    [],
+  );
+  const neutralization = parseRuntimePolicyNeutralization(record.neutralization);
+  return {
+    id: id.value,
+    name: name.value,
+    enabled: record.enabled !== false,
+    pattern: pattern.value,
+    methods: methods as RuntimeRequestPolicyRule["methods"],
+    action: action as RuntimeRequestPolicyRule["action"],
+    credentials: runtimeRequestPolicyCredentials.has(String(record.credentials))
+      ? (record.credentials as RuntimeRequestPolicyRule["credentials"])
+      : "omit",
+    cache: runtimeRequestPolicyCacheModes.has(String(record.cache))
+      ? (record.cache as RuntimeRequestPolicyRule["cache"])
+      : "no-store",
+    maxBodyBytes: readRuntimePolicyInteger(record.maxBodyBytes, 0, 1_048_576),
+    maxResponseBytes: readRuntimePolicyInteger(record.maxResponseBytes, 1_048_576, 10_485_760),
+    timeoutMs: readRuntimePolicyInteger(record.timeoutMs, 5_000, 30_000),
+    redirectScope: runtimeRequestPolicyRedirectScopes.has(String(record.redirectScope))
+      ? (record.redirectScope as RuntimeRequestPolicyRule["redirectScope"])
+      : "same_origin",
+    requestHeaders: { allow: parseRuntimePolicyStringArray(record.requestHeaders, "allow") },
+    responseHeaders: { allow: parseRuntimePolicyStringArray(record.responseHeaders, "allow") },
+    requestContentTypes: parseRuntimePolicyStringArray(record.requestContentTypes),
+    responseContentTypes: parseRuntimePolicyStringArray(record.responseContentTypes),
+    neutralization,
+    confirmations: confirmations as RuntimeRequestPolicyRule["confirmations"],
+  };
+}
+
+function readRuntimePolicyString(
+  value: unknown,
+  label: string,
+  maxLength: number,
+): { ok: true; value: string } | { ok: false; error: string } {
+  if (typeof value !== "string" || !value.trim() || value.trim().length > maxLength) {
+    return { ok: false, error: `${label} is required.` };
+  }
+  return { ok: true, value: value.trim() };
+}
+
+function parseRuntimePolicyStringSet(
+  value: unknown,
+  allowed: Set<string>,
+  defaults: string[],
+): string[] {
+  const raw = Array.isArray(value) ? value : defaults;
+  const out = new Set<string>();
+  for (const entry of raw) {
+    if (typeof entry === "string") {
+      const normalized = entry.trim();
+      if (allowed.has(normalized)) {
+        out.add(normalized);
+      }
+    }
+  }
+  return out.size ? Array.from(out) : defaults;
+}
+
+function parseRuntimePolicyStringArray(value: unknown, nestedKey?: string): string[] {
+  const source =
+    nestedKey && value && typeof value === "object"
+      ? (value as Record<string, unknown>)[nestedKey]
+      : value;
+  if (!Array.isArray(source)) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      source
+        .filter((entry): entry is string => typeof entry === "string")
+        .map((entry) => entry.trim().toLowerCase())
+        .filter(Boolean)
+        .slice(0, 20),
+    ),
+  );
+}
+
+function readRuntimePolicyInteger(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    return fallback;
+  }
+  return Math.max(0, Math.min(value, max));
+}
+
+function parseRuntimePolicyNeutralization(
+  value: unknown,
+): RuntimeRequestPolicyRule["neutralization"] {
+  const record =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  const shape =
+    record.shape === "empty_text" || record.shape === "no_content" || record.shape === "empty_json"
+      ? record.shape
+      : "empty_json";
+  if (shape === "no_content") {
+    return { shape, status: 204, contentType: null, body: null };
+  }
+  if (shape === "empty_text") {
+    return { shape, status: 200, contentType: "text/plain; charset=utf-8", body: "" };
+  }
+  return { shape, status: 200, contentType: "application/json", body: "{}" };
 }
 
 function parseCsvField(rawValue: FormDataEntryValue | null): string[] {
@@ -826,6 +1038,112 @@ export async function updateSourceSelectionAction(
     console.error("[dashboard] updateSourceSelectionAction failed:", error);
     return failed(
       toFriendlyDashboardActionError(error, "Unable to update source selection right now."),
+    );
+  }
+}
+
+export async function updateRuntimeRequestPolicyAction(
+  _prevState: ActionResponse | undefined,
+  formData: FormData,
+): Promise<ActionResponse> {
+  const siteId = formData.get("siteId")?.toString().trim();
+  if (!siteId) {
+    return failed("Site ID is required.");
+  }
+  const runtimeRequestPolicy = parseRuntimeRequestPolicyConfig(
+    formData.get("runtimeRequestPolicy"),
+  );
+  if (typeof runtimeRequestPolicy === "string") {
+    return failed(runtimeRequestPolicy);
+  }
+  const expectedRuntimeRequestPolicyFingerprint = formData
+    .get("expectedRuntimeRequestPolicyFingerprint")
+    ?.toString();
+
+  try {
+    const auth = await requireDashboardAuth();
+    if (!auth.webhooksAuth) {
+      return failed("Unable to authenticate dashboard request.");
+    }
+    if (!auth.has({ feature: "edit" })) {
+      return failed("Runtime request editing is not enabled for this account.");
+    }
+    if (!auth.mutationsAllowed) {
+      return failed(formatBillingBlockMessage(auth, "edit runtime request rules"));
+    }
+
+    const updated = await updateSite(auth.webhooksAuth, siteId, {
+      runtimeRequestPolicy,
+      ...(expectedRuntimeRequestPolicyFingerprint
+        ? { expectedRuntimeRequestPolicyFingerprint }
+        : {}),
+    });
+    await invalidateDashboardCaches(auth.webhooksAuth, siteId, {
+      invalidateSitesList: false,
+    });
+    revalidatePath(`/dashboard/sites/${siteId}`);
+    revalidatePath(`/dashboard/sites/${siteId}/runtime-requests`);
+
+    return succeeded("Runtime request policy saved.", {
+      runtimeRequestPolicy: updated.routeConfig?.runtimeRequestPolicy ?? runtimeRequestPolicy,
+      runtimeRequestPolicyFingerprint: updated.routeConfig?.runtimeRequestPolicyFingerprint ?? null,
+      runtimeRequestPolicyVersion: updated.routeConfig?.runtimeRequestPolicyVersion ?? null,
+      runtimeRequestPolicyPropagation: updated.routeConfig?.runtimeRequestPolicyPropagation ?? null,
+    });
+  } catch (error) {
+    if (isNextRedirectError(error)) {
+      throw error;
+    }
+    console.error("[dashboard] updateRuntimeRequestPolicyAction failed:", error);
+    return failed(
+      toFriendlyDashboardActionError(error, "Unable to update runtime request policy right now."),
+    );
+  }
+}
+
+export async function updateRuntimeRequestObservationLifecycleAction(
+  _prevState: ActionResponse | undefined,
+  formData: FormData,
+): Promise<ActionResponse> {
+  const siteId = formData.get("siteId")?.toString().trim();
+  const groupingPathHash = formData.get("groupingPathHash")?.toString().trim();
+  const method = formData.get("method")?.toString().trim();
+  const shapeSignature = formData.get("shapeSignature")?.toString().trim();
+  const lifecycleRaw = formData.get("lifecycle")?.toString().trim();
+  if (!siteId || !groupingPathHash || !method || !shapeSignature || !lifecycleRaw) {
+    return failed("Observation lifecycle payload is incomplete.");
+  }
+  if (!isRuntimeRequestLifecycle(lifecycleRaw)) {
+    return failed("Observation lifecycle is invalid.");
+  }
+
+  try {
+    const auth = await requireDashboardAuth();
+    if (!auth.webhooksAuth) {
+      return failed("Unable to authenticate dashboard request.");
+    }
+    if (!auth.has({ feature: "edit" })) {
+      return failed("Runtime request review is not enabled for this account.");
+    }
+    if (!auth.mutationsAllowed) {
+      return failed(formatBillingBlockMessage(auth, "review runtime request observations"));
+    }
+
+    const result = await updateRuntimeRequestObservationLifecycle(
+      auth.webhooksAuth,
+      siteId,
+      groupingPathHash,
+      { lifecycle: lifecycleRaw, method, shapeSignature },
+    );
+    revalidatePath(`/dashboard/sites/${siteId}/runtime-requests`);
+    return succeeded("Observation updated.", { state: result.state });
+  } catch (error) {
+    if (isNextRedirectError(error)) {
+      throw error;
+    }
+    console.error("[dashboard] updateRuntimeRequestObservationLifecycleAction failed:", error);
+    return failed(
+      toFriendlyDashboardActionError(error, "Unable to update runtime request observation."),
     );
   }
 }

--- a/app/dashboard/sites/[id]/runtime-requests/page.tsx
+++ b/app/dashboard/sites/[id]/runtime-requests/page.tsx
@@ -206,7 +206,27 @@ function buildRuntimeRequestsCopy(t: Translator): RuntimeRequestsCopy {
       "dashboard.runtimeRequests.rules.empty",
       "No rules. Standard observe-and-fail is active.",
     ),
-    addRule: t("dashboard.runtimeRequests.rules.add", "Add rule"),
+    presetsTitle: t("dashboard.runtimeRequests.rules.presets", "Templates"),
+    presetNeutralizeAnalytics: t(
+      "dashboard.runtimeRequests.rules.preset.neutralizeAnalytics",
+      "Neutralize analytics/beacon",
+    ),
+    presetSearchProxy: t(
+      "dashboard.runtimeRequests.rules.preset.searchProxy",
+      "Read-only search proxy",
+    ),
+    presetFeatureConfigProxy: t(
+      "dashboard.runtimeRequests.rules.preset.featureConfigProxy",
+      "Read-only feature flag/config proxy",
+    ),
+    presetRouteDataProxy: t(
+      "dashboard.runtimeRequests.rules.preset.routeDataProxy",
+      "Route-data passthrough candidate",
+    ),
+    presetFormSubmitProxy: t(
+      "dashboard.runtimeRequests.rules.preset.formSubmitProxy",
+      "Form submit advanced proxy",
+    ),
     validateDraft: t("dashboard.runtimeRequests.rules.validate", "Validate draft"),
     previewReady: t("dashboard.runtimeRequests.preview.ready", "Server validation passed"),
     previewBlocked: t(
@@ -232,6 +252,32 @@ function buildRuntimeRequestsCopy(t: Translator): RuntimeRequestsCopy {
     neutralization: t("dashboard.runtimeRequests.rule.neutralization", "Neutralization"),
     confirmations: t("dashboard.runtimeRequests.rule.confirmations", "Advanced confirmations"),
     removeRule: t("dashboard.runtimeRequests.rule.remove", "Remove rule"),
+    draftStatus: t("dashboard.runtimeRequests.status.draft", "Draft"),
+    savedStatus: t("dashboard.runtimeRequests.status.saved", "Saved"),
+    standardValue: t("dashboard.runtimeRequests.standardValue", "Standard"),
+    standardFallbackVersion: t("dashboard.runtimeRequests.standardFallbackVersion", "standard-v1"),
+    maxBodyBytes: t("dashboard.runtimeRequests.rule.maxBodyBytes", "Max body bytes"),
+    maxResponseBytes: t("dashboard.runtimeRequests.rule.maxResponseBytes", "Max response bytes"),
+    timeoutMs: t("dashboard.runtimeRequests.rule.timeoutMs", "Timeout ms"),
+    requestHeaders: t("dashboard.runtimeRequests.rule.requestHeaders", "Request header allowlist"),
+    responseHeaders: t(
+      "dashboard.runtimeRequests.rule.responseHeaders",
+      "Response header allowlist",
+    ),
+    requestContentTypes: t(
+      "dashboard.runtimeRequests.rule.requestContentTypes",
+      "Request content types",
+    ),
+    responseContentTypes: t(
+      "dashboard.runtimeRequests.rule.responseContentTypes",
+      "Response content types",
+    ),
+    redirectScope: t("dashboard.runtimeRequests.rule.redirectScope", "Redirect scope"),
+    defaultRuleName: t("dashboard.runtimeRequests.rule.defaultName", "Runtime request rule"),
+    previewErrorFallback: t(
+      "dashboard.runtimeRequests.preview.errorFallback",
+      "Unable to preview runtime request policy.",
+    ),
     validationTitle: t("dashboard.runtimeRequests.validation.title", "Validation"),
     warningsTitle: t("dashboard.runtimeRequests.validation.warnings", "Warnings"),
     matchedGroupsTitle: t(

--- a/app/dashboard/sites/[id]/runtime-requests/page.tsx
+++ b/app/dashboard/sites/[id]/runtime-requests/page.tsx
@@ -1,0 +1,246 @@
+import Link from "next/link";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+
+import { ErrorStateCard } from "@/components/dashboard/error-state-card";
+import { Button } from "@/components/ui/button";
+import { requireDashboardAuth } from "@internal/dashboard/auth";
+import { resolveDashboardErrorView } from "@internal/dashboard/error-state";
+import {
+  fetchSite,
+  listRuntimeRequestObservations,
+  WebhooksApiError,
+  type RuntimeRequestObservationGroup,
+  type Site,
+} from "@internal/dashboard/webhooks";
+import { resolveLocaleTranslator, resolvePreferredLocale, type Translator } from "@internal/i18n";
+
+import {
+  updateRuntimeRequestObservationLifecycleAction,
+  updateRuntimeRequestPolicyAction,
+} from "../../../actions";
+import { LockedFeatureCard } from "../locked-feature-card";
+import { SiteHeader } from "../site-header";
+import { RuntimeRequestsManager, type RuntimeRequestsCopy } from "./runtime-requests-manager";
+
+export const metadata = {
+  title: "Runtime requests",
+  robots: { index: false, follow: false },
+};
+
+type RuntimeRequestsPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function RuntimeRequestsPage({ params }: RuntimeRequestsPageProps) {
+  const { id } = await params;
+  const auth = await requireDashboardAuth();
+  const authToken = auth.webhooksAuth!;
+  const mutationsAllowed = auth.mutationsAllowed;
+  const locale = resolvePreferredLocale((await headers()).get("accept-language"));
+  const pricingPath = `/${locale}/pricing`;
+  const { t } = await resolveLocaleTranslator(Promise.resolve({ locale }));
+  const canEdit = auth.has({ feature: "edit" }) && mutationsAllowed;
+  const canPauseTranslations = auth.has({ feature: "edit" });
+  const canResumeTranslations = auth.has({ feature: "edit" }) && mutationsAllowed;
+
+  let site: Site | null = null;
+  let observations: RuntimeRequestObservationGroup[] = [];
+  let error: unknown = null;
+
+  try {
+    site = await fetchSite(authToken, id);
+    const observationResponse = await listRuntimeRequestObservations(authToken, id, {
+      limit: 50,
+      lifecycle: "all",
+      sort: "last_seen_desc",
+    });
+    observations = observationResponse.groups;
+  } catch (err) {
+    error = err;
+    if (err instanceof WebhooksApiError) {
+      console.warn("[dashboard] runtime requests failed", {
+        siteId: id,
+        status: err.status,
+        message: err.message,
+        details: err.details ?? null,
+        subjectAccountId: auth.subjectAccountId,
+        actorAccountId: auth.actorAccountId,
+        actingAsCustomer: auth.actingAsCustomer,
+      });
+    } else {
+      console.warn("[dashboard] runtime requests failed (unknown error)", {
+        siteId: id,
+        message: error,
+      });
+    }
+  }
+
+  if (!site) {
+    if (error) {
+      const errorView = resolveDashboardErrorView(error, {
+        title: "Unable to load runtime requests",
+        description:
+          "We could not complete your request. You can retry or return to the dashboard.",
+        message: "Unable to load runtime requests.",
+      });
+      return (
+        <ErrorStateCard
+          title={errorView.title}
+          description={errorView.description}
+          message={errorView.message}
+          actions={
+            <Button asChild variant="outline">
+              <Link href="/dashboard">Back to dashboard</Link>
+            </Button>
+          }
+        />
+      );
+    }
+    notFound();
+  }
+
+  return (
+    <div className="space-y-8">
+      <SiteHeader
+        site={site}
+        canEdit={canEdit}
+        canPauseTranslations={canPauseTranslations}
+        canResumeTranslations={canResumeTranslations}
+        deactivateLabel={t("dashboard.site.status.deactivate")}
+        reactivateLabel={t("dashboard.site.status.reactivate")}
+        deactivateConfirm={t("dashboard.site.status.deactivateConfirm")}
+        activateHelpLabel={t("dashboard.site.status.activateHelpLabel")}
+        activateHelp={t("dashboard.site.status.activateHelp")}
+      />
+
+      {canEdit ? (
+        <RuntimeRequestsManager
+          siteId={site.id}
+          initialPolicy={site.routeConfig?.runtimeRequestPolicy}
+          runtimeRequestPolicyFingerprint={
+            site.routeConfig?.runtimeRequestPolicyFingerprint ?? null
+          }
+          runtimeRequestPolicyVersion={site.routeConfig?.runtimeRequestPolicyVersion ?? null}
+          propagation={site.routeConfig?.runtimeRequestPolicyPropagation ?? null}
+          observations={observations}
+          canEdit={canEdit}
+          saveAction={updateRuntimeRequestPolicyAction}
+          lifecycleAction={updateRuntimeRequestObservationLifecycleAction}
+          copy={buildRuntimeRequestsCopy(t)}
+        />
+      ) : (
+        <LockedFeatureCard
+          title={t("dashboard.runtimeRequests.locked.title", "Runtime requests")}
+          description={
+            mutationsAllowed
+              ? t(
+                  "dashboard.runtimeRequests.locked.upgrade",
+                  "Upgrade to review observed interactive requests and configure runtime rules.",
+                )
+              : t(
+                  "dashboard.runtimeRequests.locked.billing",
+                  "Update billing to resume runtime request editing.",
+                )
+          }
+          pricingPath={pricingPath}
+          ctaLabel={
+            mutationsAllowed
+              ? t("dashboard.locked.upgradePlan", "Upgrade plan")
+              : t("dashboard.locked.updateBilling", "Update billing")
+          }
+          badgeLabel={
+            mutationsAllowed
+              ? t("dashboard.locked.badge", "Locked")
+              : t("dashboard.locked.billingIssue", "Billing issue")
+          }
+        />
+      )}
+    </div>
+  );
+}
+
+function buildRuntimeRequestsCopy(t: Translator): RuntimeRequestsCopy {
+  return {
+    title: t("dashboard.runtimeRequests.title", "Runtime requests"),
+    description: t(
+      "dashboard.runtimeRequests.description",
+      "Standard mode serves translated HTML and proven assets while unconfigured dynamic requests fail locally and are grouped here.",
+    ),
+    standardMode: t("dashboard.runtimeRequests.standardMode", "Recommended mode"),
+    activeRules: t("dashboard.runtimeRequests.activeRules", "Active rules"),
+    unreviewedGroups: t("dashboard.runtimeRequests.unreviewedGroups", "Unreviewed groups"),
+    highRiskGroups: t("dashboard.runtimeRequests.highRiskGroups", "High risk"),
+    lastSeen: t("dashboard.runtimeRequests.lastSeen", "Last seen"),
+    policyVersion: t("dashboard.runtimeRequests.policyVersion", "Served policy"),
+    propagationReady: t("dashboard.runtimeRequests.propagationReady", "Route cache current"),
+    propagationStale: t("dashboard.runtimeRequests.propagationStale", "Route cache stale"),
+    observationsTitle: t("dashboard.runtimeRequests.observations.title", "Observed requests"),
+    observationsDescription: t(
+      "dashboard.runtimeRequests.observations.description",
+      "Grouped same-origin runtime requests seen by the serve worker.",
+    ),
+    observationsEmpty: t(
+      "dashboard.runtimeRequests.observations.empty",
+      "No dynamic request groups have been observed.",
+    ),
+    method: t("dashboard.runtimeRequests.table.method", "Method"),
+    path: t("dashboard.runtimeRequests.table.path", "Path"),
+    likelyType: t("dashboard.runtimeRequests.table.likelyType", "Likely type"),
+    firstSeen: t("dashboard.runtimeRequests.table.firstSeen", "First / last seen"),
+    seenFromPage: t("dashboard.runtimeRequests.table.seenFromPage", "Seen from page"),
+    currentAction: t("dashboard.runtimeRequests.table.currentAction", "Current action"),
+    suggestedAction: t("dashboard.runtimeRequests.table.suggestedAction", "Suggested action"),
+    risk: t("dashboard.runtimeRequests.table.risk", "Risk"),
+    lifecycle: t("dashboard.runtimeRequests.table.lifecycle", "Lifecycle"),
+    reviewed: t("dashboard.runtimeRequests.lifecycle.reviewed", "Reviewed"),
+    dismissed: t("dashboard.runtimeRequests.lifecycle.dismissed", "Dismissed"),
+    ignored: t("dashboard.runtimeRequests.lifecycle.ignored", "Ignored"),
+    createRule: t("dashboard.runtimeRequests.createRule", "Create rule"),
+    rulesTitle: t("dashboard.runtimeRequests.rules.title", "Policy rules"),
+    rulesDescription: t(
+      "dashboard.runtimeRequests.rules.description",
+      "Keep Standard as the baseline and add narrow rules only for interactive behavior you understand.",
+    ),
+    noRules: t(
+      "dashboard.runtimeRequests.rules.empty",
+      "No rules. Standard observe-and-fail is active.",
+    ),
+    addRule: t("dashboard.runtimeRequests.rules.add", "Add rule"),
+    validateDraft: t("dashboard.runtimeRequests.rules.validate", "Validate draft"),
+    previewReady: t("dashboard.runtimeRequests.preview.ready", "Server validation passed"),
+    previewBlocked: t(
+      "dashboard.runtimeRequests.preview.blocked",
+      "Server validation blocked save",
+    ),
+    previewRequired: t(
+      "dashboard.runtimeRequests.preview.required",
+      "Validate the current draft before saving.",
+    ),
+    save: t("dashboard.runtimeRequests.save", "Save policy"),
+    saving: t("dashboard.runtimeRequests.saving", "Saving"),
+    reset: t("dashboard.runtimeRequests.reset", "Reset draft"),
+    enabled: t("dashboard.runtimeRequests.rule.enabled", "Enabled"),
+    name: t("dashboard.runtimeRequests.rule.name", "Name"),
+    pattern: t("dashboard.runtimeRequests.rule.pattern", "Path pattern"),
+    methods: t("dashboard.runtimeRequests.rule.methods", "Methods"),
+    action: t("dashboard.runtimeRequests.rule.action", "Action"),
+    credentials: t("dashboard.runtimeRequests.rule.credentials", "Credentials"),
+    cache: t("dashboard.runtimeRequests.rule.cache", "Cache"),
+    limits: t("dashboard.runtimeRequests.rule.limits", "Limits"),
+    headers: t("dashboard.runtimeRequests.rule.headers", "Header allowlists"),
+    neutralization: t("dashboard.runtimeRequests.rule.neutralization", "Neutralization"),
+    confirmations: t("dashboard.runtimeRequests.rule.confirmations", "Advanced confirmations"),
+    removeRule: t("dashboard.runtimeRequests.rule.remove", "Remove rule"),
+    validationTitle: t("dashboard.runtimeRequests.validation.title", "Validation"),
+    warningsTitle: t("dashboard.runtimeRequests.validation.warnings", "Warnings"),
+    matchedGroupsTitle: t(
+      "dashboard.runtimeRequests.validation.matchedGroups",
+      "Matched observations",
+    ),
+    redactionNote: t(
+      "dashboard.runtimeRequests.redactionNote",
+      "Details are redacted: no cookies, auth headers, bodies, raw query strings, or sensitive full URLs are shown.",
+    ),
+  };
+}

--- a/app/dashboard/sites/[id]/runtime-requests/runtime-requests-manager.test.tsx
+++ b/app/dashboard/sites/[id]/runtime-requests/runtime-requests-manager.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ActionResponse } from "@/app/dashboard/actions";
+import type {
+  RuntimeRequestObservationGroup,
+  RuntimeRequestPolicyConfig,
+} from "@internal/dashboard/webhooks";
+
+import { RuntimeRequestsManager, type RuntimeRequestsCopy } from "./runtime-requests-manager";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+const copy: RuntimeRequestsCopy = {
+  title: "Runtime requests",
+  description: "Runtime request policy.",
+  standardMode: "Recommended mode",
+  activeRules: "Active rules",
+  unreviewedGroups: "Unreviewed groups",
+  highRiskGroups: "High risk",
+  lastSeen: "Last seen",
+  policyVersion: "Served policy",
+  propagationReady: "Route cache current",
+  propagationStale: "Route cache stale",
+  observationsTitle: "Observed requests",
+  observationsDescription: "Grouped requests.",
+  observationsEmpty: "No observations.",
+  method: "Method",
+  path: "Path",
+  likelyType: "Likely type",
+  firstSeen: "First / last seen",
+  seenFromPage: "Seen from page",
+  currentAction: "Current action",
+  suggestedAction: "Suggested action",
+  risk: "Risk",
+  lifecycle: "Lifecycle",
+  reviewed: "Reviewed",
+  dismissed: "Dismissed",
+  ignored: "Ignored",
+  createRule: "Create rule",
+  rulesTitle: "Policy rules",
+  rulesDescription: "Rules.",
+  noRules: "No rules.",
+  addRule: "Add rule",
+  validateDraft: "Validate draft",
+  previewReady: "Server validation passed",
+  previewBlocked: "Server validation blocked save",
+  previewRequired: "Validate before saving.",
+  save: "Save policy",
+  saving: "Saving",
+  reset: "Reset draft",
+  enabled: "Enabled",
+  name: "Name",
+  pattern: "Path pattern",
+  methods: "Methods",
+  action: "Action",
+  credentials: "Credentials",
+  cache: "Cache",
+  limits: "Limits",
+  headers: "Header allowlists",
+  neutralization: "Neutralization",
+  confirmations: "Advanced confirmations",
+  removeRule: "Remove rule",
+  validationTitle: "Validation",
+  warningsTitle: "Warnings",
+  matchedGroupsTitle: "Matched observations",
+  redactionNote: "Redacted details only.",
+};
+
+const emptyPolicy: RuntimeRequestPolicyConfig = {
+  schemaVersion: 1,
+  mode: "standard",
+  enabled: true,
+  rules: [],
+};
+
+const observation: RuntimeRequestObservationGroup = {
+  siteId: "site-1",
+  groupingPathHash: "cart-group",
+  shapeSignature: "POST:cart-group:high_risk_dynamic:fetch:json",
+  path: "/api/cart",
+  method: "POST",
+  likelyType: "high_risk_dynamic",
+  intent: "fetch",
+  acceptClass: "json",
+  risk: "high",
+  riskReasons: ["high_risk_path"],
+  firstSeenAt: "2026-05-04T00:00:00.000Z",
+  lastSeenAt: "2026-05-04T01:00:00.000Z",
+  count: 2,
+  seenFromPage: "/pricing",
+  currentAction: "observe",
+  suggestedAction: "deny",
+  policyRuleId: null,
+  routePolicyVersion: "site-config:v1",
+  routePolicyStale: false,
+  lifecycle: "open",
+  reviewedAt: null,
+  dismissedAt: null,
+  ignoredAt: null,
+  bodyPresent: true,
+  bodySizeBucket: "1-1kb",
+};
+
+afterEach(() => {
+  cleanup();
+  (globalThis as { fetch: typeof fetch }).fetch = ORIGINAL_FETCH;
+  vi.restoreAllMocks();
+});
+
+function renderManager(options: { saveAction?: RuntimeRequestsManagerPropsSave } = {}) {
+  const saveAction = options.saveAction ?? vi.fn(async () => ({ ok: true, message: "saved" }));
+  const lifecycleAction = vi.fn(async () => ({ ok: true, message: "updated" }));
+  render(
+    <RuntimeRequestsManager
+      siteId="site-1"
+      initialPolicy={emptyPolicy}
+      runtimeRequestPolicyFingerprint="fingerprint-1"
+      runtimeRequestPolicyVersion="site-config:v1"
+      propagation={{
+        servedVersion: "site-config:v1",
+        expectedVersion: "site-config:v1",
+        stale: false,
+      }}
+      observations={[observation]}
+      canEdit
+      saveAction={saveAction}
+      lifecycleAction={lifecycleAction}
+      copy={copy}
+    />,
+  );
+  return { saveAction, lifecycleAction };
+}
+
+type RuntimeRequestsManagerPropsSave = (
+  prev: ActionResponse | undefined,
+  formData: FormData,
+) => Promise<ActionResponse>;
+
+describe("RuntimeRequestsManager", () => {
+  it("creates a draft rule from an observation without saving it", () => {
+    const saveAction = vi.fn(async () => ({ ok: true, message: "saved" }));
+    renderManager({ saveAction });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create rule" }));
+
+    expect(screen.getByDisplayValue("/api/cart")).toBeTruthy();
+    expect(saveAction).not.toHaveBeenCalled();
+  });
+
+  it("blocks save on server validation errors and preserves the draft", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            runtimeRequestPolicy: emptyPolicy,
+            validationErrors: [
+              {
+                code: "confirmation_required_high_risk_path",
+                ruleId: "cart",
+                message: "High-risk path confirmation required.",
+              },
+            ],
+            warnings: [],
+            collisions: [],
+            highRiskConfirmations: [
+              { ruleId: "cart", code: "confirmation_required_high_risk_path" },
+            ],
+            sampleResults: [],
+            matchedObservationGroups: [],
+            propagation: {
+              currentRouteConfigUpdatedAt: "2026-05-04T00:00:00.000Z",
+              currentRuntimeRequestPolicyVersion: "site-config:v1",
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+    const saveAction = vi.fn(async () => ({ ok: true, message: "saved" }));
+    renderManager({ saveAction });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create rule" }));
+    fireEvent.click(screen.getByRole("button", { name: "Validate draft" }));
+
+    expect(await screen.findAllByText(/confirmation_required_high_risk_path/)).toHaveLength(2);
+    expect(screen.getByRole<HTMLButtonElement>("button", { name: "Save policy" }).disabled).toBe(
+      true,
+    );
+    expect(screen.getByDisplayValue("/api/cart")).toBeTruthy();
+    expect(saveAction).not.toHaveBeenCalled();
+  });
+});

--- a/app/dashboard/sites/[id]/runtime-requests/runtime-requests-manager.test.tsx
+++ b/app/dashboard/sites/[id]/runtime-requests/runtime-requests-manager.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ActionResponse } from "@/app/dashboard/actions";
@@ -42,7 +42,12 @@ const copy: RuntimeRequestsCopy = {
   rulesTitle: "Policy rules",
   rulesDescription: "Rules.",
   noRules: "No rules.",
-  addRule: "Add rule",
+  presetsTitle: "Templates",
+  presetNeutralizeAnalytics: "Neutralize analytics/beacon",
+  presetSearchProxy: "Read-only search proxy",
+  presetFeatureConfigProxy: "Read-only feature flag/config proxy",
+  presetRouteDataProxy: "Route-data passthrough candidate",
+  presetFormSubmitProxy: "Form submit advanced proxy",
   validateDraft: "Validate draft",
   previewReady: "Server validation passed",
   previewBlocked: "Server validation blocked save",
@@ -62,6 +67,20 @@ const copy: RuntimeRequestsCopy = {
   neutralization: "Neutralization",
   confirmations: "Advanced confirmations",
   removeRule: "Remove rule",
+  draftStatus: "Draft",
+  savedStatus: "Saved",
+  standardValue: "Standard",
+  standardFallbackVersion: "standard-v1",
+  maxBodyBytes: "Max body bytes",
+  maxResponseBytes: "Max response bytes",
+  timeoutMs: "Timeout ms",
+  requestHeaders: "Request header allowlist",
+  responseHeaders: "Response header allowlist",
+  requestContentTypes: "Request content types",
+  responseContentTypes: "Response content types",
+  redirectScope: "Redirect scope",
+  defaultRuleName: "Runtime request rule",
+  previewErrorFallback: "Unable to preview runtime request policy.",
   validationTitle: "Validation",
   warningsTitle: "Warnings",
   matchedGroupsTitle: "Matched observations",
@@ -147,6 +166,29 @@ describe("RuntimeRequestsManager", () => {
 
     expect(screen.getByDisplayValue("/api/cart")).toBeTruthy();
     expect(saveAction).not.toHaveBeenCalled();
+  });
+
+  it("adds rules only through explicit templates", () => {
+    const saveAction = vi.fn(async () => ({ ok: true, message: "saved" }));
+    renderManager({ saveAction });
+
+    expect(screen.queryByRole("button", { name: "Add rule" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Read-only search proxy" }));
+
+    expect(screen.getByDisplayValue("/api/search")).toBeTruthy();
+    expect(screen.getByDisplayValue("Read-only search proxy")).toBeTruthy();
+    expect(saveAction).not.toHaveBeenCalled();
+  });
+
+  it("supports dismissing observed request groups", async () => {
+    const { lifecycleAction } = renderManager();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismissed" }));
+
+    await waitFor(() => expect(lifecycleAction).toHaveBeenCalled());
+    const call = lifecycleAction.mock.calls[0] as unknown as [ActionResponse | undefined, FormData];
+    const formData = call[1];
+    expect(formData.get("lifecycle")).toBe("dismissed");
   });
 
   it("blocks save on server validation errors and preserves the draft", async () => {

--- a/app/dashboard/sites/[id]/runtime-requests/runtime-requests-manager.tsx
+++ b/app/dashboard/sites/[id]/runtime-requests/runtime-requests-manager.tsx
@@ -1,0 +1,1077 @@
+"use client";
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Eye,
+  Loader2,
+  Plus,
+  Save,
+  ShieldAlert,
+  Trash2,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+
+import type { ActionResponse } from "@/app/dashboard/actions";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Field } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import type {
+  RuntimeRequestLifecycle,
+  RuntimeRequestObservationGroup,
+  RuntimeRequestPolicyAction,
+  RuntimeRequestPolicyConfig,
+  RuntimeRequestPolicyConfirmation,
+  RuntimeRequestPolicyMethod,
+  RuntimeRequestPolicyPreviewResponse,
+  RuntimeRequestPolicyRule,
+  RuntimeRequestPolicyPropagation,
+} from "@internal/dashboard/webhooks";
+
+const ALL_METHODS: RuntimeRequestPolicyMethod[] = [
+  "GET",
+  "HEAD",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "OPTIONS",
+];
+const CONFIRMATIONS: RuntimeRequestPolicyConfirmation[] = [
+  "non_get_proxy",
+  "credential_forwarding",
+  "high_risk_path",
+];
+const DEFAULT_POLICY: RuntimeRequestPolicyConfig = {
+  schemaVersion: 1,
+  mode: "standard",
+  enabled: true,
+  rules: [],
+};
+
+export type RuntimeRequestsCopy = {
+  title: string;
+  description: string;
+  standardMode: string;
+  activeRules: string;
+  unreviewedGroups: string;
+  highRiskGroups: string;
+  lastSeen: string;
+  policyVersion: string;
+  propagationReady: string;
+  propagationStale: string;
+  observationsTitle: string;
+  observationsDescription: string;
+  observationsEmpty: string;
+  method: string;
+  path: string;
+  likelyType: string;
+  firstSeen: string;
+  seenFromPage: string;
+  currentAction: string;
+  suggestedAction: string;
+  risk: string;
+  lifecycle: string;
+  reviewed: string;
+  dismissed: string;
+  ignored: string;
+  createRule: string;
+  rulesTitle: string;
+  rulesDescription: string;
+  noRules: string;
+  addRule: string;
+  validateDraft: string;
+  previewReady: string;
+  previewBlocked: string;
+  previewRequired: string;
+  save: string;
+  saving: string;
+  reset: string;
+  enabled: string;
+  name: string;
+  pattern: string;
+  methods: string;
+  action: string;
+  credentials: string;
+  cache: string;
+  limits: string;
+  headers: string;
+  neutralization: string;
+  confirmations: string;
+  removeRule: string;
+  validationTitle: string;
+  warningsTitle: string;
+  matchedGroupsTitle: string;
+  redactionNote: string;
+};
+
+type RuntimeRequestsManagerProps = {
+  siteId: string;
+  initialPolicy: RuntimeRequestPolicyConfig | null | undefined;
+  runtimeRequestPolicyFingerprint?: string | null;
+  runtimeRequestPolicyVersion?: string | null;
+  propagation?: RuntimeRequestPolicyPropagation | null;
+  observations: RuntimeRequestObservationGroup[];
+  canEdit: boolean;
+  saveAction: (
+    prevState: ActionResponse | undefined,
+    formData: FormData,
+  ) => Promise<ActionResponse>;
+  lifecycleAction: (
+    prevState: ActionResponse | undefined,
+    formData: FormData,
+  ) => Promise<ActionResponse>;
+  copy: RuntimeRequestsCopy;
+};
+
+export function RuntimeRequestsManager({
+  siteId,
+  initialPolicy,
+  runtimeRequestPolicyFingerprint,
+  runtimeRequestPolicyVersion,
+  propagation,
+  observations,
+  canEdit,
+  saveAction,
+  lifecycleAction,
+  copy,
+}: RuntimeRequestsManagerProps) {
+  const normalizedInitialPolicy = useMemo(
+    () => normalizeRuntimePolicy(initialPolicy ?? DEFAULT_POLICY),
+    [initialPolicy],
+  );
+  const [persistedPolicy, setPersistedPolicy] = useState(normalizedInitialPolicy);
+  const [draftPolicy, setDraftPolicy] = useState(normalizedInitialPolicy);
+  const [expectedFingerprint, setExpectedFingerprint] = useState(
+    runtimeRequestPolicyFingerprint ?? null,
+  );
+  const [servedVersion, setServedVersion] = useState(runtimeRequestPolicyVersion ?? null);
+  const [servedPropagation, setServedPropagation] = useState(propagation ?? null);
+  const [groups, setGroups] = useState(observations);
+  const [preview, setPreview] = useState<RuntimeRequestPolicyPreviewResponse | null>(null);
+  const [previewFingerprint, setPreviewFingerprint] = useState("");
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [isPreviewing, setPreviewing] = useState(false);
+  const [isSaving, setSaving] = useState(false);
+  const [saveResult, setSaveResult] = useState<ActionResponse | null>(null);
+  const [lifecycleResult, setLifecycleResult] = useState<ActionResponse | null>(null);
+
+  const persistedFingerprint = runtimePolicyFingerprint(persistedPolicy);
+  const draftFingerprint = runtimePolicyFingerprint(draftPolicy);
+  const hasUnsavedChanges = draftFingerprint !== persistedFingerprint;
+  const activeRuleCount = draftPolicy.rules.filter((rule) => rule.enabled).length;
+  const unreviewedCount = groups.filter((group) => group.lifecycle === "open").length;
+  const highRiskCount = groups.filter(
+    (group) => group.risk === "high" && group.lifecycle !== "ignored",
+  ).length;
+  const lastSeenAt = groups
+    .map((group) => group.lastSeenAt)
+    .sort((left, right) => right.localeCompare(left))[0];
+  const previewIsCurrent = previewFingerprint === draftFingerprint;
+  const previewBlocksSave =
+    !preview ||
+    !previewIsCurrent ||
+    preview.validationErrors.length > 0 ||
+    preview.highRiskConfirmations.length > 0 ||
+    preview.collisions.length > 0;
+  const canSave =
+    canEdit &&
+    hasUnsavedChanges &&
+    !isSaving &&
+    !isPreviewing &&
+    !previewError &&
+    !previewBlocksSave;
+
+  const updateDraft = (
+    updater: (policy: RuntimeRequestPolicyConfig) => RuntimeRequestPolicyConfig,
+  ) => {
+    setDraftPolicy((current) => normalizeRuntimePolicy(updater(current)));
+    setPreview(null);
+    setPreviewFingerprint("");
+    setPreviewError(null);
+    setSaveResult(null);
+  };
+
+  const runPreview = () => {
+    if (!canEdit) {
+      return;
+    }
+    setPreviewing(true);
+    setPreviewError(null);
+    void (async () => {
+      try {
+        const response = await fetch(
+          `/api/dashboard/sites/${encodeURIComponent(siteId)}/runtime-request-policy/preview`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              runtimeRequestPolicy: draftPolicy,
+              samples: groups.slice(0, 10).map((group) => ({
+                url: `https://example.invalid${group.path}`,
+                method: group.method,
+                accept: group.acceptClass === "json" ? "application/json" : "*/*",
+              })),
+            }),
+            cache: "no-store",
+          },
+        );
+        const body = (await response.json()) as unknown;
+        if (!response.ok) {
+          setPreviewError(extractPreviewMessage(body));
+          return;
+        }
+        setPreview(body as RuntimeRequestPolicyPreviewResponse);
+        setPreviewFingerprint(draftFingerprint);
+      } catch (error) {
+        setPreviewError(error instanceof Error ? error.message : copy.previewBlocked);
+      } finally {
+        setPreviewing(false);
+      }
+    })();
+  };
+
+  const savePolicy = () => {
+    if (!canSave) {
+      return;
+    }
+    setSaving(true);
+    void (async () => {
+      const formData = new FormData();
+      formData.set("siteId", siteId);
+      formData.set("runtimeRequestPolicy", JSON.stringify(draftPolicy));
+      if (expectedFingerprint) {
+        formData.set("expectedRuntimeRequestPolicyFingerprint", expectedFingerprint);
+      }
+      try {
+        const result = await saveAction(undefined, formData);
+        setSaveResult(result);
+        if (!result.ok) {
+          return;
+        }
+        const savedPolicy = readSavedRuntimePolicy(result.meta) ?? draftPolicy;
+        setPersistedPolicy(savedPolicy);
+        setDraftPolicy(savedPolicy);
+        setExpectedFingerprint(readMetaString(result.meta, "runtimeRequestPolicyFingerprint"));
+        setServedVersion(readMetaString(result.meta, "runtimeRequestPolicyVersion"));
+        setServedPropagation(readSavedPropagation(result.meta));
+        setPreview(null);
+        setPreviewFingerprint("");
+      } catch (error) {
+        setSaveResult({
+          ok: false,
+          message: error instanceof Error ? error.message : copy.previewBlocked,
+        });
+      } finally {
+        setSaving(false);
+      }
+    })();
+  };
+
+  const updateLifecycle = (
+    group: RuntimeRequestObservationGroup,
+    lifecycle: RuntimeRequestLifecycle,
+  ) => {
+    if (!canEdit) {
+      return;
+    }
+    const formData = new FormData();
+    formData.set("siteId", siteId);
+    formData.set("groupingPathHash", group.groupingPathHash);
+    formData.set("method", group.method);
+    formData.set("shapeSignature", group.shapeSignature);
+    formData.set("lifecycle", lifecycle);
+    void lifecycleAction(undefined, formData).then((result) => {
+      setLifecycleResult(result);
+      if (result.ok) {
+        setGroups((current) =>
+          current.map((entry) =>
+            entry.groupingPathHash === group.groupingPathHash &&
+            entry.method === group.method &&
+            entry.shapeSignature === group.shapeSignature
+              ? { ...entry, lifecycle }
+              : entry,
+          ),
+        );
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle>{copy.title}</CardTitle>
+            <CardDescription>{copy.description}</CardDescription>
+          </div>
+          <Badge variant={servedPropagation?.stale ? "destructive" : "secondary"}>
+            {servedPropagation?.stale ? copy.propagationStale : copy.propagationReady}
+          </Badge>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-5">
+          <Metric label={copy.standardMode} value="Standard" />
+          <Metric label={copy.activeRules} value={String(activeRuleCount)} />
+          <Metric label={copy.unreviewedGroups} value={String(unreviewedCount)} />
+          <Metric label={copy.highRiskGroups} value={String(highRiskCount)} />
+          <Metric label={copy.lastSeen} value={formatDate(lastSeenAt)} />
+          <div className="md:col-span-5">
+            <p className="text-xs text-muted-foreground">
+              {copy.policyVersion}:{" "}
+              {servedVersion ?? servedPropagation?.servedVersion ?? "standard-v1"}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{copy.observationsTitle}</CardTitle>
+          <CardDescription>{copy.observationsDescription}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-xs text-muted-foreground">{copy.redactionNote}</p>
+          <ObservationsTable
+            canEdit={canEdit}
+            copy={copy}
+            groups={groups}
+            onCreateRule={(group) => updateDraft((policy) => addRuleFromObservation(policy, group))}
+            onLifecycle={updateLifecycle}
+          />
+          {lifecycleResult ? (
+            <p
+              role={lifecycleResult.ok ? "status" : "alert"}
+              className={cn(
+                "text-sm",
+                lifecycleResult.ok ? "text-emerald-700" : "text-destructive",
+              )}
+            >
+              {lifecycleResult.message}
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle>{copy.rulesTitle}</CardTitle>
+            <CardDescription>{copy.rulesDescription}</CardDescription>
+          </div>
+          <Badge variant={hasUnsavedChanges ? "outline" : "secondary"}>
+            {hasUnsavedChanges ? "Draft" : "Saved"}
+          </Badge>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!canEdit || isSaving}
+              onClick={() =>
+                updateDraft((policy) => ({ ...policy, rules: [...policy.rules, createRule()] }))
+              }
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              {copy.addRule}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!canEdit || isPreviewing}
+              onClick={runPreview}
+            >
+              {isPreviewing ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Eye className="mr-2 h-4 w-4" />
+              )}
+              {copy.validateDraft}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!hasUnsavedChanges || isSaving}
+              onClick={() => setDraftPolicy(persistedPolicy)}
+            >
+              {copy.reset}
+            </Button>
+            <Button type="button" disabled={!canSave} onClick={savePolicy}>
+              {isSaving ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-2 h-4 w-4" />
+              )}
+              {isSaving ? copy.saving : copy.save}
+            </Button>
+          </div>
+
+          <PreviewStatus
+            copy={copy}
+            preview={preview}
+            previewError={previewError}
+            isCurrent={previewIsCurrent}
+          />
+
+          {draftPolicy.rules.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{copy.noRules}</p>
+          ) : (
+            <div className="space-y-4">
+              {draftPolicy.rules.map((rule, index) => (
+                <RuleEditor
+                  key={rule.id}
+                  copy={copy}
+                  canEdit={canEdit && !isSaving}
+                  rule={rule}
+                  onChange={(nextRule) =>
+                    updateDraft((policy) => ({
+                      ...policy,
+                      rules: policy.rules.map((entry, ruleIndex) =>
+                        ruleIndex === index ? nextRule : entry,
+                      ),
+                    }))
+                  }
+                  onRemove={() =>
+                    updateDraft((policy) => ({
+                      ...policy,
+                      rules: policy.rules.filter((_, ruleIndex) => ruleIndex !== index),
+                    }))
+                  }
+                />
+              ))}
+            </div>
+          )}
+
+          {saveResult ? (
+            <p
+              role={saveResult.ok ? "status" : "alert"}
+              className={cn("text-sm", saveResult.ok ? "text-emerald-700" : "text-destructive")}
+            >
+              {saveResult.message}
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border/60 bg-muted/20 p-3">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function ObservationsTable({
+  canEdit,
+  copy,
+  groups,
+  onCreateRule,
+  onLifecycle,
+}: {
+  canEdit: boolean;
+  copy: RuntimeRequestsCopy;
+  groups: RuntimeRequestObservationGroup[];
+  onCreateRule: (group: RuntimeRequestObservationGroup) => void;
+  onLifecycle: (group: RuntimeRequestObservationGroup, lifecycle: RuntimeRequestLifecycle) => void;
+}) {
+  if (!groups.length) {
+    return <p className="text-sm text-muted-foreground">{copy.observationsEmpty}</p>;
+  }
+  return (
+    <div className="overflow-x-auto rounded-md border border-border/60">
+      <table className="w-full min-w-[980px] border-collapse text-sm">
+        <thead className="bg-muted/40 text-left text-xs text-muted-foreground">
+          <tr>
+            {[
+              copy.method,
+              copy.path,
+              copy.likelyType,
+              copy.firstSeen,
+              copy.seenFromPage,
+              copy.currentAction,
+              copy.suggestedAction,
+              copy.risk,
+              copy.lifecycle,
+              "",
+            ].map((heading) => (
+              <th key={heading || "actions"} className="px-3 py-2 font-medium">
+                {heading}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {groups.map((group) => (
+            <tr
+              key={`${group.groupingPathHash}:${group.method}:${group.shapeSignature}`}
+              className="border-t border-border/60"
+            >
+              <td className="px-3 py-2 font-mono text-xs">{group.method}</td>
+              <td className="px-3 py-2">
+                <div className="font-mono text-xs">{group.path}</div>
+                <div className="text-xs text-muted-foreground">{group.count}x</div>
+              </td>
+              <td className="px-3 py-2">{formatClassification(group.likelyType)}</td>
+              <td className="px-3 py-2">
+                {formatDate(group.firstSeenAt)} → {formatDate(group.lastSeenAt)}
+              </td>
+              <td className="px-3 py-2 font-mono text-xs">{group.seenFromPage ?? "—"}</td>
+              <td className="px-3 py-2">{group.currentAction}</td>
+              <td className="px-3 py-2">{group.suggestedAction}</td>
+              <td className="px-3 py-2">
+                <RiskBadge risk={group.risk} />
+              </td>
+              <td className="px-3 py-2">{group.lifecycle}</td>
+              <td className="px-3 py-2">
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={!canEdit}
+                    onClick={() => onCreateRule(group)}
+                  >
+                    {copy.createRule}
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={!canEdit}
+                    onClick={() => onLifecycle(group, "reviewed")}
+                  >
+                    {copy.reviewed}
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={!canEdit}
+                    onClick={() => onLifecycle(group, "ignored")}
+                  >
+                    {copy.ignored}
+                  </Button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RuleEditor({
+  canEdit,
+  copy,
+  rule,
+  onChange,
+  onRemove,
+}: {
+  canEdit: boolean;
+  copy: RuntimeRequestsCopy;
+  rule: RuntimeRequestPolicyRule;
+  onChange: (rule: RuntimeRequestPolicyRule) => void;
+  onRemove: () => void;
+}) {
+  const methodSet = new Set(rule.methods);
+  return (
+    <div className="rounded-md border border-border/60 bg-muted/10 p-4">
+      <div className="grid gap-4 lg:grid-cols-[1fr_1fr_auto]">
+        <label className="flex items-center gap-2 text-sm font-medium">
+          <input
+            type="checkbox"
+            checked={rule.enabled}
+            disabled={!canEdit}
+            onChange={(event) => onChange({ ...rule, enabled: event.target.checked })}
+          />
+          {copy.enabled}
+        </label>
+        <Field label={copy.name} htmlFor={`${rule.id}-name`}>
+          <Input
+            id={`${rule.id}-name`}
+            value={rule.name}
+            disabled={!canEdit}
+            onChange={(event) => onChange({ ...rule, name: event.target.value })}
+          />
+        </Field>
+        <Button type="button" variant="outline" disabled={!canEdit} onClick={onRemove}>
+          <Trash2 className="mr-2 h-4 w-4" />
+          {copy.removeRule}
+        </Button>
+      </div>
+      <div className="mt-4 grid gap-4 lg:grid-cols-3">
+        <Field label={copy.pattern} htmlFor={`${rule.id}-pattern`}>
+          <Input
+            id={`${rule.id}-pattern`}
+            value={rule.pattern}
+            disabled={!canEdit}
+            onChange={(event) => onChange({ ...rule, pattern: event.target.value })}
+          />
+        </Field>
+        <Field label={copy.action} htmlFor={`${rule.id}-action`}>
+          <select
+            id={`${rule.id}-action`}
+            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            value={rule.action}
+            disabled={!canEdit}
+            onChange={(event) =>
+              onChange(applyActionDefaults(rule, event.target.value as RuntimeRequestPolicyAction))
+            }
+          >
+            {(["observe", "deny", "neutralize", "proxy"] as RuntimeRequestPolicyAction[]).map(
+              (action) => (
+                <option key={action} value={action}>
+                  {action}
+                </option>
+              ),
+            )}
+          </select>
+        </Field>
+        <Field label={copy.credentials} htmlFor={`${rule.id}-credentials`}>
+          <select
+            id={`${rule.id}-credentials`}
+            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            value={rule.credentials}
+            disabled={!canEdit}
+            onChange={(event) =>
+              onChange({
+                ...rule,
+                credentials: event.target.value as RuntimeRequestPolicyRule["credentials"],
+              })
+            }
+          >
+            <option value="omit">omit</option>
+            <option value="same_origin">same_origin</option>
+            <option value="include">include</option>
+          </select>
+        </Field>
+      </div>
+      <fieldset className="mt-4">
+        <legend className="text-sm font-medium">{copy.methods}</legend>
+        <div className="mt-2 flex flex-wrap gap-3">
+          {ALL_METHODS.map((method) => (
+            <label key={method} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={methodSet.has(method)}
+                disabled={!canEdit}
+                onChange={(event) => {
+                  const next = new Set(methodSet);
+                  if (event.target.checked) next.add(method);
+                  else next.delete(method);
+                  onChange({ ...rule, methods: Array.from(next) as RuntimeRequestPolicyMethod[] });
+                }}
+              />
+              {method}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+      <div className="mt-4 grid gap-4 lg:grid-cols-4">
+        <Field label="Max body bytes" htmlFor={`${rule.id}-body`}>
+          <Input
+            id={`${rule.id}-body`}
+            type="number"
+            min={0}
+            value={rule.maxBodyBytes}
+            disabled={!canEdit}
+            onChange={(event) => onChange({ ...rule, maxBodyBytes: Number(event.target.value) })}
+          />
+        </Field>
+        <Field label="Max response bytes" htmlFor={`${rule.id}-response`}>
+          <Input
+            id={`${rule.id}-response`}
+            type="number"
+            min={0}
+            value={rule.maxResponseBytes}
+            disabled={!canEdit}
+            onChange={(event) =>
+              onChange({ ...rule, maxResponseBytes: Number(event.target.value) })
+            }
+          />
+        </Field>
+        <Field label="Timeout ms" htmlFor={`${rule.id}-timeout`}>
+          <Input
+            id={`${rule.id}-timeout`}
+            type="number"
+            min={1}
+            value={rule.timeoutMs}
+            disabled={!canEdit}
+            onChange={(event) => onChange({ ...rule, timeoutMs: Number(event.target.value) })}
+          />
+        </Field>
+        <Field label={copy.cache} htmlFor={`${rule.id}-cache`}>
+          <select
+            id={`${rule.id}-cache`}
+            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            value={rule.cache}
+            disabled={!canEdit}
+            onChange={(event) =>
+              onChange({ ...rule, cache: event.target.value as RuntimeRequestPolicyRule["cache"] })
+            }
+          >
+            <option value="no-store">no-store</option>
+            <option value="edge">edge</option>
+          </select>
+        </Field>
+      </div>
+      <div className="mt-4 grid gap-4 lg:grid-cols-2">
+        <Field label={`${copy.headers} request`} htmlFor={`${rule.id}-request-headers`}>
+          <Input
+            id={`${rule.id}-request-headers`}
+            value={rule.requestHeaders.allow.join(", ")}
+            disabled={!canEdit}
+            onChange={(event) =>
+              onChange({ ...rule, requestHeaders: { allow: splitList(event.target.value) } })
+            }
+          />
+        </Field>
+        <Field label={`${copy.headers} response`} htmlFor={`${rule.id}-response-headers`}>
+          <Input
+            id={`${rule.id}-response-headers`}
+            value={rule.responseHeaders.allow.join(", ")}
+            disabled={!canEdit}
+            onChange={(event) =>
+              onChange({ ...rule, responseHeaders: { allow: splitList(event.target.value) } })
+            }
+          />
+        </Field>
+        <Field label="Request content types" htmlFor={`${rule.id}-request-content-types`}>
+          <Input
+            id={`${rule.id}-request-content-types`}
+            value={rule.requestContentTypes.join(", ")}
+            disabled={!canEdit}
+            onChange={(event) =>
+              onChange({ ...rule, requestContentTypes: splitList(event.target.value) })
+            }
+          />
+        </Field>
+        <Field label="Response content types" htmlFor={`${rule.id}-response-content-types`}>
+          <Input
+            id={`${rule.id}-response-content-types`}
+            value={rule.responseContentTypes.join(", ")}
+            disabled={!canEdit}
+            onChange={(event) =>
+              onChange({ ...rule, responseContentTypes: splitList(event.target.value) })
+            }
+          />
+        </Field>
+      </div>
+      <div className="mt-4 grid gap-4 lg:grid-cols-2">
+        <Field label={copy.neutralization} htmlFor={`${rule.id}-neutralization`}>
+          <select
+            id={`${rule.id}-neutralization`}
+            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            value={rule.neutralization.shape}
+            disabled={!canEdit}
+            onChange={(event) =>
+              onChange({
+                ...rule,
+                neutralization: neutralizationForShape(
+                  event.target.value as RuntimeRequestPolicyRule["neutralization"]["shape"],
+                ),
+              })
+            }
+          >
+            <option value="empty_json">empty_json</option>
+            <option value="empty_text">empty_text</option>
+            <option value="no_content">no_content</option>
+          </select>
+        </Field>
+        <Field label="Redirect scope" htmlFor={`${rule.id}-redirect`}>
+          <select
+            id={`${rule.id}-redirect`}
+            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            value={rule.redirectScope}
+            disabled={!canEdit}
+            onChange={(event) =>
+              onChange({
+                ...rule,
+                redirectScope: event.target.value as RuntimeRequestPolicyRule["redirectScope"],
+              })
+            }
+          >
+            <option value="same_origin">same_origin</option>
+            <option value="same_registrable_domain">same_registrable_domain</option>
+          </select>
+        </Field>
+      </div>
+      <fieldset className="mt-4">
+        <legend className="text-sm font-medium">{copy.confirmations}</legend>
+        <div className="mt-2 flex flex-wrap gap-3">
+          {CONFIRMATIONS.map((confirmation) => (
+            <label key={confirmation} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={rule.confirmations.includes(confirmation)}
+                disabled={!canEdit}
+                onChange={(event) => {
+                  const next = new Set(rule.confirmations);
+                  if (event.target.checked) next.add(confirmation);
+                  else next.delete(confirmation);
+                  onChange({ ...rule, confirmations: Array.from(next) });
+                }}
+              />
+              {confirmation}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+    </div>
+  );
+}
+
+function PreviewStatus({
+  copy,
+  preview,
+  previewError,
+  isCurrent,
+}: {
+  copy: RuntimeRequestsCopy;
+  preview: RuntimeRequestPolicyPreviewResponse | null;
+  previewError: string | null;
+  isCurrent: boolean;
+}) {
+  if (previewError) {
+    return <ValidationAlert title={copy.validationTitle} messages={[previewError]} />;
+  }
+  if (!preview || !isCurrent) {
+    return (
+      <Alert>
+        <Eye className="h-4 w-4" />
+        <AlertTitle>{copy.previewRequired}</AlertTitle>
+        <AlertDescription>{copy.previewRequired}</AlertDescription>
+      </Alert>
+    );
+  }
+  const validationMessages = [
+    ...preview.validationErrors.map((error) => `${error.code}: ${error.message}`),
+    ...preview.collisions.map(
+      (collision) => `${collision.code}: ${collision.leftRuleId} / ${collision.rightRuleId}`,
+    ),
+    ...preview.highRiskConfirmations.map((entry) => `${entry.code}: ${entry.ruleId}`),
+  ];
+  return (
+    <div className="space-y-3">
+      {validationMessages.length ? (
+        <ValidationAlert title={copy.validationTitle} messages={validationMessages} />
+      ) : (
+        <Alert>
+          <CheckCircle2 className="h-4 w-4" />
+          <AlertTitle>{copy.previewReady}</AlertTitle>
+          <AlertDescription>{copy.previewReady}</AlertDescription>
+        </Alert>
+      )}
+      {preview.warnings.length ? (
+        <ValidationAlert
+          title={copy.warningsTitle}
+          messages={preview.warnings.map((warning) => `${warning.code}: ${warning.message}`)}
+        />
+      ) : null}
+      {preview.matchedObservationGroups.length ? (
+        <Alert>
+          <ShieldAlert className="h-4 w-4" />
+          <AlertTitle>{copy.matchedGroupsTitle}</AlertTitle>
+          <AlertDescription>
+            {preview.matchedObservationGroups.map((group) => group.path).join(", ")}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+    </div>
+  );
+}
+
+function ValidationAlert({ title, messages }: { title: string; messages: string[] }) {
+  return (
+    <Alert variant="destructive">
+      <AlertTriangle className="h-4 w-4" />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>
+        <ul className="list-disc space-y-1 pl-4">
+          {messages.map((message) => (
+            <li key={message}>{message}</li>
+          ))}
+        </ul>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+function RiskBadge({ risk }: { risk: RuntimeRequestObservationGroup["risk"] }) {
+  return (
+    <Badge variant={risk === "high" ? "destructive" : risk === "medium" ? "outline" : "secondary"}>
+      {risk}
+    </Badge>
+  );
+}
+
+function normalizeRuntimePolicy(policy: RuntimeRequestPolicyConfig): RuntimeRequestPolicyConfig {
+  return {
+    schemaVersion: 1,
+    mode: "standard",
+    enabled: policy.enabled !== false,
+    rules: policy.rules.map((rule) => ({
+      ...createRule(),
+      ...rule,
+      methods: rule.methods.length ? rule.methods : ["GET", "HEAD"],
+      requestHeaders: { allow: rule.requestHeaders?.allow ?? [] },
+      responseHeaders: { allow: rule.responseHeaders?.allow ?? [] },
+      requestContentTypes: rule.requestContentTypes ?? [],
+      responseContentTypes: rule.responseContentTypes ?? [],
+      neutralization: rule.neutralization ?? neutralizationForShape("empty_json"),
+      confirmations: rule.confirmations ?? [],
+    })),
+  };
+}
+
+function createRule(overrides: Partial<RuntimeRequestPolicyRule> = {}): RuntimeRequestPolicyRule {
+  const id = overrides.id ?? `rule-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  return {
+    id,
+    name: overrides.name ?? "Runtime request rule",
+    enabled: overrides.enabled ?? true,
+    pattern: overrides.pattern ?? "/api/search",
+    methods: overrides.methods ?? ["GET", "HEAD"],
+    action: overrides.action ?? "observe",
+    credentials: overrides.credentials ?? "omit",
+    cache: overrides.cache ?? "no-store",
+    maxBodyBytes: overrides.maxBodyBytes ?? 0,
+    maxResponseBytes: overrides.maxResponseBytes ?? 1_048_576,
+    timeoutMs: overrides.timeoutMs ?? 5_000,
+    redirectScope: overrides.redirectScope ?? "same_origin",
+    requestHeaders: overrides.requestHeaders ?? { allow: [] },
+    responseHeaders: overrides.responseHeaders ?? { allow: [] },
+    requestContentTypes: overrides.requestContentTypes ?? [],
+    responseContentTypes: overrides.responseContentTypes ?? [],
+    neutralization: overrides.neutralization ?? neutralizationForShape("empty_json"),
+    confirmations: overrides.confirmations ?? [],
+  };
+}
+
+function addRuleFromObservation(
+  policy: RuntimeRequestPolicyConfig,
+  group: RuntimeRequestObservationGroup,
+): RuntimeRequestPolicyConfig {
+  const suggestedProxy =
+    group.suggestedAction === "proxy" && (group.method === "GET" || group.method === "HEAD");
+  const action: RuntimeRequestPolicyAction = suggestedProxy ? "proxy" : group.suggestedAction;
+  const confirmations: RuntimeRequestPolicyConfirmation[] =
+    group.risk === "high" ? ["high_risk_path"] : [];
+  return {
+    ...policy,
+    rules: [
+      ...policy.rules,
+      createRule({
+        name: `${formatClassification(group.likelyType)} ${group.path}`,
+        pattern: group.path,
+        action,
+        methods: [group.method as RuntimeRequestPolicyMethod],
+        confirmations,
+      }),
+    ],
+  };
+}
+
+function applyActionDefaults(
+  rule: RuntimeRequestPolicyRule,
+  action: RuntimeRequestPolicyAction,
+): RuntimeRequestPolicyRule {
+  if (action === "proxy") {
+    return {
+      ...rule,
+      action,
+      methods: ["GET", "HEAD"],
+      credentials: "omit",
+      cache: "no-store",
+      maxBodyBytes: 0,
+    };
+  }
+  if (action === "neutralize") {
+    return {
+      ...rule,
+      action,
+      methods: ["GET", "HEAD", "POST", "OPTIONS"],
+      neutralization: neutralizationForShape("empty_json"),
+    };
+  }
+  return { ...rule, action };
+}
+
+function neutralizationForShape(
+  shape: RuntimeRequestPolicyRule["neutralization"]["shape"],
+): RuntimeRequestPolicyRule["neutralization"] {
+  if (shape === "no_content") {
+    return { shape, status: 204, contentType: null, body: null };
+  }
+  if (shape === "empty_text") {
+    return { shape, status: 200, contentType: "text/plain; charset=utf-8", body: "" };
+  }
+  return { shape, status: 200, contentType: "application/json", body: "{}" };
+}
+
+function splitList(value: string): string[] {
+  return value
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function runtimePolicyFingerprint(policy: RuntimeRequestPolicyConfig): string {
+  return JSON.stringify(policy);
+}
+
+function formatClassification(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+function formatDate(value: string | undefined): string {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function extractPreviewMessage(value: unknown): string {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    if (typeof record.error === "string") {
+      return record.error;
+    }
+  }
+  return "Unable to preview runtime request policy.";
+}
+
+function readSavedRuntimePolicy(meta: Record<string, unknown> | undefined) {
+  const value = meta?.runtimeRequestPolicy;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return normalizeRuntimePolicy(value as RuntimeRequestPolicyConfig);
+}
+
+function readMetaString(meta: Record<string, unknown> | undefined, key: string): string | null {
+  const value = meta?.[key];
+  return typeof value === "string" ? value : null;
+}
+
+function readSavedPropagation(meta: Record<string, unknown> | undefined) {
+  const value = meta?.runtimeRequestPolicyPropagation;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as RuntimeRequestPolicyPropagation;
+}

--- a/app/dashboard/sites/[id]/runtime-requests/runtime-requests-manager.tsx
+++ b/app/dashboard/sites/[id]/runtime-requests/runtime-requests-manager.tsx
@@ -84,7 +84,12 @@ export type RuntimeRequestsCopy = {
   rulesTitle: string;
   rulesDescription: string;
   noRules: string;
-  addRule: string;
+  presetsTitle: string;
+  presetNeutralizeAnalytics: string;
+  presetSearchProxy: string;
+  presetFeatureConfigProxy: string;
+  presetRouteDataProxy: string;
+  presetFormSubmitProxy: string;
   validateDraft: string;
   previewReady: string;
   previewBlocked: string;
@@ -104,10 +109,37 @@ export type RuntimeRequestsCopy = {
   neutralization: string;
   confirmations: string;
   removeRule: string;
+  draftStatus: string;
+  savedStatus: string;
+  standardValue: string;
+  standardFallbackVersion: string;
+  maxBodyBytes: string;
+  maxResponseBytes: string;
+  timeoutMs: string;
+  requestHeaders: string;
+  responseHeaders: string;
+  requestContentTypes: string;
+  responseContentTypes: string;
+  redirectScope: string;
+  defaultRuleName: string;
+  previewErrorFallback: string;
   validationTitle: string;
   warningsTitle: string;
   matchedGroupsTitle: string;
   redactionNote: string;
+};
+
+type RuntimeRequestPreset = {
+  id: string;
+  label: keyof Pick<
+    RuntimeRequestsCopy,
+    | "presetNeutralizeAnalytics"
+    | "presetSearchProxy"
+    | "presetFeatureConfigProxy"
+    | "presetRouteDataProxy"
+    | "presetFormSubmitProxy"
+  >;
+  rule: Partial<RuntimeRequestPolicyRule>;
 };
 
 type RuntimeRequestsManagerProps = {
@@ -223,7 +255,7 @@ export function RuntimeRequestsManager({
         );
         const body = (await response.json()) as unknown;
         if (!response.ok) {
-          setPreviewError(extractPreviewMessage(body));
+          setPreviewError(extractPreviewMessage(body, copy));
           return;
         }
         setPreview(body as RuntimeRequestPolicyPreviewResponse);
@@ -315,7 +347,7 @@ export function RuntimeRequestsManager({
           </Badge>
         </CardHeader>
         <CardContent className="grid gap-3 md:grid-cols-5">
-          <Metric label={copy.standardMode} value="Standard" />
+          <Metric label={copy.standardMode} value={copy.standardValue} />
           <Metric label={copy.activeRules} value={String(activeRuleCount)} />
           <Metric label={copy.unreviewedGroups} value={String(unreviewedCount)} />
           <Metric label={copy.highRiskGroups} value={String(highRiskCount)} />
@@ -323,7 +355,7 @@ export function RuntimeRequestsManager({
           <div className="md:col-span-5">
             <p className="text-xs text-muted-foreground">
               {copy.policyVersion}:{" "}
-              {servedVersion ?? servedPropagation?.servedVersion ?? "standard-v1"}
+              {servedVersion ?? servedPropagation?.servedVersion ?? copy.standardFallbackVersion}
             </p>
           </div>
         </CardContent>
@@ -364,22 +396,34 @@ export function RuntimeRequestsManager({
             <CardDescription>{copy.rulesDescription}</CardDescription>
           </div>
           <Badge variant={hasUnsavedChanges ? "outline" : "secondary"}>
-            {hasUnsavedChanges ? "Draft" : "Saved"}
+            {hasUnsavedChanges ? copy.draftStatus : copy.savedStatus}
           </Badge>
         </CardHeader>
         <CardContent className="space-y-5">
+          <div className="space-y-2">
+            <p className="text-sm font-medium">{copy.presetsTitle}</p>
+            <div className="flex flex-wrap gap-2">
+              {buildRuntimeRequestPresets(copy).map((preset) => (
+                <Button
+                  key={preset.id}
+                  type="button"
+                  variant="outline"
+                  disabled={!canEdit || isSaving}
+                  onClick={() =>
+                    updateDraft((policy) => ({
+                      ...policy,
+                      rules: [...policy.rules, createRule(preset.rule, copy)],
+                    }))
+                  }
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  {copy[preset.label]}
+                </Button>
+              ))}
+            </div>
+          </div>
+
           <div className="flex flex-wrap gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              disabled={!canEdit || isSaving}
-              onClick={() =>
-                updateDraft((policy) => ({ ...policy, rules: [...policy.rules, createRule()] }))
-              }
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              {copy.addRule}
-            </Button>
             <Button
               type="button"
               variant="outline"
@@ -556,6 +600,15 @@ function ObservationsTable({
                     size="sm"
                     variant="outline"
                     disabled={!canEdit}
+                    onClick={() => onLifecycle(group, "dismissed")}
+                  >
+                    {copy.dismissed}
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={!canEdit}
                     onClick={() => onLifecycle(group, "ignored")}
                   >
                     {copy.ignored}
@@ -678,7 +731,7 @@ function RuleEditor({
         </div>
       </fieldset>
       <div className="mt-4 grid gap-4 lg:grid-cols-4">
-        <Field label="Max body bytes" htmlFor={`${rule.id}-body`}>
+        <Field label={copy.maxBodyBytes} htmlFor={`${rule.id}-body`}>
           <Input
             id={`${rule.id}-body`}
             type="number"
@@ -688,7 +741,7 @@ function RuleEditor({
             onChange={(event) => onChange({ ...rule, maxBodyBytes: Number(event.target.value) })}
           />
         </Field>
-        <Field label="Max response bytes" htmlFor={`${rule.id}-response`}>
+        <Field label={copy.maxResponseBytes} htmlFor={`${rule.id}-response`}>
           <Input
             id={`${rule.id}-response`}
             type="number"
@@ -700,7 +753,7 @@ function RuleEditor({
             }
           />
         </Field>
-        <Field label="Timeout ms" htmlFor={`${rule.id}-timeout`}>
+        <Field label={copy.timeoutMs} htmlFor={`${rule.id}-timeout`}>
           <Input
             id={`${rule.id}-timeout`}
             type="number"
@@ -726,7 +779,7 @@ function RuleEditor({
         </Field>
       </div>
       <div className="mt-4 grid gap-4 lg:grid-cols-2">
-        <Field label={`${copy.headers} request`} htmlFor={`${rule.id}-request-headers`}>
+        <Field label={copy.requestHeaders} htmlFor={`${rule.id}-request-headers`}>
           <Input
             id={`${rule.id}-request-headers`}
             value={rule.requestHeaders.allow.join(", ")}
@@ -736,7 +789,7 @@ function RuleEditor({
             }
           />
         </Field>
-        <Field label={`${copy.headers} response`} htmlFor={`${rule.id}-response-headers`}>
+        <Field label={copy.responseHeaders} htmlFor={`${rule.id}-response-headers`}>
           <Input
             id={`${rule.id}-response-headers`}
             value={rule.responseHeaders.allow.join(", ")}
@@ -746,7 +799,7 @@ function RuleEditor({
             }
           />
         </Field>
-        <Field label="Request content types" htmlFor={`${rule.id}-request-content-types`}>
+        <Field label={copy.requestContentTypes} htmlFor={`${rule.id}-request-content-types`}>
           <Input
             id={`${rule.id}-request-content-types`}
             value={rule.requestContentTypes.join(", ")}
@@ -756,7 +809,7 @@ function RuleEditor({
             }
           />
         </Field>
-        <Field label="Response content types" htmlFor={`${rule.id}-response-content-types`}>
+        <Field label={copy.responseContentTypes} htmlFor={`${rule.id}-response-content-types`}>
           <Input
             id={`${rule.id}-response-content-types`}
             value={rule.responseContentTypes.join(", ")}
@@ -788,7 +841,7 @@ function RuleEditor({
             <option value="no_content">no_content</option>
           </select>
         </Field>
-        <Field label="Redirect scope" htmlFor={`${rule.id}-redirect`}>
+        <Field label={copy.redirectScope} htmlFor={`${rule.id}-redirect`}>
           <select
             id={`${rule.id}-redirect`}
             className="h-10 rounded-md border border-input bg-background px-3 text-sm"
@@ -915,6 +968,86 @@ function RiskBadge({ risk }: { risk: RuntimeRequestObservationGroup["risk"] }) {
   );
 }
 
+function buildRuntimeRequestPresets(copy: RuntimeRequestsCopy): RuntimeRequestPreset[] {
+  return [
+    {
+      id: "neutralize-analytics",
+      label: "presetNeutralizeAnalytics",
+      rule: {
+        name: copy.presetNeutralizeAnalytics,
+        pattern: "/analytics/*",
+        methods: ["GET", "HEAD", "POST", "OPTIONS"],
+        action: "neutralize",
+        maxBodyBytes: 0,
+        maxResponseBytes: 0,
+        neutralization: neutralizationForShape("empty_json"),
+      },
+    },
+    {
+      id: "search-proxy",
+      label: "presetSearchProxy",
+      rule: {
+        name: copy.presetSearchProxy,
+        pattern: "/api/search",
+        methods: ["GET", "HEAD"],
+        action: "proxy",
+        credentials: "omit",
+        cache: "no-store",
+        maxBodyBytes: 0,
+        maxResponseBytes: 1_048_576,
+        responseContentTypes: ["application/json"],
+      },
+    },
+    {
+      id: "feature-config-proxy",
+      label: "presetFeatureConfigProxy",
+      rule: {
+        name: copy.presetFeatureConfigProxy,
+        pattern: "/api/config",
+        methods: ["GET", "HEAD"],
+        action: "proxy",
+        credentials: "omit",
+        cache: "no-store",
+        maxBodyBytes: 0,
+        maxResponseBytes: 262_144,
+        responseContentTypes: ["application/json"],
+      },
+    },
+    {
+      id: "route-data-proxy",
+      label: "presetRouteDataProxy",
+      rule: {
+        name: copy.presetRouteDataProxy,
+        pattern: "/_next/data/*",
+        methods: ["GET", "HEAD"],
+        action: "proxy",
+        credentials: "omit",
+        cache: "no-store",
+        maxBodyBytes: 0,
+        maxResponseBytes: 1_048_576,
+        responseContentTypes: ["application/json"],
+      },
+    },
+    {
+      id: "form-submit-proxy",
+      label: "presetFormSubmitProxy",
+      rule: {
+        name: copy.presetFormSubmitProxy,
+        pattern: "/api/forms/*",
+        methods: ["POST"],
+        action: "proxy",
+        credentials: "omit",
+        cache: "no-store",
+        maxBodyBytes: 65_536,
+        maxResponseBytes: 262_144,
+        requestContentTypes: ["application/json", "application/x-www-form-urlencoded"],
+        responseContentTypes: ["application/json"],
+        confirmations: ["non_get_proxy", "high_risk_path"],
+      },
+    },
+  ];
+}
+
 function normalizeRuntimePolicy(policy: RuntimeRequestPolicyConfig): RuntimeRequestPolicyConfig {
   return {
     schemaVersion: 1,
@@ -934,11 +1067,14 @@ function normalizeRuntimePolicy(policy: RuntimeRequestPolicyConfig): RuntimeRequ
   };
 }
 
-function createRule(overrides: Partial<RuntimeRequestPolicyRule> = {}): RuntimeRequestPolicyRule {
+function createRule(
+  overrides: Partial<RuntimeRequestPolicyRule> = {},
+  copy?: RuntimeRequestsCopy,
+): RuntimeRequestPolicyRule {
   const id = overrides.id ?? `rule-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
   return {
     id,
-    name: overrides.name ?? "Runtime request rule",
+    name: overrides.name ?? copy?.defaultRuleName ?? "Runtime request rule",
     enabled: overrides.enabled ?? true,
     pattern: overrides.pattern ?? "/api/search",
     methods: overrides.methods ?? ["GET", "HEAD"],
@@ -1045,14 +1181,14 @@ function formatDate(value: string | undefined): string {
   return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
-function extractPreviewMessage(value: unknown): string {
+function extractPreviewMessage(value: unknown, copy: RuntimeRequestsCopy): string {
   if (value && typeof value === "object" && !Array.isArray(value)) {
     const record = value as Record<string, unknown>;
     if (typeof record.error === "string") {
       return record.error;
     }
   }
-  return "Unable to preview runtime request policy.";
+  return copy.previewErrorFallback;
 }
 
 function readSavedRuntimePolicy(meta: Record<string, unknown> | undefined) {

--- a/app/dashboard/sites/[id]/runtime-requests/runtime-requests-manager.tsx
+++ b/app/dashboard/sites/[id]/runtime-requests/runtime-requests-manager.tsx
@@ -19,7 +19,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import type {
   RuntimeRequestLifecycle,

--- a/content/docs/_generated/backend-feature-catalog.snapshot.json
+++ b/content/docs/_generated/backend-feature-catalog.snapshot.json
@@ -255,6 +255,25 @@
       "endpoint": {
         "auth": "bearer",
         "method": "POST",
+        "operationId": "admin.routeCaches.reconcile",
+        "path": "/admin/route-caches/reconcile"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "admin",
+      "id": "api.admin.routeCaches.reconcile",
+      "name": "Reconcile customer and showcase route caches",
+      "routeIds": [
+        "admin.routeCaches.reconcile"
+      ],
+      "stability": "Internal",
+      "summary": "Internal admin operation that rebuilds customer and showcase route-cache entries for active sites from the current persisted site config. Use after route-cache contract changes or managed showcase route-cache drift; dryRun reports served versus expected runtime request policy versions without mutating KV/R2.",
+      "userFacing": false
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
         "operationId": "agency.customers.create",
         "path": "/agency/customers"
       },

--- a/content/docs/_generated/backend-feature-catalog.snapshot.json
+++ b/content/docs/_generated/backend-feature-catalog.snapshot.json
@@ -1294,6 +1294,84 @@
       "endpoint": {
         "auth": "bearer",
         "method": "POST",
+        "operationId": "sites.runtimeRequestPolicy.preview",
+        "path": "/sites/:siteId/runtime-request-policy/preview"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.runtimeRequestPolicy",
+      "id": "api.sites.runtimeRequestPolicy.preview",
+      "name": "Preview runtime request policy",
+      "playbooks": [
+        {
+          "anchor": "playbook-site-portfolio-management",
+          "id": "playbook-site-portfolio-management",
+          "title": "Playbook: Site Portfolio Management"
+        }
+      ],
+      "routeIds": [
+        "sites.runtimeRequestPolicy.preview"
+      ],
+      "stability": "GA",
+      "summary": "Validates and dry-runs a draft runtimeRequestPolicy with the canonical runtime evaluator. This endpoint is read-only and returns stable validation codes, warnings, collisions, high-risk confirmations, sample evaluations, and matched observation groups.",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "PATCH",
+        "operationId": "sites.runtimeRequests.observations.lifecycle",
+        "path": "/sites/:siteId/runtime-requests/observations/:groupHash"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.runtimeRequests",
+      "id": "api.sites.runtimeRequests.observations.lifecycle",
+      "name": "Update runtime request observation lifecycle",
+      "playbooks": [
+        {
+          "anchor": "playbook-site-portfolio-management",
+          "id": "playbook-site-portfolio-management",
+          "title": "Playbook: Site Portfolio Management"
+        }
+      ],
+      "routeIds": [
+        "sites.runtimeRequests.observations.lifecycle"
+      ],
+      "stability": "GA",
+      "summary": "Marks a grouped runtime request observation as reviewed, dismissed, ignored, or open for dashboard triage.",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "GET",
+        "operationId": "sites.runtimeRequests.observations.list",
+        "path": "/sites/:siteId/runtime-requests/observations"
+      },
+      "family": "api",
+      "flagKeys": [],
+      "group": "sites.runtimeRequests",
+      "id": "api.sites.runtimeRequests.observations.list",
+      "name": "List grouped runtime request observations",
+      "playbooks": [
+        {
+          "anchor": "playbook-site-portfolio-management",
+          "id": "playbook-site-portfolio-management",
+          "title": "Playbook: Site Portfolio Management"
+        }
+      ],
+      "routeIds": [
+        "sites.runtimeRequests.observations.list"
+      ],
+      "stability": "GA",
+      "summary": "Returns grouped, redacted runtime request observations for a site. Raw queries, bodies, cookies, auth headers, CSRF tokens, and sensitive URLs are never returned.",
+      "userFacing": true
+    },
+    {
+      "endpoint": {
+        "auth": "bearer",
+        "method": "POST",
         "operationId": "sites.showcase.create",
         "path": "/sites/:siteId/showcase"
       },

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -1998,6 +1998,16 @@
           "proxyCspOverrideMode": {
             "$ref": "#/components/schemas/ProxyCspOverrideMode"
           },
+          "runtimeRequestPolicy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RuntimeRequestPolicyConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "servingMode": {
             "$ref": "#/components/schemas/ServingMode"
           },
@@ -4758,6 +4768,20 @@
             "$ref": "#/components/schemas/ProxyCspOverrideMode",
             "description": "Default: off"
           },
+          "runtimeRequestPolicy": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyConfig"
+          },
+          "runtimeRequestPolicyFingerprint": {
+            "description": "Derived fingerprint of normalized runtime request policy for optimistic saves.",
+            "type": "string"
+          },
+          "runtimeRequestPolicyPropagation": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyPropagation"
+          },
+          "runtimeRequestPolicyVersion": {
+            "description": "Route-config-derived runtime policy version served by customer route caches.",
+            "type": "string"
+          },
           "sourceLang": {
             "type": "string"
           },
@@ -4836,6 +4860,895 @@
           "origin"
         ],
         "type": "object"
+      },
+      "RuntimeRequestAcceptClass": {
+        "enum": [
+          "html",
+          "json",
+          "rsc",
+          "asset",
+          "event-stream",
+          "other",
+          "missing"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestBodySizeBucket": {
+        "enum": [
+          "none",
+          "unknown",
+          "1-1kb",
+          "1kb-10kb",
+          "10kb-100kb",
+          "100kb-1mb",
+          "over-1mb"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestClassification": {
+        "enum": [
+          "malformed",
+          "static_asset",
+          "showcase_telemetry",
+          "html_navigation",
+          "dynamic_api",
+          "route_data",
+          "api_like_json",
+          "high_risk_dynamic",
+          "preflight",
+          "default_dynamic"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestDiagnosticCode": {
+        "enum": [
+          "runtime_request_observed",
+          "runtime_request_denied",
+          "runtime_request_neutralized",
+          "runtime_request_proxy_allowed",
+          "runtime_request_policy_disabled"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestHeaderPolicy": {
+        "additionalProperties": false,
+        "properties": {
+          "allow": {
+            "description": "Header names explicitly allowed by this rule. Defaults to an empty allowlist.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "allow"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestIntent": {
+        "enum": [
+          "navigation",
+          "fetch",
+          "route-data",
+          "asset",
+          "preflight",
+          "beacon",
+          "form",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestLifecycle": {
+        "enum": [
+          "open",
+          "reviewed",
+          "dismissed",
+          "ignored"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestNeutralizationResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "body": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "contentType": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "shape": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyNeutralizationShape"
+          },
+          "status": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "shape",
+          "status",
+          "contentType",
+          "body"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestObservationGroup": {
+        "additionalProperties": false,
+        "properties": {
+          "acceptClass": {
+            "$ref": "#/components/schemas/RuntimeRequestAcceptClass"
+          },
+          "bodyPresent": {
+            "type": "boolean"
+          },
+          "bodySizeBucket": {
+            "$ref": "#/components/schemas/RuntimeRequestBodySizeBucket"
+          },
+          "count": {
+            "type": "number"
+          },
+          "currentAction": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyAction"
+          },
+          "dismissedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "firstSeenAt": {
+            "type": "string"
+          },
+          "groupingPathHash": {
+            "type": "string"
+          },
+          "ignoredAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "intent": {
+            "$ref": "#/components/schemas/RuntimeRequestIntent"
+          },
+          "lastSeenAt": {
+            "type": "string"
+          },
+          "lifecycle": {
+            "$ref": "#/components/schemas/RuntimeRequestLifecycle"
+          },
+          "likelyType": {
+            "$ref": "#/components/schemas/RuntimeRequestClassification"
+          },
+          "method": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "policyRuleId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reviewedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "risk": {
+            "$ref": "#/components/schemas/RuntimeRequestRisk"
+          },
+          "riskReasons": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "routePolicyStale": {
+            "type": "boolean"
+          },
+          "routePolicyVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "seenFromPage": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "shapeSignature": {
+            "type": "string"
+          },
+          "siteId": {
+            "type": "string"
+          },
+          "suggestedAction": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyAction"
+          }
+        },
+        "required": [
+          "siteId",
+          "groupingPathHash",
+          "shapeSignature",
+          "path",
+          "method",
+          "likelyType",
+          "intent",
+          "acceptClass",
+          "risk",
+          "riskReasons",
+          "firstSeenAt",
+          "lastSeenAt",
+          "count",
+          "seenFromPage",
+          "currentAction",
+          "suggestedAction",
+          "policyRuleId",
+          "routePolicyVersion",
+          "routePolicyStale",
+          "lifecycle",
+          "reviewedAt",
+          "dismissedAt",
+          "ignoredAt",
+          "bodyPresent",
+          "bodySizeBucket"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestObservationGroupsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "groups": {
+            "items": {
+              "$ref": "#/components/schemas/RuntimeRequestObservationGroup"
+            },
+            "type": "array"
+          },
+          "nextCursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "groups",
+          "nextCursor"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestObservationLifecycleRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "lifecycle": {
+            "$ref": "#/components/schemas/RuntimeRequestLifecycle"
+          },
+          "method": {
+            "type": "string"
+          },
+          "shapeSignature": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "lifecycle",
+          "method",
+          "shapeSignature"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestObservationLifecycleResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "state": {
+            "additionalProperties": false,
+            "properties": {
+              "dismissedAt": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "groupingPathHash": {
+                "type": "string"
+              },
+              "ignoredAt": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "method": {
+                "type": "string"
+              },
+              "reviewedAt": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "shapeSignature": {
+                "type": "string"
+              },
+              "siteId": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "siteId",
+              "groupingPathHash",
+              "method",
+              "shapeSignature",
+              "reviewedAt",
+              "dismissedAt",
+              "ignoredAt",
+              "updatedAt"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "state"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestPolicyAction": {
+        "enum": [
+          "observe",
+          "deny",
+          "neutralize",
+          "proxy"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestPolicyCache": {
+        "enum": [
+          "no-store",
+          "edge"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestPolicyConfig": {
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyMode"
+          },
+          "rules": {
+            "items": {
+              "$ref": "#/components/schemas/RuntimeRequestPolicyRule"
+            },
+            "type": "array"
+          },
+          "schemaVersion": {
+            "const": 1,
+            "type": "number"
+          }
+        },
+        "required": [
+          "schemaVersion",
+          "mode",
+          "enabled",
+          "rules"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestPolicyConfirmation": {
+        "enum": [
+          "non_get_proxy",
+          "credential_forwarding",
+          "high_risk_path"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestPolicyCredentials": {
+        "enum": [
+          "omit",
+          "same_origin",
+          "include"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestPolicyEvaluation": {
+        "additionalProperties": false,
+        "properties": {
+          "acceptClass": {
+            "$ref": "#/components/schemas/RuntimeRequestAcceptClass"
+          },
+          "action": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyAction"
+          },
+          "bodyPresent": {
+            "type": "boolean"
+          },
+          "bodySizeBucket": {
+            "$ref": "#/components/schemas/RuntimeRequestBodySizeBucket"
+          },
+          "canonicalizationIssue": {
+            "enum": [
+              "malformed_url",
+              "encoded_slash",
+              "dot_segments",
+              "invalid_encoding",
+              null
+            ],
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "classification": {
+            "$ref": "#/components/schemas/RuntimeRequestClassification"
+          },
+          "diagnosticCode": {
+            "$ref": "#/components/schemas/RuntimeRequestDiagnosticCode"
+          },
+          "groupingPath": {
+            "type": "string"
+          },
+          "groupingPathHash": {
+            "type": "string"
+          },
+          "hasQuery": {
+            "type": "boolean"
+          },
+          "host": {
+            "type": "string"
+          },
+          "intent": {
+            "$ref": "#/components/schemas/RuntimeRequestIntent"
+          },
+          "method": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RuntimeRequestPolicyMethod"
+              },
+              {
+                "const": "OTHER",
+                "type": "string"
+              }
+            ]
+          },
+          "normalizedPath": {
+            "type": "string"
+          },
+          "policyVersion": {
+            "type": "string"
+          },
+          "risk": {
+            "$ref": "#/components/schemas/RuntimeRequestRisk"
+          },
+          "riskReasons": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "ruleId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "shouldFetchSourceOrigin": {
+            "type": "boolean"
+          },
+          "shouldStoreObservation": {
+            "type": "boolean"
+          },
+          "source": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicySource"
+          },
+          "status": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "policyVersion",
+          "method",
+          "host",
+          "normalizedPath",
+          "groupingPath",
+          "groupingPathHash",
+          "hasQuery",
+          "bodySizeBucket",
+          "bodyPresent",
+          "acceptClass",
+          "intent",
+          "classification",
+          "canonicalizationIssue",
+          "risk",
+          "riskReasons",
+          "action",
+          "source",
+          "ruleId",
+          "shouldFetchSourceOrigin",
+          "shouldStoreObservation",
+          "status",
+          "diagnosticCode"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestPolicyMethod": {
+        "enum": [
+          "GET",
+          "HEAD",
+          "POST",
+          "PUT",
+          "PATCH",
+          "DELETE",
+          "OPTIONS"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestPolicyMode": {
+        "const": "standard",
+        "type": "string"
+      },
+      "RuntimeRequestPolicyNeutralizationShape": {
+        "enum": [
+          "empty_json",
+          "empty_text",
+          "no_content"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestPolicyPreviewRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "runtimeRequestPolicy": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyConfig"
+          },
+          "samples": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/RuntimeRequestPolicyPreviewSample"
+                }
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "runtimeRequestPolicy"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestPolicyPreviewResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "collisions": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "leftRuleId": {
+                  "type": "string"
+                },
+                "rightRuleId": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "leftRuleId",
+                "rightRuleId",
+                "code"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "highRiskConfirmations": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "ruleId": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "ruleId",
+                "code"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "matchedObservationGroups": {
+            "items": {
+              "$ref": "#/components/schemas/RuntimeRequestObservationGroup"
+            },
+            "type": "array"
+          },
+          "propagation": {
+            "additionalProperties": false,
+            "properties": {
+              "currentRouteConfigUpdatedAt": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "currentRuntimeRequestPolicyVersion": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "currentRouteConfigUpdatedAt",
+              "currentRuntimeRequestPolicyVersion"
+            ],
+            "type": "object"
+          },
+          "runtimeRequestPolicy": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyConfig"
+          },
+          "sampleResults": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "index": {
+                  "type": "number"
+                },
+                "result": {
+                  "$ref": "#/components/schemas/RuntimeRequestPolicyEvaluation"
+                }
+              },
+              "required": [
+                "index",
+                "result"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "validationErrors": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "ruleId": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "code",
+                "ruleId",
+                "message"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "warnings": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "ruleId": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "code",
+                "ruleId",
+                "message"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "runtimeRequestPolicy",
+          "validationErrors",
+          "warnings",
+          "collisions",
+          "highRiskConfirmations",
+          "sampleResults",
+          "matchedObservationGroups",
+          "propagation"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestPolicyPreviewSample": {
+        "additionalProperties": false,
+        "properties": {
+          "accept": {
+            "type": "string"
+          },
+          "method": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestPolicyPropagation": {
+        "additionalProperties": false,
+        "properties": {
+          "expectedVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "servedVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "stale": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "servedVersion",
+          "expectedVersion",
+          "stale"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestPolicyRedirectScope": {
+        "enum": [
+          "same_origin",
+          "same_registrable_domain"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestPolicyRule": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyAction"
+          },
+          "cache": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyCache"
+          },
+          "confirmations": {
+            "items": {
+              "$ref": "#/components/schemas/RuntimeRequestPolicyConfirmation"
+            },
+            "type": "array"
+          },
+          "credentials": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyCredentials"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "maxBodyBytes": {
+            "type": "number"
+          },
+          "maxResponseBytes": {
+            "type": "number"
+          },
+          "methods": {
+            "items": {
+              "$ref": "#/components/schemas/RuntimeRequestPolicyMethod"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "neutralization": {
+            "$ref": "#/components/schemas/RuntimeRequestNeutralizationResponse"
+          },
+          "pattern": {
+            "description": "Root-relative exact path or final-wildcard pattern, for example `/api/search` or `/flags/*`.",
+            "type": "string"
+          },
+          "redirectScope": {
+            "$ref": "#/components/schemas/RuntimeRequestPolicyRedirectScope"
+          },
+          "requestContentTypes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "requestHeaders": {
+            "$ref": "#/components/schemas/RuntimeRequestHeaderPolicy"
+          },
+          "responseContentTypes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "responseHeaders": {
+            "$ref": "#/components/schemas/RuntimeRequestHeaderPolicy"
+          },
+          "timeoutMs": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "enabled",
+          "pattern",
+          "methods",
+          "action",
+          "credentials",
+          "cache",
+          "maxBodyBytes",
+          "maxResponseBytes",
+          "timeoutMs",
+          "redirectScope",
+          "requestHeaders",
+          "responseHeaders",
+          "requestContentTypes",
+          "responseContentTypes",
+          "neutralization",
+          "confirmations"
+        ],
+        "type": "object"
+      },
+      "RuntimeRequestPolicySource": {
+        "enum": [
+          "explicit_rule",
+          "standard_default",
+          "policy_disabled"
+        ],
+        "type": "string"
+      },
+      "RuntimeRequestRisk": {
+        "enum": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "type": "string"
       },
       "ServingMode": {
         "enum": [
@@ -7201,6 +8114,10 @@
             "description": "Optional optimistic concurrency token for dashboard source-selection edits. When provided with sourceSelection, the update fails with 409 if the current route-config row changed.",
             "type": "string"
           },
+          "expectedRuntimeRequestPolicyFingerprint": {
+            "description": "Optional optimistic concurrency token for dashboard runtime-request-policy edits. When provided with runtimeRequestPolicy, the update fails with 409 if current policy differs.",
+            "type": "string"
+          },
           "expectedSourceSelectionFingerprint": {
             "description": "Optional optimistic concurrency token for dashboard source-selection edits. When provided with sourceSelection, the update fails with 409 if current flat sourceSelection.rules differ.",
             "type": "string"
@@ -7263,6 +8180,16 @@
           },
           "proxyCspOverrideMode": {
             "$ref": "#/components/schemas/ProxyCspOverrideMode"
+          },
+          "runtimeRequestPolicy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RuntimeRequestPolicyConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "servingMode": {
             "$ref": "#/components/schemas/ServingMode"
@@ -12899,6 +13826,510 @@
         "tags": [
           "Sites",
           "Pipeline"
+        ]
+      }
+    },
+    "/sites/{siteId}/runtime-request-policy/preview": {
+      "post": {
+        "description": "Validates and dry-runs a draft runtimeRequestPolicy with the canonical runtime evaluator. This endpoint is read-only and returns stable validation codes, warnings, collisions, high-risk confirmations, sample evaluations, and matched observation groups.",
+        "operationId": "sites.runtimeRequestPolicy.preview",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "runtimeRequestPolicy": {
+                  "enabled": true,
+                  "mode": "standard",
+                  "rules": [
+                    {
+                      "action": "observe",
+                      "cache": "no-store",
+                      "confirmations": [
+                        "non_get_proxy"
+                      ],
+                      "credentials": "omit",
+                      "enabled": true,
+                      "id": "string",
+                      "maxBodyBytes": 1,
+                      "maxResponseBytes": 1,
+                      "methods": [
+                        "GET"
+                      ],
+                      "name": "string",
+                      "neutralization": {
+                        "body": "string",
+                        "contentType": "string",
+                        "status": 1
+                      },
+                      "pattern": "string",
+                      "redirectScope": "same_origin",
+                      "requestContentTypes": [
+                        "string"
+                      ],
+                      "requestHeaders": {
+                        "allow": [
+                          "string"
+                        ]
+                      },
+                      "responseContentTypes": [
+                        "string"
+                      ],
+                      "responseHeaders": {
+                        "allow": [
+                          "string"
+                        ]
+                      },
+                      "timeoutMs": 1
+                    }
+                  ],
+                  "schemaVersion": 1
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/RuntimeRequestPolicyPreviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "collisions": [
+                    {
+                      "code": "string",
+                      "leftRuleId": "string",
+                      "rightRuleId": "string"
+                    }
+                  ],
+                  "highRiskConfirmations": [
+                    {
+                      "code": "string",
+                      "ruleId": "string"
+                    }
+                  ],
+                  "matchedObservationGroups": [
+                    {
+                      "acceptClass": "html",
+                      "bodyPresent": true,
+                      "bodySizeBucket": "none",
+                      "count": 1,
+                      "currentAction": "observe",
+                      "dismissedAt": "string",
+                      "firstSeenAt": "string",
+                      "groupingPathHash": "string",
+                      "ignoredAt": "string",
+                      "intent": "navigation",
+                      "lastSeenAt": "string",
+                      "lifecycle": "open",
+                      "likelyType": "malformed",
+                      "method": "string",
+                      "path": "string",
+                      "policyRuleId": "string",
+                      "reviewedAt": "string",
+                      "risk": "low",
+                      "riskReasons": [
+                        "string"
+                      ],
+                      "routePolicyStale": true,
+                      "routePolicyVersion": "string",
+                      "seenFromPage": "string",
+                      "shapeSignature": "string",
+                      "siteId": "string",
+                      "suggestedAction": "observe"
+                    }
+                  ],
+                  "propagation": {
+                    "currentRouteConfigUpdatedAt": "string",
+                    "currentRuntimeRequestPolicyVersion": "string"
+                  },
+                  "runtimeRequestPolicy": {
+                    "enabled": true,
+                    "mode": "standard",
+                    "rules": [
+                      {
+                        "action": "observe",
+                        "cache": "no-store",
+                        "confirmations": [
+                          "non_get_proxy"
+                        ],
+                        "credentials": "omit",
+                        "enabled": true,
+                        "id": "string",
+                        "maxBodyBytes": 1,
+                        "maxResponseBytes": 1,
+                        "methods": [
+                          "GET"
+                        ],
+                        "name": "string",
+                        "neutralization": {
+                          "body": "string",
+                          "contentType": "string",
+                          "status": 1
+                        },
+                        "pattern": "string",
+                        "redirectScope": "same_origin",
+                        "requestContentTypes": [
+                          "string"
+                        ],
+                        "requestHeaders": {
+                          "allow": [
+                            "string"
+                          ]
+                        },
+                        "responseContentTypes": [
+                          "string"
+                        ],
+                        "responseHeaders": {
+                          "allow": [
+                            "string"
+                          ]
+                        },
+                        "timeoutMs": 1
+                      }
+                    ],
+                    "schemaVersion": 1
+                  },
+                  "sampleResults": [
+                    {
+                      "index": 1,
+                      "result": {
+                        "acceptClass": "html",
+                        "action": "observe",
+                        "bodyPresent": true,
+                        "bodySizeBucket": "none",
+                        "canonicalizationIssue": "malformed_url",
+                        "classification": "malformed",
+                        "diagnosticCode": "runtime_request_observed",
+                        "groupingPath": "string",
+                        "groupingPathHash": "string",
+                        "hasQuery": true,
+                        "host": "string",
+                        "intent": "navigation",
+                        "method": "GET",
+                        "normalizedPath": "string",
+                        "policyVersion": "string",
+                        "risk": "low",
+                        "riskReasons": [
+                          "string"
+                        ],
+                        "ruleId": "string",
+                        "shouldFetchSourceOrigin": true,
+                        "shouldStoreObservation": true,
+                        "source": "explicit_rule",
+                        "status": 1
+                      }
+                    }
+                  ],
+                  "validationErrors": [
+                    {
+                      "code": "string",
+                      "message": "string",
+                      "ruleId": "string"
+                    }
+                  ],
+                  "warnings": [
+                    {
+                      "code": "string",
+                      "message": "string",
+                      "ruleId": "string"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeRequestPolicyPreviewResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Preview runtime request policy",
+        "tags": [
+          "Sites",
+          "Runtime Requests"
+        ]
+      }
+    },
+    "/sites/{siteId}/runtime-requests/observations": {
+      "get": {
+        "description": "Returns grouped, redacted runtime request observations for a site. Raw queries, bodies, cookies, auth headers, CSRF tokens, and sensitive URLs are never returned.",
+        "operationId": "sites.runtimeRequests.observations.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "groups": [
+                    {
+                      "acceptClass": "html",
+                      "bodyPresent": true,
+                      "bodySizeBucket": "none",
+                      "count": 1,
+                      "currentAction": "observe",
+                      "dismissedAt": "string",
+                      "firstSeenAt": "string",
+                      "groupingPathHash": "string",
+                      "ignoredAt": "string",
+                      "intent": "navigation",
+                      "lastSeenAt": "string",
+                      "lifecycle": "open",
+                      "likelyType": "malformed",
+                      "method": "string",
+                      "path": "string",
+                      "policyRuleId": "string",
+                      "reviewedAt": "string",
+                      "risk": "low",
+                      "riskReasons": [
+                        "string"
+                      ],
+                      "routePolicyStale": true,
+                      "routePolicyVersion": "string",
+                      "seenFromPage": "string",
+                      "shapeSignature": "string",
+                      "siteId": "string",
+                      "suggestedAction": "observe"
+                    }
+                  ],
+                  "nextCursor": "string"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeRequestObservationGroupsResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List grouped runtime request observations",
+        "tags": [
+          "Sites",
+          "Runtime Requests"
+        ]
+      }
+    },
+    "/sites/{siteId}/runtime-requests/observations/{groupHash}": {
+      "patch": {
+        "description": "Marks a grouped runtime request observation as reviewed, dismissed, ignored, or open for dashboard triage.",
+        "operationId": "sites.runtimeRequests.observations.lifecycle",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "siteId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "groupHash",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "lifecycle": "open",
+                "method": "string",
+                "shapeSignature": "string"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/RuntimeRequestObservationLifecycleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "state": {
+                    "dismissedAt": "string",
+                    "groupingPathHash": "string",
+                    "ignoredAt": "string",
+                    "method": "string",
+                    "reviewedAt": "string",
+                    "shapeSignature": "string",
+                    "siteId": "string",
+                    "updatedAt": "string"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeRequestObservationLifecycleResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Update runtime request observation lifecycle",
+        "tags": [
+          "Sites",
+          "Runtime Requests"
         ]
       }
     },

--- a/content/docs/_generated/backend-openapi.snapshot.json
+++ b/content/docs/_generated/backend-openapi.snapshot.json
@@ -443,6 +443,9 @@
             },
             "type": "array"
           },
+          "routeCacheRefresh": {
+            "$ref": "#/components/schemas/ManagedDemoRouteCacheRefreshSummary"
+          },
           "siteId": {
             "type": "string"
           },
@@ -679,6 +682,152 @@
           "createdAt",
           "updatedAt",
           "feedback"
+        ],
+        "type": "object"
+      },
+      "AdminRouteCacheReconcilePolicyState": {
+        "additionalProperties": false,
+        "properties": {
+          "expectedVersion": {
+            "type": "string"
+          },
+          "servedVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "stale": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "servedVersion",
+          "expectedVersion",
+          "stale"
+        ],
+        "type": "object"
+      },
+      "AdminRouteCacheReconcileRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "customerRoutes": {
+            "type": "boolean"
+          },
+          "dryRun": {
+            "type": "boolean"
+          },
+          "showcaseRoutes": {
+            "type": "boolean"
+          },
+          "siteIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "AdminRouteCacheReconcileResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "customerRoutes": {
+            "type": "boolean"
+          },
+          "dryRun": {
+            "type": "boolean"
+          },
+          "requestedSiteIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/AdminRouteCacheReconcileSiteResult"
+            },
+            "type": "array"
+          },
+          "showcaseRoutes": {
+            "type": "boolean"
+          },
+          "totals": {
+            "additionalProperties": false,
+            "properties": {
+              "dryRun": {
+                "type": "number"
+              },
+              "failed": {
+                "type": "number"
+              },
+              "refreshed": {
+                "type": "number"
+              },
+              "sitesConsidered": {
+                "type": "number"
+              },
+              "skipped": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "sitesConsidered",
+              "refreshed",
+              "dryRun",
+              "skipped",
+              "failed"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "dryRun",
+          "customerRoutes",
+          "showcaseRoutes",
+          "requestedSiteIds",
+          "totals",
+          "results"
+        ],
+        "type": "object"
+      },
+      "AdminRouteCacheReconcileSiteResult": {
+        "additionalProperties": false,
+        "properties": {
+          "context": {
+            "enum": [
+              "customer",
+              "showcase"
+            ],
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "runtimeRequestPolicy": {
+            "$ref": "#/components/schemas/AdminRouteCacheReconcilePolicyState"
+          },
+          "siteId": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "refreshed",
+              "dry_run",
+              "skipped",
+              "failed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "siteId",
+          "context",
+          "status"
         ],
         "type": "object"
       },
@@ -3960,6 +4109,48 @@
           "activeDeploymentId",
           "activeDeploymentRowId",
           "activeDeploymentStatus"
+        ],
+        "type": "object"
+      },
+      "ManagedDemoRouteCacheRefreshSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "attempted": {
+            "type": "boolean"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "refreshed": {
+            "type": "boolean"
+          },
+          "runtimeRequestPolicy": {
+            "additionalProperties": false,
+            "properties": {
+              "expectedVersion": {
+                "type": "string"
+              },
+              "servedVersion": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "stale": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "servedVersion",
+              "expectedVersion",
+              "stale"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "attempted",
+          "refreshed"
         ],
         "type": "object"
       },
@@ -9670,6 +9861,134 @@
           }
         ],
         "summary": "Get preview detail with ordered reviews",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/admin/route-caches/reconcile": {
+      "post": {
+        "description": "Internal admin operation that rebuilds customer and showcase route-cache entries for active sites from the current persisted site config. Use after route-cache contract changes or managed showcase route-cache drift; dryRun reports served versus expected runtime request policy versions without mutating KV/R2.",
+        "operationId": "admin.routeCaches.reconcile",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "customerRoutes": true,
+                "dryRun": true,
+                "showcaseRoutes": true,
+                "siteIds": [
+                  "site_123"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/AdminRouteCacheReconcileRequest"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "customerRoutes": true,
+                  "dryRun": true,
+                  "requestedSiteIds": [
+                    "site_123"
+                  ],
+                  "results": [
+                    {
+                      "context": "customer",
+                      "runtimeRequestPolicy": {
+                        "expectedVersion": "site-config:2026-05-05T00:00:00.000Z",
+                        "servedVersion": "site-config:2026-05-05T00:00:00.000Z",
+                        "stale": false
+                      },
+                      "siteId": "site_123",
+                      "status": "dry_run"
+                    }
+                  ],
+                  "showcaseRoutes": true,
+                  "totals": {
+                    "dryRun": 2,
+                    "failed": 0,
+                    "refreshed": 0,
+                    "sitesConsidered": 1,
+                    "skipped": 0
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AdminRouteCacheReconcileResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "unauthorized"
+                  },
+                  "error": "Unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "internal_ops_disabled"
+                  },
+                  "error": "Internal admin access is disabled for this account"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal admin access is required."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "details": {
+                    "code": "rate_limited"
+                  },
+                  "error": "Rate limit exceeded"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Rate limit exceeded",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the request can be retried.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Reconcile customer and showcase route caches",
         "tags": [
           "Admin"
         ]

--- a/content/docs/_generated/backend-playbooks.snapshot.md
+++ b/content/docs/_generated/backend-playbooks.snapshot.md
@@ -33,11 +33,17 @@ Human workflow playbooks built on top of generated operation contracts. Payload 
    - `operationId`: `sites.sourceSelection.preview`
 7. Preview source-selection tree projections for dashboard editing:
    - `operationId`: `sites.sourceSelection.treePreview`
-8. Update site configuration:
+8. Review observed runtime requests before adding interactive-feature rules:
+   - `operationId`: `sites.runtimeRequests.observations.list`
+9. Update observation lifecycle after triage:
+   - `operationId`: `sites.runtimeRequests.observations.lifecycle`
+10. Preview runtime request policy drafts before saving:
+   - `operationId`: `sites.runtimeRequestPolicy.preview`
+11. Update site configuration:
    - `operationId`: `sites.update`
-9. List discovered pages for a site:
+12. List discovered pages for a site:
    - `operationId`: `sites.pages.list`
-10. Generate language switcher snippets for custom frontend integration:
+13. Generate language switcher snippets for custom frontend integration:
     - `operationId`: `sites.switcherSnippets.get`
 
 ## Playbook: Admin Managed Demos

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-05T09:59:46+09:00",
+  "generatedAt": "2026-05-05T10:42:14+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 80970,
@@ -32,7 +32,7 @@
       "sha256": "9e29de75fcd4681f0f1da887ba41758e7c533c014da0c6022bfd81c0ba7c1f31"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-05-05T09:59:46+09:00",
+  "sourceRepoCommitTimestamp": "2026-05-05T10:42:14+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "51a13d6cac0f3db1c2b4d00c668c0d41d1e6f836"
+  "sourceRepoSha": "360428085cef42a068d3fea8c72b4b6dce370ace"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,17 +1,17 @@
 {
-  "generatedAt": "2026-05-05T09:28:23+09:00",
+  "generatedAt": "2026-05-05T09:43:06+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
-      "bytes": 78056,
-      "sha256": "d8c3ea5bb796bf6e5ff00ff21a113f9baafb2784c73664f7d9ee6dacf6a32009"
+      "bytes": 80970,
+      "sha256": "7418dc845c19cfd244b3511fa8c2ca564c3b26c5954d6aba4746c4f830fe3bb4"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
       "bytes": 442754,
       "sha256": "52fe269e8bd559b5ab6f7d1f3e18d92d1c51fc9378a8e689c9bddf0a832cfd2f"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
-      "bytes": 7329,
-      "sha256": "8c39b24cd6cd1a25cb611e35d4bb171bd708929d2984e4acf838e9bfa9a48299"
+      "bytes": 7697,
+      "sha256": "50872c9be06ce180d2c726e66b23c991411e157a67293f60d8bd27ec88eee947"
     }
   },
   "requiredEnv": [
@@ -20,19 +20,19 @@
   "schemaVersion": 1,
   "sourceFiles": {
     "docs/reference/API_PLAYBOOKS.md": {
-      "bytes": 7329,
-      "sha256": "8c39b24cd6cd1a25cb611e35d4bb171bd708929d2984e4acf838e9bfa9a48299"
+      "bytes": 7697,
+      "sha256": "50872c9be06ce180d2c726e66b23c991411e157a67293f60d8bd27ec88eee947"
     },
     "docs/reference/feature-catalog.generated.json": {
-      "bytes": 72546,
-      "sha256": "baf9c26445c7d9ef5fa1a85001f7c6c3a606ed49a31719153c581cc2216b25ff"
+      "bytes": 75412,
+      "sha256": "aab2162045056c8020831f530a89be3b4074850065d1c19338153c929461cde0"
     },
     "docs/reference/openapi.json": {
       "bytes": 352034,
       "sha256": "9e29de75fcd4681f0f1da887ba41758e7c533c014da0c6022bfd81c0ba7c1f31"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-05-05T09:28:23+09:00",
+  "sourceRepoCommitTimestamp": "2026-05-05T09:43:06+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "2c4bc774afcf46bf1557f139ed35d3a3ed969202"
+  "sourceRepoSha": "a3f5f56dcb9b0d8dcbeede5d05cc2bd2d78b51ab"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-05T09:43:06+09:00",
+  "generatedAt": "2026-05-05T09:59:46+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 80970,
@@ -32,7 +32,7 @@
       "sha256": "9e29de75fcd4681f0f1da887ba41758e7c533c014da0c6022bfd81c0ba7c1f31"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-05-05T09:43:06+09:00",
+  "sourceRepoCommitTimestamp": "2026-05-05T09:59:46+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "a3f5f56dcb9b0d8dcbeede5d05cc2bd2d78b51ab"
+  "sourceRepoSha": "51a13d6cac0f3db1c2b4d00c668c0d41d1e6f836"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-05T08:50:15+09:00",
+  "generatedAt": "2026-05-05T09:28:23+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 78056,
@@ -32,7 +32,7 @@
       "sha256": "9e29de75fcd4681f0f1da887ba41758e7c533c014da0c6022bfd81c0ba7c1f31"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-05-05T08:50:15+09:00",
+  "sourceRepoCommitTimestamp": "2026-05-05T09:28:23+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "2d5214ff2098ff0d2796e130010afb2cde8f1dff"
+  "sourceRepoSha": "2c4bc774afcf46bf1557f139ed35d3a3ed969202"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-05-04T19:31:23+09:00",
+  "generatedAt": "2026-05-05T08:50:15+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
       "bytes": 78056,
       "sha256": "d8c3ea5bb796bf6e5ff00ff21a113f9baafb2784c73664f7d9ee6dacf6a32009"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 402023,
-      "sha256": "a6520f680f52c7916bd6ea05faf514f419377a5c20b8a2e4095796d0e297dce7"
+      "bytes": 442754,
+      "sha256": "52fe269e8bd559b5ab6f7d1f3e18d92d1c51fc9378a8e689c9bddf0a832cfd2f"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
       "bytes": 7329,
@@ -28,11 +28,11 @@
       "sha256": "baf9c26445c7d9ef5fa1a85001f7c6c3a606ed49a31719153c581cc2216b25ff"
     },
     "docs/reference/openapi.json": {
-      "bytes": 319597,
-      "sha256": "e346c6ed99f2083ebafef6e2c919a56a361449c04986ecc1af0484718f3d349f"
+      "bytes": 352034,
+      "sha256": "9e29de75fcd4681f0f1da887ba41758e7c533c014da0c6022bfd81c0ba7c1f31"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-05-04T19:31:23+09:00",
+  "sourceRepoCommitTimestamp": "2026-05-05T08:50:15+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "744178999eb1f177cf704d79d90505772485ebcf"
+  "sourceRepoSha": "2d5214ff2098ff0d2796e130010afb2cde8f1dff"
 }

--- a/content/docs/_generated/backend-sync-manifest.json
+++ b/content/docs/_generated/backend-sync-manifest.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-05-05T10:42:14+09:00",
+  "generatedAt": "2026-05-05T16:27:36+09:00",
   "generatedFiles": {
     "content/docs/_generated/backend-feature-catalog.snapshot.json": {
-      "bytes": 80970,
-      "sha256": "7418dc845c19cfd244b3511fa8c2ca564c3b26c5954d6aba4746c4f830fe3bb4"
+      "bytes": 81798,
+      "sha256": "8cbe4c420ea185ae01e76581440b42cf32575bbf5859f1211d897a5be0fd3b7e"
     },
     "content/docs/_generated/backend-openapi.snapshot.json": {
-      "bytes": 442754,
-      "sha256": "52fe269e8bd559b5ab6f7d1f3e18d92d1c51fc9378a8e689c9bddf0a832cfd2f"
+      "bytes": 451600,
+      "sha256": "afe0044e0b62150a6717f5cf20ad2802b0c14d5369d5cf255823e67f71aa645b"
     },
     "content/docs/_generated/backend-playbooks.snapshot.md": {
       "bytes": 7697,
@@ -24,15 +24,15 @@
       "sha256": "50872c9be06ce180d2c726e66b23c991411e157a67293f60d8bd27ec88eee947"
     },
     "docs/reference/feature-catalog.generated.json": {
-      "bytes": 75412,
-      "sha256": "aab2162045056c8020831f530a89be3b4074850065d1c19338153c929461cde0"
+      "bytes": 76224,
+      "sha256": "04b19ea6955cdf6b431118333a2ac4132f53ae44dd3dc8eb7fd57294747efce1"
     },
     "docs/reference/openapi.json": {
-      "bytes": 352034,
-      "sha256": "9e29de75fcd4681f0f1da887ba41758e7c533c014da0c6022bfd81c0ba7c1f31"
+      "bytes": 359082,
+      "sha256": "2af4be2530b9bbe9b5470bd73413d6b4c3762e1b3a33d6c5daa230427582c6dc"
     }
   },
-  "sourceRepoCommitTimestamp": "2026-05-05T10:42:14+09:00",
+  "sourceRepoCommitTimestamp": "2026-05-05T16:27:36+09:00",
   "sourceRepoPath": "/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo",
-  "sourceRepoSha": "360428085cef42a068d3fea8c72b4b6dce370ace"
+  "sourceRepoSha": "489c2a5a994b59feeaa7dce7641c87328bbb1a56"
 }

--- a/docs/backend/DASHBOARD_SPECS.md
+++ b/docs/backend/DASHBOARD_SPECS.md
@@ -79,6 +79,9 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
 - **RouteConfig**:
   - `updatedAt`: optional optimistic concurrency token for guarded route-config writes.
   - `sourceSelectionFingerprint`: optional optimistic concurrency token for guarded source-selection writes.
+  - `runtimeRequestPolicyFingerprint`: optional optimistic concurrency token for guarded runtime-request-policy writes.
+  - `runtimeRequestPolicyVersion`: served policy version propagated through route caches.
+  - `runtimeRequestPolicyPropagation`: `{ servedVersion, expectedVersion, stale }`.
   - `sourceLang`, `sourceOrigin`, `pattern` (string or `null`).
   - `locales`: `[{ lang, origin, routePrefix }]`.
   - `clientRuntimeEnabled`: boolean.
@@ -86,6 +89,7 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
   - `translatableAttributes`: `string[] | null`.
   - `spaRefresh`: object or `null`.
   - `sourceSelection`: optional flat policy object `{ rules }`; `rules` is capped at 200 and may contain backend actions such as `include`, `exclude`, and `canonical_source`.
+  - `runtimeRequestPolicy`: optional versioned Standard policy object. Missing configs are normalized by the backend to schema version `1` Standard behavior.
 - **CrawlStatus**: `{ enqueued: boolean, error?: string }`.
 - **Deployment**: `{ targetLang, status, deploymentId?, activatedAt?, routePrefix?, artifactManifest?, activeDeploymentId?, domain?, domainStatus?, serveEnabled, servingStatus, translationRun? }`.
 - **GlossaryEntry**: `{ source, target, targetLangs?, matchType?, caseSensitive?, scope? }`.
@@ -219,6 +223,7 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
   - **Warning:** changing `sourceUrl` is destructive. It wipes pages/translations/deployments, resets status to `inactive`, seeds pages from robots/sitemaps, and requires reactivation before crawling. UI should require explicit confirmation.
   - Activating a site (`status: "active"`) requires at least one verified domain and triggers a crawl.
   - Source-selection saves use the same endpoint with `sourceSelection` plus `expectedRouteConfigUpdatedAt` and/or `expectedSourceSelectionFingerprint`; guarded writes are source-selection-only and stale writes return `409`.
+  - Runtime request policy saves use the same endpoint with `runtimeRequestPolicy` plus `expectedRuntimeRequestPolicyFingerprint`; stale writes return `409` and route-cache propagation exposes the saved policy version/stale state.
 - Response `200`: updated `Site`.
 
 - Website mapping:
@@ -239,6 +244,33 @@ Purpose: single source of truth for the customer dashboard. Includes API contrac
   - `search` is a backend global source-path search across known site paths, not a frontend filter over the loaded preview rows. Search results include ancestor folder context.
   - `limit` is an optional integer `1..200`; `cursor` is the opaque backend cursor from the previous response.
 - Response: normalized `sourceSelection`, global `summary`, tree `nodes`, cursor `pagination`, `warnings`, `impact`, and `inventory` metadata (`knownPagesTotal`, result mode/scope, `maxPageSize`, `complete`) so the website does not claim a complete origin inventory when the backend returned a bounded projection.
+
+`GET /api/sites/:id/runtime-requests/observations`
+
+- Returns grouped, redacted same-origin runtime request observations for the site.
+- Query: `limit` (`1..100`), `cursor`, `lifecycle` (`open|reviewed|dismissed|ignored|all`), `risk` (`low|medium|high|all`), `method`, `search`, and `sort` (`last_seen_desc|last_seen_asc|count_desc`).
+- Response: `{ groups, nextCursor }`. Each group includes method, normalized path, likely type, intent, accept class, first/last seen, sampled count, seen-from-page context, current/suggested action, risk, lifecycle state, body presence/size bucket, and route-policy version/stale state. The API never returns cookies, auth headers, bodies, raw query strings, CSRF tokens, or sensitive full URLs.
+
+`PATCH /api/sites/:id/runtime-requests/observations/:groupHash`
+
+- Updates lifecycle for a grouped runtime request observation.
+- Payload: `{ method, shapeSignature, lifecycle }` where lifecycle is `open`, `reviewed`, `dismissed`, or `ignored`.
+- Groups reopen automatically when the observed shape changes or a new high-risk shape appears.
+
+`POST /api/sites/:id/runtime-request-policy/preview`
+
+- Read-only validation and dry-run for draft `runtimeRequestPolicy`.
+- Response: normalized policy, stable validation error codes, warnings, collisions, high-risk confirmations, sample evaluator results, matched observation groups, and current propagation metadata.
+- The website may do lightweight UX validation, but server preview is authoritative and must pass before save.
+
+Runtime Requests dashboard mapping:
+
+- `/dashboard/sites/:id/runtime-requests` is the customer workflow for interactive features. Standard mode is the happy path: translated HTML and proven assets work without configuration, external public resources remain external, and unconfigured same-origin dynamic requests fail locally and become redacted observation groups.
+- Summary cards show Standard mode, active rules, unreviewed/high-risk groups, last seen, served policy version, and route-cache propagation state.
+- The observations table shows method, normalized path/pattern, likely type, first/last seen, sampled count, seen from page, current action, suggested action, risk, and lifecycle controls.
+- Rule creation uses explicit templates only: neutralize analytics/beacon, read-only search proxy, read-only feature flag/config proxy, route-data passthrough candidate, and form submit advanced proxy. Do not add a “proxy all APIs” control.
+- Rule saves require a current server preview. Validation failures preserve the draft and block save. Advanced confirmations are required for non-GET proxy, credential forwarding, and auth/cart/checkout/payment/account/admin/form paths.
+- Default proxy template values are `credentials=omit`, `cache=no-store`, `maxBodyBytes=0`, `GET/HEAD` only, request/response header allowlists empty, and same-origin redirect scope.
 
 `POST /api/sites/:id/crawl`
 

--- a/internal/dashboard/webhooks.openapi-contract.test.ts
+++ b/internal/dashboard/webhooks.openapi-contract.test.ts
@@ -414,6 +414,9 @@ describe("webhooks OpenAPI contract (dashboard client)", () => {
       { path: "/sites/{siteId}/dashboard", method: "get" },
       { path: "/sites/{siteId}/source-selection/preview", method: "post" },
       { path: "/sites/{siteId}/source-selection/tree-preview", method: "post" },
+      { path: "/sites/{siteId}/runtime-requests/observations", method: "get" },
+      { path: "/sites/{siteId}/runtime-requests/observations/{groupHash}", method: "patch" },
+      { path: "/sites/{siteId}/runtime-request-policy/preview", method: "post" },
       { path: "/sites/{siteId}/showcase", method: "get" },
       { path: "/sites/{siteId}/showcase", method: "post" },
       { path: "/sites/{siteId}/showcase", method: "patch" },
@@ -579,6 +582,14 @@ describe("webhooks OpenAPI contract (dashboard client)", () => {
       {
         name: "SourceSelectionTreePreviewResponse",
         schema: __webhooksZodContracts.sourceSelectionTreePreviewResponseSchema,
+      },
+      {
+        name: "RuntimeRequestObservationGroupsResponse",
+        schema: __webhooksZodContracts.runtimeRequestObservationGroupsResponseSchema,
+      },
+      {
+        name: "RuntimeRequestPolicyPreviewResponse",
+        schema: __webhooksZodContracts.runtimeRequestPolicyPreviewResponseSchema,
       },
       { name: "GlossaryResponse", schema: __webhooksZodContracts.upsertGlossaryResponseSchema },
       {

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -144,6 +144,80 @@ const sourceSelectionConfigSchema = z
   })
   .strict();
 
+const runtimeRequestPolicyActionSchema = z.enum(["observe", "deny", "neutralize", "proxy"]);
+const runtimeRequestPolicyMethodSchema = z.enum([
+  "GET",
+  "HEAD",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "OPTIONS",
+]);
+const runtimeRequestPolicyCredentialsSchema = z.enum(["omit", "same_origin", "include"]);
+const runtimeRequestPolicyCacheSchema = z.enum(["no-store", "edge"]);
+const runtimeRequestPolicyRedirectScopeSchema = z.enum(["same_origin", "same_registrable_domain"]);
+const runtimeRequestPolicyNeutralizationShapeSchema = z.enum([
+  "empty_json",
+  "empty_text",
+  "no_content",
+]);
+const runtimeRequestPolicyConfirmationSchema = z.enum([
+  "non_get_proxy",
+  "credential_forwarding",
+  "high_risk_path",
+]);
+const runtimeRequestHeaderPolicySchema = z
+  .object({
+    allow: z.array(z.string()),
+  })
+  .strict();
+const runtimeRequestNeutralizationSchema = z
+  .object({
+    shape: runtimeRequestPolicyNeutralizationShapeSchema,
+    status: z.number().int().min(100).max(599),
+    contentType: z.string().nullable(),
+    body: z.string().nullable(),
+  })
+  .strict();
+const runtimeRequestPolicyRuleSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    enabled: z.boolean(),
+    pattern: z.string(),
+    methods: z.array(runtimeRequestPolicyMethodSchema),
+    action: runtimeRequestPolicyActionSchema,
+    credentials: runtimeRequestPolicyCredentialsSchema,
+    cache: runtimeRequestPolicyCacheSchema,
+    maxBodyBytes: z.number().int().nonnegative(),
+    maxResponseBytes: z.number().int().nonnegative(),
+    timeoutMs: z.number().int().positive(),
+    redirectScope: runtimeRequestPolicyRedirectScopeSchema,
+    requestHeaders: runtimeRequestHeaderPolicySchema,
+    responseHeaders: runtimeRequestHeaderPolicySchema,
+    requestContentTypes: z.array(z.string()),
+    responseContentTypes: z.array(z.string()),
+    neutralization: runtimeRequestNeutralizationSchema,
+    confirmations: z.array(runtimeRequestPolicyConfirmationSchema),
+  })
+  .strict();
+const runtimeRequestPolicyConfigSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    mode: z.literal("standard"),
+    enabled: z.boolean(),
+    rules: z.array(runtimeRequestPolicyRuleSchema),
+  })
+  .strict();
+const runtimeRequestPolicyPropagationSchema = z
+  .object({
+    servedVersion: z.string().nullable(),
+    expectedVersion: z.string().nullable(),
+    stale: z.boolean(),
+  })
+  .strict();
+
 const localizedPathTemplateSchema = z
   .object({
     targetLang: z.string(),
@@ -187,6 +261,9 @@ const routeConfigSchema = z
   .object({
     updatedAt: z.string().optional(),
     sourceSelectionFingerprint: z.string().optional(),
+    runtimeRequestPolicyFingerprint: z.string().optional(),
+    runtimeRequestPolicyVersion: z.string().optional(),
+    runtimeRequestPolicyPropagation: runtimeRequestPolicyPropagationSchema.optional(),
     sourceLang: z.string(),
     sourceOrigin: z.string(),
     pattern: z.string().nullable().optional(),
@@ -203,6 +280,7 @@ const routeConfigSchema = z
     languageSwitcher: languageSwitcherSettingsSchema.nullable().optional(),
     localizedPathTemplates: z.array(localizedPathTemplateSchema).nullable().optional(),
     sourceSelection: sourceSelectionConfigSchema.optional(),
+    runtimeRequestPolicy: runtimeRequestPolicyConfigSchema.optional(),
   })
   .nullable();
 
@@ -909,6 +987,177 @@ const sourceSelectionTreePreviewResponseSchema = z
   })
   .strict();
 
+const runtimeRequestAcceptClassSchema = z.enum([
+  "html",
+  "json",
+  "rsc",
+  "asset",
+  "event-stream",
+  "other",
+  "missing",
+]);
+const runtimeRequestIntentSchema = z.enum([
+  "navigation",
+  "fetch",
+  "route-data",
+  "asset",
+  "preflight",
+  "beacon",
+  "form",
+  "unknown",
+]);
+const runtimeRequestClassificationSchema = z.enum([
+  "malformed",
+  "static_asset",
+  "showcase_telemetry",
+  "html_navigation",
+  "dynamic_api",
+  "route_data",
+  "api_like_json",
+  "high_risk_dynamic",
+  "preflight",
+  "default_dynamic",
+]);
+const runtimeRequestRiskSchema = z.enum(["low", "medium", "high"]);
+const runtimeRequestLifecycleSchema = z.enum(["open", "reviewed", "dismissed", "ignored"]);
+const runtimeRequestBodySizeBucketSchema = z.enum([
+  "none",
+  "unknown",
+  "1-1kb",
+  "1kb-10kb",
+  "10kb-100kb",
+  "100kb-1mb",
+  "over-1mb",
+]);
+const runtimeRequestPolicySourceSchema = z.enum([
+  "explicit_rule",
+  "standard_default",
+  "policy_disabled",
+]);
+const runtimeRequestDiagnosticCodeSchema = z.enum([
+  "runtime_request_observed",
+  "runtime_request_denied",
+  "runtime_request_neutralized",
+  "runtime_request_proxy_allowed",
+  "runtime_request_policy_disabled",
+]);
+const runtimeRequestPolicyEvaluationSchema = z
+  .object({
+    policyVersion: z.string(),
+    method: runtimeRequestPolicyMethodSchema.or(z.literal("OTHER")),
+    host: z.string(),
+    normalizedPath: z.string(),
+    groupingPath: z.string(),
+    groupingPathHash: z.string(),
+    hasQuery: z.boolean(),
+    bodySizeBucket: runtimeRequestBodySizeBucketSchema,
+    bodyPresent: z.boolean(),
+    acceptClass: runtimeRequestAcceptClassSchema,
+    intent: runtimeRequestIntentSchema,
+    classification: runtimeRequestClassificationSchema,
+    canonicalizationIssue: z
+      .enum(["malformed_url", "encoded_slash", "dot_segments", "invalid_encoding"])
+      .nullable(),
+    risk: runtimeRequestRiskSchema,
+    riskReasons: z.array(z.string()),
+    action: runtimeRequestPolicyActionSchema,
+    source: runtimeRequestPolicySourceSchema,
+    ruleId: z.string().nullable(),
+    shouldFetchSourceOrigin: z.boolean(),
+    shouldStoreObservation: z.boolean(),
+    status: z.number().int(),
+    diagnosticCode: runtimeRequestDiagnosticCodeSchema,
+  })
+  .strict();
+const runtimeRequestObservationGroupSchema = z
+  .object({
+    siteId: z.string(),
+    groupingPathHash: z.string(),
+    shapeSignature: z.string(),
+    path: z.string(),
+    method: z.string(),
+    likelyType: runtimeRequestClassificationSchema,
+    intent: runtimeRequestIntentSchema,
+    acceptClass: runtimeRequestAcceptClassSchema,
+    risk: runtimeRequestRiskSchema,
+    riskReasons: z.array(z.string()),
+    firstSeenAt: z.string(),
+    lastSeenAt: z.string(),
+    count: z.number().int().nonnegative(),
+    seenFromPage: z.string().nullable(),
+    currentAction: runtimeRequestPolicyActionSchema,
+    suggestedAction: runtimeRequestPolicyActionSchema,
+    policyRuleId: z.string().nullable(),
+    routePolicyVersion: z.string().nullable(),
+    routePolicyStale: z.boolean(),
+    lifecycle: runtimeRequestLifecycleSchema,
+    reviewedAt: z.string().nullable(),
+    dismissedAt: z.string().nullable(),
+    ignoredAt: z.string().nullable(),
+    bodyPresent: z.boolean(),
+    bodySizeBucket: runtimeRequestBodySizeBucketSchema,
+  })
+  .strict();
+const runtimeRequestObservationGroupsResponseSchema = z
+  .object({
+    groups: z.array(runtimeRequestObservationGroupSchema),
+    nextCursor: z.string().nullable(),
+  })
+  .strict();
+const runtimeRequestObservationLifecycleResponseSchema = z
+  .object({
+    state: z
+      .object({
+        siteId: z.string(),
+        groupingPathHash: z.string(),
+        method: z.string(),
+        shapeSignature: z.string(),
+        reviewedAt: z.string().nullable(),
+        dismissedAt: z.string().nullable(),
+        ignoredAt: z.string().nullable(),
+        updatedAt: z.string(),
+      })
+      .strict(),
+  })
+  .strict();
+const runtimeRequestPolicyPreviewSampleSchema = z
+  .object({
+    url: z.string(),
+    method: z.string().optional(),
+    accept: z.string().optional(),
+  })
+  .strict();
+const runtimeRequestPolicyPreviewResponseSchema = z
+  .object({
+    runtimeRequestPolicy: runtimeRequestPolicyConfigSchema,
+    validationErrors: z.array(
+      z.object({ code: z.string(), ruleId: z.string(), message: z.string() }).strict(),
+    ),
+    warnings: z.array(
+      z.object({ code: z.string(), ruleId: z.string(), message: z.string() }).strict(),
+    ),
+    collisions: z.array(
+      z.object({ leftRuleId: z.string(), rightRuleId: z.string(), code: z.string() }).strict(),
+    ),
+    highRiskConfirmations: z.array(z.object({ ruleId: z.string(), code: z.string() }).strict()),
+    sampleResults: z.array(
+      z
+        .object({
+          index: z.number().int().nonnegative(),
+          result: runtimeRequestPolicyEvaluationSchema,
+        })
+        .strict(),
+    ),
+    matchedObservationGroups: z.array(runtimeRequestObservationGroupSchema),
+    propagation: z
+      .object({
+        currentRouteConfigUpdatedAt: z.string().nullable(),
+        currentRuntimeRequestPolicyVersion: z.string().nullable(),
+      })
+      .strict(),
+  })
+  .strict();
+
 const featureFlagsSchema = z
   .object({
     editEnabled: z.boolean(),
@@ -1311,6 +1560,33 @@ export type SourceSelectionTreePreviewInventory = z.infer<
 export type SourceSelectionTreePreviewResponse = z.infer<
   typeof sourceSelectionTreePreviewResponseSchema
 >;
+export type RuntimeRequestPolicyAction = z.infer<typeof runtimeRequestPolicyActionSchema>;
+export type RuntimeRequestPolicyMethod = z.infer<typeof runtimeRequestPolicyMethodSchema>;
+export type RuntimeRequestPolicyCredentials = z.infer<typeof runtimeRequestPolicyCredentialsSchema>;
+export type RuntimeRequestPolicyCache = z.infer<typeof runtimeRequestPolicyCacheSchema>;
+export type RuntimeRequestPolicyRedirectScope = z.infer<
+  typeof runtimeRequestPolicyRedirectScopeSchema
+>;
+export type RuntimeRequestPolicyNeutralizationShape = z.infer<
+  typeof runtimeRequestPolicyNeutralizationShapeSchema
+>;
+export type RuntimeRequestPolicyConfirmation = z.infer<
+  typeof runtimeRequestPolicyConfirmationSchema
+>;
+export type RuntimeRequestPolicyRule = z.infer<typeof runtimeRequestPolicyRuleSchema>;
+export type RuntimeRequestPolicyConfig = z.infer<typeof runtimeRequestPolicyConfigSchema>;
+export type RuntimeRequestPolicyPropagation = z.infer<typeof runtimeRequestPolicyPropagationSchema>;
+export type RuntimeRequestObservationGroup = z.infer<typeof runtimeRequestObservationGroupSchema>;
+export type RuntimeRequestObservationGroupsResponse = z.infer<
+  typeof runtimeRequestObservationGroupsResponseSchema
+>;
+export type RuntimeRequestLifecycle = z.infer<typeof runtimeRequestLifecycleSchema>;
+export type RuntimeRequestPolicyPreviewSample = z.infer<
+  typeof runtimeRequestPolicyPreviewSampleSchema
+>;
+export type RuntimeRequestPolicyPreviewResponse = z.infer<
+  typeof runtimeRequestPolicyPreviewResponseSchema
+>;
 export type CrawlStatus = z.infer<typeof crawlStatusSchema>;
 export type NotifyWebhookEventType = z.infer<typeof webhookEventTypeSchema>;
 export type Deployment = z.infer<typeof deploymentSchema>;
@@ -1414,6 +1690,9 @@ export const __webhooksZodContracts = {
   siteDashboardResponseSchema,
   sourceSelectionPreviewResponseSchema,
   sourceSelectionTreePreviewResponseSchema,
+  runtimeRequestObservationGroupsResponseSchema,
+  runtimeRequestObservationLifecycleResponseSchema,
+  runtimeRequestPolicyPreviewResponseSchema,
   upsertDigestSubscriptionResponseSchema,
   crawlTranslateResponseSchema,
   setTranslationSummaryPreferenceResponseSchema,
@@ -1484,6 +1763,15 @@ const FALLBACK_SUPPORTED_LANGUAGES: readonly SupportedLanguage[] = [
 
 export const SUPPORTED_LANGUAGES_STATIC: SupportedLanguage[] = [...FALLBACK_SUPPORTED_LANGUAGES];
 
+function createDashboardE2eMockRuntimeRequestPolicy(rules: RuntimeRequestPolicyRule[] = []) {
+  return {
+    schemaVersion: 1 as const,
+    mode: "standard" as const,
+    enabled: true,
+    rules,
+  };
+}
+
 function createDashboardE2eMockSiteSummary(siteId: string) {
   return {
     id: siteId,
@@ -1518,6 +1806,7 @@ function createDashboardE2eMockSite(siteId: string) {
       { sourceLang: "en", targetLang: "ja", alias: null, serveEnabled: true },
     ],
     routeConfig: {
+      updatedAt: now,
       sourceLang: "en",
       sourceOrigin: DASHBOARD_E2E_MOCK_SOURCE_URL,
       pattern: null,
@@ -1534,6 +1823,14 @@ function createDashboardE2eMockSite(siteId: string) {
         errorFallback: "baseline" as const,
         enableSectionScope: false,
       },
+      runtimeRequestPolicyFingerprint: JSON.stringify({ schemaVersion: 1, rules: [] }),
+      runtimeRequestPolicyVersion: `site-config:${now}`,
+      runtimeRequestPolicyPropagation: {
+        servedVersion: `site-config:${now}`,
+        expectedVersion: `site-config:${now}`,
+        stale: false,
+      },
+      runtimeRequestPolicy: createDashboardE2eMockRuntimeRequestPolicy(),
     },
     domains: [
       {
@@ -1835,6 +2132,203 @@ function createDashboardE2eMockSourceSelectionPreview(
   };
 }
 
+function createDashboardE2eMockRuntimeObservationGroups(searchParams: URLSearchParams) {
+  const now = new Date().toISOString();
+  const groups = [
+    {
+      siteId: DASHBOARD_E2E_MOCK_SITE_ID,
+      groupingPathHash: "cart-group",
+      shapeSignature: "POST:cart-group:high_risk_dynamic:fetch:json",
+      path: "/api/cart",
+      method: "POST",
+      likelyType: "high_risk_dynamic" as const,
+      intent: "fetch" as const,
+      acceptClass: "json" as const,
+      risk: "high" as const,
+      riskReasons: ["non_read_method", "high_risk_path"],
+      firstSeenAt: new Date(Date.now() - 86_400_000).toISOString(),
+      lastSeenAt: now,
+      count: 7,
+      seenFromPage: "/pricing",
+      currentAction: "observe" as const,
+      suggestedAction: "deny" as const,
+      policyRuleId: null,
+      routePolicyVersion: `site-config:${now}`,
+      routePolicyStale: false,
+      lifecycle: "open" as const,
+      reviewedAt: null,
+      dismissedAt: null,
+      ignoredAt: null,
+      bodyPresent: true,
+      bodySizeBucket: "1-1kb" as const,
+    },
+    {
+      siteId: DASHBOARD_E2E_MOCK_SITE_ID,
+      groupingPathHash: "search-group",
+      shapeSignature: "GET:search-group:dynamic_api:fetch:json",
+      path: "/api/search",
+      method: "GET",
+      likelyType: "dynamic_api" as const,
+      intent: "fetch" as const,
+      acceptClass: "json" as const,
+      risk: "medium" as const,
+      riskReasons: [],
+      firstSeenAt: new Date(Date.now() - 172_800_000).toISOString(),
+      lastSeenAt: new Date(Date.now() - 3_600_000).toISOString(),
+      count: 18,
+      seenFromPage: "/",
+      currentAction: "observe" as const,
+      suggestedAction: "proxy" as const,
+      policyRuleId: null,
+      routePolicyVersion: `site-config:${now}`,
+      routePolicyStale: false,
+      lifecycle: "open" as const,
+      reviewedAt: null,
+      dismissedAt: null,
+      ignoredAt: null,
+      bodyPresent: false,
+      bodySizeBucket: "none" as const,
+    },
+  ];
+  const risk = searchParams.get("risk");
+  const lifecycle = searchParams.get("lifecycle");
+  const search = searchParams.get("search")?.trim().toLowerCase();
+  const filtered = groups.filter((group) => {
+    if (risk && group.risk !== risk) return false;
+    if (lifecycle && group.lifecycle !== lifecycle) return false;
+    if (search && !group.path.toLowerCase().includes(search)) return false;
+    return true;
+  });
+  return { groups: filtered, nextCursor: null };
+}
+
+function createDashboardE2eMockRuntimePolicyPreview(body: unknown) {
+  const payload = getBodyRecord(body);
+  const rawPolicy = getBodyRecord(payload.runtimeRequestPolicy);
+  const rawRules = Array.isArray(rawPolicy.rules) ? rawPolicy.rules : [];
+  const rules = rawRules
+    .filter((value): value is Record<string, unknown> => isRecord(value))
+    .map((rule, index) => createRuntimeRequestPolicyRuleFromRecord(rule, index));
+  const runtimeRequestPolicy = createDashboardE2eMockRuntimeRequestPolicy(rules);
+  const validationErrors = rules.flatMap((rule) => {
+    const errors: Array<{ code: string; ruleId: string; message: string }> = [];
+    if (
+      rule.action === "proxy" &&
+      rule.methods.some((method) => method !== "GET" && method !== "HEAD") &&
+      !rule.confirmations.includes("non_get_proxy")
+    ) {
+      errors.push({
+        code: "confirmation_required_non_get_proxy",
+        ruleId: rule.id,
+        message: "Non-GET proxy rules require confirmation.",
+      });
+    }
+    if (
+      rule.action === "proxy" &&
+      rule.credentials !== "omit" &&
+      !rule.confirmations.includes("credential_forwarding")
+    ) {
+      errors.push({
+        code: "confirmation_required_credential_forwarding",
+        ruleId: rule.id,
+        message: "Credential forwarding requires confirmation.",
+      });
+    }
+    if (
+      /\/(?:api\/)?(?:auth|cart|checkout|payment|account|admin)(?:\/|$)/i.test(rule.pattern) &&
+      !rule.confirmations.includes("high_risk_path")
+    ) {
+      errors.push({
+        code: "confirmation_required_high_risk_path",
+        ruleId: rule.id,
+        message: "High-risk paths require confirmation.",
+      });
+    }
+    return errors;
+  });
+  return {
+    runtimeRequestPolicy,
+    validationErrors,
+    warnings: [],
+    collisions: [],
+    highRiskConfirmations: validationErrors.map((error) => ({
+      ruleId: error.ruleId,
+      code: error.code,
+    })),
+    sampleResults: [],
+    matchedObservationGroups: createDashboardE2eMockRuntimeObservationGroups(
+      new URLSearchParams(),
+    ).groups.filter((group) => rules.some((rule) => group.path === rule.pattern)),
+    propagation: {
+      currentRouteConfigUpdatedAt: new Date().toISOString(),
+      currentRuntimeRequestPolicyVersion: `site-config:${new Date().toISOString()}`,
+    },
+  };
+}
+
+function createRuntimeRequestPolicyRuleFromRecord(
+  record: Record<string, unknown>,
+  index: number,
+): RuntimeRequestPolicyRule {
+  const action =
+    record.action === "deny" ||
+    record.action === "neutralize" ||
+    record.action === "proxy" ||
+    record.action === "observe"
+      ? record.action
+      : "observe";
+  const methods = Array.isArray(record.methods)
+    ? record.methods.filter(
+        (method): method is RuntimeRequestPolicyMethod =>
+          runtimeRequestPolicyMethodSchema.safeParse(method).success,
+      )
+    : action === "proxy"
+      ? (["GET", "HEAD"] as RuntimeRequestPolicyMethod[])
+      : (["GET", "HEAD", "POST", "OPTIONS"] as RuntimeRequestPolicyMethod[]);
+  const confirmations = Array.isArray(record.confirmations)
+    ? record.confirmations.filter(
+        (value): value is RuntimeRequestPolicyConfirmation =>
+          runtimeRequestPolicyConfirmationSchema.safeParse(value).success,
+      )
+    : [];
+  return {
+    id: typeof record.id === "string" && record.id.trim() ? record.id.trim() : `rule-${index + 1}`,
+    name:
+      typeof record.name === "string" && record.name.trim()
+        ? record.name.trim()
+        : `Rule ${index + 1}`,
+    enabled: record.enabled !== false,
+    pattern:
+      typeof record.pattern === "string" && record.pattern.trim()
+        ? record.pattern.trim()
+        : "/api/*",
+    methods,
+    action,
+    credentials:
+      record.credentials === "same_origin" || record.credentials === "include"
+        ? record.credentials
+        : "omit",
+    cache: record.cache === "edge" ? "edge" : "no-store",
+    maxBodyBytes: typeof record.maxBodyBytes === "number" ? record.maxBodyBytes : 0,
+    maxResponseBytes:
+      typeof record.maxResponseBytes === "number" ? record.maxResponseBytes : 1_048_576,
+    timeoutMs: typeof record.timeoutMs === "number" ? record.timeoutMs : 5_000,
+    redirectScope:
+      record.redirectScope === "same_registrable_domain" ? record.redirectScope : "same_origin",
+    requestHeaders: { allow: [] },
+    responseHeaders: { allow: [] },
+    requestContentTypes: [],
+    responseContentTypes: [],
+    neutralization: {
+      shape: "empty_json",
+      status: 200,
+      contentType: "application/json",
+      body: "{}",
+    },
+    confirmations,
+  };
+}
+
 function createDashboardE2eMockSiteShowcase(siteId: string) {
   const now = new Date().toISOString();
   return {
@@ -2059,6 +2553,41 @@ function resolveDashboardE2eMockPayload(input: {
   const siteDashboardMatch = pathname.match(/^\/sites\/([^/]+)\/dashboard$/);
   if (siteDashboardMatch && method === "GET") {
     return createDashboardE2eMockDashboardPayload(siteDashboardMatch[1], url.searchParams);
+  }
+
+  const runtimeObservationsMatch = pathname.match(
+    /^\/sites\/([^/]+)\/runtime-requests\/observations$/,
+  );
+  if (runtimeObservationsMatch && method === "GET") {
+    return createDashboardE2eMockRuntimeObservationGroups(url.searchParams);
+  }
+
+  const runtimeObservationLifecycleMatch = pathname.match(
+    /^\/sites\/([^/]+)\/runtime-requests\/observations\/([^/]+)$/,
+  );
+  if (runtimeObservationLifecycleMatch && method === "PATCH") {
+    const payload = getBodyRecord(input.body);
+    const now = new Date().toISOString();
+    return {
+      state: {
+        siteId: runtimeObservationLifecycleMatch[1],
+        groupingPathHash: decodeURIComponent(runtimeObservationLifecycleMatch[2]),
+        method: typeof payload.method === "string" ? payload.method : "GET",
+        shapeSignature:
+          typeof payload.shapeSignature === "string" ? payload.shapeSignature : "GET:mock",
+        reviewedAt: payload.lifecycle === "reviewed" ? now : null,
+        dismissedAt: payload.lifecycle === "dismissed" ? now : null,
+        ignoredAt: payload.lifecycle === "ignored" ? now : null,
+        updatedAt: now,
+      },
+    };
+  }
+
+  const runtimePolicyPreviewMatch = pathname.match(
+    /^\/sites\/([^/]+)\/runtime-request-policy\/preview$/,
+  );
+  if (runtimePolicyPreviewMatch && method === "POST") {
+    return createDashboardE2eMockRuntimePolicyPreview(input.body);
   }
 
   const sourceSelectionPreviewMatch = pathname.match(
@@ -2962,6 +3491,86 @@ export async function previewSourceSelectionTree(
   });
 }
 
+export async function listRuntimeRequestObservations(
+  auth: AuthInput,
+  siteId: string,
+  options?: {
+    limit?: number;
+    cursor?: string | null;
+    lifecycle?: RuntimeRequestLifecycle | "all";
+    risk?: "low" | "medium" | "high" | "all";
+    method?: string | null;
+    search?: string | null;
+    sort?: "last_seen_desc" | "last_seen_asc" | "count_desc";
+  },
+): Promise<RuntimeRequestObservationGroupsResponse> {
+  const qs = new URLSearchParams();
+  if (typeof options?.limit === "number") {
+    qs.set("limit", String(options.limit));
+  }
+  if (typeof options?.cursor === "string" && options.cursor.trim()) {
+    qs.set("cursor", options.cursor);
+  }
+  if (options?.lifecycle && options.lifecycle !== "all") {
+    qs.set("lifecycle", options.lifecycle);
+  }
+  if (options?.risk && options.risk !== "all") {
+    qs.set("risk", options.risk);
+  }
+  if (typeof options?.method === "string" && options.method.trim()) {
+    qs.set("method", options.method.trim().toUpperCase());
+  }
+  if (typeof options?.search === "string" && options.search.trim()) {
+    qs.set("search", options.search.trim());
+  }
+  if (options?.sort) {
+    qs.set("sort", options.sort);
+  }
+  const path = qs.size
+    ? `/sites/${siteId}/runtime-requests/observations?${qs.toString()}`
+    : `/sites/${siteId}/runtime-requests/observations`;
+  return request({
+    path,
+    auth,
+    schema: runtimeRequestObservationGroupsResponseSchema,
+    timeoutProfile: "detail",
+  });
+}
+
+export async function updateRuntimeRequestObservationLifecycle(
+  auth: AuthInput,
+  siteId: string,
+  groupingPathHash: string,
+  payload: { lifecycle: RuntimeRequestLifecycle; method: string; shapeSignature: string },
+) {
+  return request({
+    path: `/sites/${siteId}/runtime-requests/observations/${encodeURIComponent(groupingPathHash)}`,
+    method: "PATCH",
+    auth,
+    body: payload,
+    schema: runtimeRequestObservationLifecycleResponseSchema,
+    timeoutProfile: "mutation",
+  });
+}
+
+export async function previewRuntimeRequestPolicy(
+  auth: AuthInput,
+  siteId: string,
+  payload: {
+    runtimeRequestPolicy: RuntimeRequestPolicyConfig;
+    samples?: Array<string | RuntimeRequestPolicyPreviewSample>;
+  },
+): Promise<RuntimeRequestPolicyPreviewResponse> {
+  return request({
+    path: `/sites/${siteId}/runtime-request-policy/preview`,
+    method: "POST",
+    auth,
+    body: payload,
+    schema: runtimeRequestPolicyPreviewResponseSchema,
+    timeoutProfile: "detail",
+  });
+}
+
 export async function getSiteShowcase(
   auth: AuthInput,
   siteId: string,
@@ -3018,6 +3627,7 @@ export type CreateSitePayload = {
   translatableAttributes?: string[] | null;
   spaRefresh?: SpaRefreshSettings | null;
   sourceSelection?: SourceSelectionConfig | null;
+  runtimeRequestPolicy?: RuntimeRequestPolicyConfig | null;
   webhookUrl?: string | null;
   webhookSecret?: string | null;
   webhookEvents?: NotifyWebhookEventType[];
@@ -3041,6 +3651,7 @@ export async function updateSite(
     status?: "active" | "inactive";
     expectedRouteConfigUpdatedAt?: string;
     expectedSourceSelectionFingerprint?: string;
+    expectedRuntimeRequestPolicyFingerprint?: string;
   },
 ) {
   return request({

--- a/internal/dashboard/webhooks.ts
+++ b/internal/dashboard/webhooks.ts
@@ -1120,13 +1120,6 @@ const runtimeRequestObservationLifecycleResponseSchema = z
       .strict(),
   })
   .strict();
-const runtimeRequestPolicyPreviewSampleSchema = z
-  .object({
-    url: z.string(),
-    method: z.string().optional(),
-    accept: z.string().optional(),
-  })
-  .strict();
 const runtimeRequestPolicyPreviewResponseSchema = z
   .object({
     runtimeRequestPolicy: runtimeRequestPolicyConfigSchema,
@@ -1581,9 +1574,11 @@ export type RuntimeRequestObservationGroupsResponse = z.infer<
   typeof runtimeRequestObservationGroupsResponseSchema
 >;
 export type RuntimeRequestLifecycle = z.infer<typeof runtimeRequestLifecycleSchema>;
-export type RuntimeRequestPolicyPreviewSample = z.infer<
-  typeof runtimeRequestPolicyPreviewSampleSchema
->;
+export type RuntimeRequestPolicyPreviewSample = {
+  url: string;
+  method?: string;
+  accept?: string;
+};
 export type RuntimeRequestPolicyPreviewResponse = z.infer<
   typeof runtimeRequestPolicyPreviewResponseSchema
 >;


### PR DESCRIPTION
## Summary
- Adds the Runtime Requests / Interactive Features dashboard workflow for redacted observation groups, Standard mode status, rule editing, server preview/validation, lifecycle actions, propagation state, and high-risk confirmations.
- Syncs backend OpenAPI/docs artifacts from backend PR #135 and extends dashboard client schemas/functions for observations, lifecycle, runtime request policy preview, and save.
- Fixes the source-selection review finding: save persists editable flat draft rules, not `preview.sourceSelection`; the regression suite covers that behavior.

## Cross-links
- Backend PR: https://github.com/lucent-lab/weblingo/pull/135

## Dashboard workflow
- No-configuration-needed Standard mode is the happy path.
- Summary shows active rule count, unreviewed/high-risk observed groups, last seen, served policy version, and propagation/stale state when returned by backend.
- Observed request groups show method, redacted path/pattern, likely type, first/last seen, count, seen-from page, current/suggested action, risk label, and lifecycle controls.
- Rule editor supports enabled/name/pattern/methods/action/credentials/body and response limits/header policies/cache/redirect scope/neutralization shape through the synced API contract.
- Presets are explicit: neutralize analytics/beacon, read-only search proxy, read-only feature flag/config proxy, route-data passthrough candidate, and advanced form submit proxy. There is no “proxy all APIs” control.

## Safety and UX model
- Draft rules must preview before save, and server validation is authoritative.
- Validation errors block save and preserve the draft.
- Advanced confirmations are required for non-GET proxy, credential forwarding, and high-risk auth/cart/checkout/payment/account/admin paths.
- Defaults omit credentials, use no-store behavior, and keep simple proxy to GET/HEAD-only.
- UI uses existing dashboard auth/session/account/agency-subject scoping patterns and accessible labeled controls.

## Rollout and rollback
- Customer dashboard exposure is backend feature-flag gated and the UI consumes the backend-provided propagation state.
- Rollback path: disable dashboard exposure and/or backend enforcement/proxy/ingest flags; saved draft policies remain persisted but inactive if enforcement is disabled.

## Out of scope
- No production deploys from this PR.
- No broad API proxy UX, generic JSON/data translation, or mutation-capable live checks against production origins.

## Validation
- `WEBLINGO_REPO_PATH=/Users/francoisgueguen/Documents/workspaces-self/saas/weblingo corepack pnpm docs:sync:check` passed.
- `corepack pnpm test:contracts` passed.
- `corepack pnpm test` passed: 72 files / 324 tests.
- `corepack pnpm run check` passed.
- Backend live validation for the paired PR: `corepack pnpm premerge:showcase:live` passed 10/10 and `corepack pnpm showcase:live:matrix:check` passed. `showcase:live:crawl` was blocked by missing local `WEBHOOKS_API_BASE_URL`.

## Review and audits
- `$gh-codex-review-triage`: no Codex review threads on PR #73.
- GPT-5.4-mini reviews challenged backend/runtime propagation and missing-header behavior; valid issues were fixed in backend PR #135.
- `$architectural-cleanup-audit`: no dashboard architecture blocker; UI delegates runtime policy ownership to backend preview/save APIs.
- `$big-o-audit`: no frontend blocker found in dashboard pagination/search for the current API shape; backend residual aggregation and route-cache write costs are documented on PR #135.

Draft remains until both PRs and release validation are accepted.
